### PR TITLE
Rebrand to MyDeck and update README with fork information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,65 +1,29 @@
-# Readeck App
+# MyDeck
 
-![Build Status](https://img.shields.io/github/check-runs/jensomato/ReadeckApp/develop)
 [![License](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
-[![Translation status](https://hosted.weblate.org/widget/readeckapp/app/svg-badge.svg)](https://hosted.weblate.org/engage/readeckapp/)
 
 ## Overview
 
-Readeck App is an Android application designed to help users manage and read their saved articles and bookmarks. Currently, the app supports reading and listing bookmarks.
+MyDeck is an Android application for managing and reading your saved articles and bookmarks with a Pocket-like user experience. It is forked from [ReadeckApp](https://github.com/jensomato/ReadeckApp) and is currently being refactored to provide a more streamlined and intuitive interface.
 
-This app is a companion to Readeck (https://readeck.org/en/), a self-hosted read-it-later service. To use this app, you'll need a Readeck account and server instance.
+This app is a companion to [Readeck](https://readeck.org/en/), a self-hosted read-it-later service. To use this app, you'll need a Readeck account and server instance.
 
-## Installation
+## Acknowledgements
 
-Readeck App is available on F-Droid and by downloading the APK file directly from our [GitHub Releases page](https://github.com/jensomato/ReadeckApp/releases).
+MyDeck is based on [ReadeckApp](https://github.com/jensomato/ReadeckApp) by jensomato, which is licensed under the GNU General Public License v3.0.
 
-[<img src="https://f-droid.org/badge/get-it-on.png"
-    alt="Get it on F-Droid"
-    height="80">](https://f-droid.org/en/packages/de.readeckapp/)
+### Major Changes
 
-There is also a snapshot releases built from the `develop` branch. This means they might not be as stable as a final release, but they'll give you a sneak peek at the latest features and improvements.
+As required by the GNU GPL v3, here are the major modifications made to the original ReadeckApp:
 
-## Screenshots
+* Rebranding as MyDeck
+* Replace All and Unread views with My List view that shows all unarchived bookmarks
+* Remove (for now) the Article, Photo and Video menu options
+* Revise header to show view name
+* Add About menu option / dialog
 
-[<img width=200 alt="Screenshot 1"
-src="metadata/en-US/images/phoneScreenshots/screenshot1.png?raw=true">](metadata/en-US/images/phoneScreenshots/screenshot1.png?raw=true)
-[<img width=200 alt="Screenshot 2"
-src="metadata/en-US/images/phoneScreenshots/screenshot2.png?raw=true">](metadata/en-US/images/phoneScreenshots/screenshot2.png?raw=true)
-
-## Translation
-
-Translations are hosted on [Weblate](https://hosted.weblate.org/projects/readeckapp/). Feel free to add or update translations.
-
-If you don't see your language, please create an issue.
-
-## Tech Stack
-
-This project uses the following technologies:
-
-*   [Kotlin](https://kotlinlang.org/)
-*   [Jetpack Compose](https://developer.android.com/jetpack/compose)
-*   [Kotlin Coroutines](https://kotlinlang.org/docs/coroutines-overview.html)
-*   [Jetpack Navigation](https://developer.android.com/jetpack/compose/navigation)
-*   [Timber](https://github.com/JakeWharton/timber)
-*   [Hilt](https://dagger.dev/hilt/) for dependency injection
-*   [Retrofit](https://square.github.com/retrofit/) for network requests
-*   [Room](https://developer.android.com/training/data-storage/room) for local data persistence
-*   ...
-
-## Roadmap
-
-Here are some of the features planned for future releases:
-
-*   ✅ ~~Offline access to saved content~~
-*   Organizing content with labels and categories
-*   ✅ ~~Mark articles as read/unread~~
-*   ✅ ~~Archive/unarchive articles~~
-*   ✅ ~~Favorite articles~~
-*   ✅ ~~Add articles~~
-*   ...
+This list will be updated as the refactor progresses.
 
 ## License
 
 This project is licensed under the [GNU General Public License v3.0](LICENSE). Some of the used libraries are released under different licenses.
-


### PR DESCRIPTION
## Summary
This PR updates the README to reflect the rebranding of ReadeckApp to MyDeck and documents the major changes made as part of the fork. The documentation now clearly indicates this is a refactored fork of the original ReadeckApp project with GPL v3 compliance.

## Key Changes
- **Rebranding**: Updated project name from "Readeck App" to "MyDeck" throughout the README
- **Fork Documentation**: Added acknowledgements section crediting the original ReadeckApp project and its author (jensomato)
- **GPL Compliance**: Added "Major Changes" section documenting modifications made to the original codebase as required by GNU GPL v3
- **Simplified Documentation**: Removed sections no longer applicable to MyDeck:
  - Build status badge
  - Translation/Weblate information
  - Installation instructions (F-Droid, APK downloads)
  - Screenshots
  - Tech stack details
  - Roadmap
- **Updated Overview**: Clarified that MyDeck is a Pocket-like fork focused on providing a streamlined interface for Readeck

## Notable Details
The "Major Changes" section explicitly lists the modifications made during the refactor:
- UI rebranding
- Simplified views (My List replacing All/Unread)
- Removed content type filters (Article, Photo, Video)
- Header revisions
- New About menu option

This approach ensures GPL v3 compliance by transparently documenting all significant modifications to the original work.