### PR TITLE
Phase 1: Add offline action queue, soft-delete, and background sync worker

### DIFF
--- a/app/src/main/java/com/mydeck/app/domain/mapper/BookmarkMapper.kt
+++ b/app/src/main/java/com/mydeck/app/domain/mapper/BookmarkMapper.kt
@@ -43,6 +43,7 @@ fun Bookmark.toEntity(): BookmarkWithArticleContent = BookmarkWithArticleContent
         isDeleted = isDeleted,
         isMarked = isMarked,
         isArchived = isArchived,
+        isLocalDeleted = false,
         labels = labels,
         readProgress = readProgress,
         wordCount = wordCount,

--- a/app/src/main/java/com/mydeck/app/domain/model/PendingActionPayloads.kt
+++ b/app/src/main/java/com/mydeck/app/domain/model/PendingActionPayloads.kt
@@ -1,0 +1,15 @@
+package com.mydeck.app.domain.model
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ProgressPayload(
+    val progress: Int,
+    val timestamp: Instant
+)
+
+@Serializable
+data class TogglePayload(
+    val value: Boolean
+)

--- a/app/src/main/java/com/mydeck/app/io/db/Converters.kt
+++ b/app/src/main/java/com/mydeck/app/io/db/Converters.kt
@@ -1,6 +1,7 @@
 package com.mydeck.app.io.db
 
 import androidx.room.TypeConverter
+import com.mydeck.app.io.db.model.ActionType
 import com.mydeck.app.io.db.model.BookmarkEntity
 import kotlinx.datetime.Instant
 
@@ -61,5 +62,15 @@ class Converters {
             BookmarkEntity.Type.VIDEO.value -> BookmarkEntity.Type.VIDEO
             else -> throw IllegalStateException("$stateValue can not be converted to BookmarkEntity.Type")
         }
+    }
+
+    @TypeConverter
+    fun fromActionType(actionType: ActionType): String {
+        return actionType.name
+    }
+
+    @TypeConverter
+    fun toActionType(value: String): ActionType {
+        return ActionType.valueOf(value)
     }
 }

--- a/app/src/main/java/com/mydeck/app/io/db/DatabaseModule.kt
+++ b/app/src/main/java/com/mydeck/app/io/db/DatabaseModule.kt
@@ -8,6 +8,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import com.mydeck.app.io.db.dao.BookmarkDao
+import com.mydeck.app.io.db.dao.PendingActionDao
 import javax.inject.Singleton
 
 @Module
@@ -21,7 +22,8 @@ object DatabaseModule {
             .addMigrations(
                 MyDeckDatabase.MIGRATION_1_2,
                 MyDeckDatabase.MIGRATION_2_3,
-                MyDeckDatabase.MIGRATION_3_4
+                MyDeckDatabase.MIGRATION_3_4,
+                MyDeckDatabase.MIGRATION_4_5
             )
             .build()
     }
@@ -30,4 +32,9 @@ object DatabaseModule {
     @Singleton
     fun provideBookmarkDao(readeckDatabase: MyDeckDatabase): BookmarkDao =
         readeckDatabase.getBookmarkDao()
+
+    @Provides
+    @Singleton
+    fun providePendingActionDao(readeckDatabase: MyDeckDatabase): PendingActionDao =
+        readeckDatabase.getPendingActionDao()
 }

--- a/app/src/main/java/com/mydeck/app/io/db/dao/PendingActionDao.kt
+++ b/app/src/main/java/com/mydeck/app/io/db/dao/PendingActionDao.kt
@@ -1,0 +1,35 @@
+package com.mydeck.app.io.db.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.mydeck.app.io.db.model.ActionType
+import com.mydeck.app.io.db.model.PendingActionEntity
+
+@Dao
+interface PendingActionDao {
+    @Query(
+        """
+        SELECT * FROM pending_actions
+        WHERE bookmarkId = :bookmarkId AND actionType = :actionType
+        LIMIT 1
+        """
+    )
+    suspend fun findAction(bookmarkId: String, actionType: ActionType): PendingActionEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAction(action: PendingActionEntity)
+
+    @Query("UPDATE pending_actions SET payload = :payload, createdAt = :createdAt WHERE id = :id")
+    suspend fun updateAction(id: Long, payload: String?, createdAt: kotlinx.datetime.Instant)
+
+    @Query("DELETE FROM pending_actions WHERE id = :id")
+    suspend fun deleteAction(id: Long)
+
+    @Query("DELETE FROM pending_actions WHERE bookmarkId = :bookmarkId")
+    suspend fun deleteAllForBookmark(bookmarkId: String)
+
+    @Query("SELECT * FROM pending_actions ORDER BY createdAt ASC")
+    suspend fun getAllActionsSorted(): List<PendingActionEntity>
+}

--- a/app/src/main/java/com/mydeck/app/io/db/model/BookmarkEntity.kt
+++ b/app/src/main/java/com/mydeck/app/io/db/model/BookmarkEntity.kt
@@ -37,6 +37,7 @@ data class BookmarkEntity(
     val isDeleted: Boolean,
     val isMarked: Boolean,
     val isArchived: Boolean,
+    val isLocalDeleted: Boolean = false,
     val labels: List<String>,
     val readProgress: Int,
     val wordCount: Int?,

--- a/app/src/main/java/com/mydeck/app/io/db/model/PendingActionEntity.kt
+++ b/app/src/main/java/com/mydeck/app/io/db/model/PendingActionEntity.kt
@@ -1,0 +1,27 @@
+package com.mydeck.app.io.db.model
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import kotlinx.datetime.Instant
+
+@Entity(
+    tableName = "pending_actions",
+    indices = [Index(value = ["bookmarkId", "actionType"])]
+)
+data class PendingActionEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+    val bookmarkId: String,
+    val actionType: ActionType,
+    val payload: String?,
+    val createdAt: Instant
+)
+
+enum class ActionType {
+    UPDATE_PROGRESS,
+    TOGGLE_FAVORITE,
+    TOGGLE_ARCHIVE,
+    TOGGLE_READ,
+    DELETE
+}

--- a/app/src/main/java/com/mydeck/app/worker/ActionSyncWorker.kt
+++ b/app/src/main/java/com/mydeck/app/worker/ActionSyncWorker.kt
@@ -1,0 +1,157 @@
+package com.mydeck.app.worker
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import com.mydeck.app.domain.model.ProgressPayload
+import com.mydeck.app.domain.model.TogglePayload
+import com.mydeck.app.io.db.dao.BookmarkDao
+import com.mydeck.app.io.db.dao.PendingActionDao
+import com.mydeck.app.io.db.model.ActionType
+import com.mydeck.app.io.db.model.PendingActionEntity
+import com.mydeck.app.io.rest.ReadeckApi
+import com.mydeck.app.io.rest.model.EditBookmarkDto
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import timber.log.Timber
+import java.io.IOException
+
+@HiltWorker
+class ActionSyncWorker @AssistedInject constructor(
+    @Assisted appContext: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val pendingActionDao: PendingActionDao,
+    private val bookmarkDao: BookmarkDao,
+    private val readeckApi: ReadeckApi,
+    private val json: Json
+) : CoroutineWorker(appContext, workerParams) {
+    override suspend fun doWork(): Result {
+        val actions = pendingActionDao.getAllActionsSorted()
+        for (action in actions) {
+            when (val outcome = processAction(action)) {
+                is ActionOutcome.Success -> pendingActionDao.deleteAction(action.id)
+                is ActionOutcome.Retry -> return Result.retry()
+                is ActionOutcome.Drop -> pendingActionDao.deleteAction(action.id)
+            }
+        }
+        return Result.success()
+    }
+
+    private suspend fun processAction(action: PendingActionEntity): ActionOutcome {
+        return when (action.actionType) {
+            ActionType.UPDATE_PROGRESS -> handleProgress(action)
+            ActionType.TOGGLE_FAVORITE -> handleToggle(action) { value ->
+                EditBookmarkDto(isMarked = value)
+            }
+            ActionType.TOGGLE_ARCHIVE -> handleToggle(action) { value ->
+                EditBookmarkDto(isArchived = value)
+            }
+            ActionType.TOGGLE_READ -> handleToggle(action) { value ->
+                EditBookmarkDto(readProgress = if (value) 100 else 0)
+            }
+            ActionType.DELETE -> handleDelete(action)
+        }
+    }
+
+    private suspend fun handleProgress(action: PendingActionEntity): ActionOutcome {
+        val payload = action.payload ?: return ActionOutcome.Drop("Missing payload for progress update.")
+        val progressPayload = decodePayload<ProgressPayload>(payload) ?: return ActionOutcome.Drop(
+            "Invalid progress payload."
+        )
+        return handleEdit(action, EditBookmarkDto(readProgress = progressPayload.progress))
+    }
+
+    private suspend fun handleToggle(
+        action: PendingActionEntity,
+        mapper: (Boolean) -> EditBookmarkDto
+    ): ActionOutcome {
+        val payload = action.payload ?: return ActionOutcome.Drop("Missing payload for toggle.")
+        val togglePayload = decodePayload<TogglePayload>(payload) ?: return ActionOutcome.Drop(
+            "Invalid toggle payload."
+        )
+        return handleEdit(action, mapper(togglePayload.value))
+    }
+
+    private suspend fun handleEdit(action: PendingActionEntity, body: EditBookmarkDto): ActionOutcome {
+        return try {
+            val response = readeckApi.editBookmark(id = action.bookmarkId, body = body)
+            when {
+                response.isSuccessful -> ActionOutcome.Success
+                response.code() == 404 -> {
+                    bookmarkDao.deleteBookmark(action.bookmarkId)
+                    ActionOutcome.Success
+                }
+                response.code().isTransientError() -> ActionOutcome.Retry("Transient error ${response.code()}")
+                else -> ActionOutcome.Drop("Permanent error ${response.code()}")
+            }
+        } catch (e: IOException) {
+            Timber.w(e, "Transient failure syncing action ${action.id}")
+            ActionOutcome.Retry(e.message)
+        } catch (e: Exception) {
+            Timber.e(e, "Permanent failure syncing action ${action.id}")
+            ActionOutcome.Drop(e.message)
+        }
+    }
+
+    private suspend fun handleDelete(action: PendingActionEntity): ActionOutcome {
+        return try {
+            val response = readeckApi.deleteBookmark(id = action.bookmarkId)
+            when {
+                response.isSuccessful || response.code() == 404 -> {
+                    bookmarkDao.deleteBookmark(action.bookmarkId)
+                    ActionOutcome.Success
+                }
+                response.code().isTransientError() -> ActionOutcome.Retry("Transient error ${response.code()}")
+                else -> ActionOutcome.Drop("Permanent error ${response.code()}")
+            }
+        } catch (e: IOException) {
+            Timber.w(e, "Transient failure deleting bookmark ${action.bookmarkId}")
+            ActionOutcome.Retry(e.message)
+        } catch (e: Exception) {
+            Timber.e(e, "Permanent failure deleting bookmark ${action.bookmarkId}")
+            ActionOutcome.Drop(e.message)
+        }
+    }
+
+    private inline fun <reified T> decodePayload(payload: String): T? {
+        return try {
+            json.decodeFromString<T>(payload)
+        } catch (e: SerializationException) {
+            Timber.e(e, "Failed to parse payload: $payload")
+            null
+        }
+    }
+
+    private fun Int.isTransientError(): Boolean {
+        return this in 500..599 || this == 408 || this == 429
+    }
+
+    private sealed class ActionOutcome {
+        data object Success : ActionOutcome()
+        data class Retry(val reason: String? = null) : ActionOutcome()
+        data class Drop(val reason: String? = null) : ActionOutcome()
+    }
+
+    companion object {
+        const val UNIQUE_WORK_NAME = "OfflineActionSync"
+
+        fun enqueue(workManager: WorkManager) {
+            val request = OneTimeWorkRequestBuilder<ActionSyncWorker>()
+                .setConstraints(
+                    Constraints.Builder()
+                        .setRequiredNetworkType(NetworkType.CONNECTED)
+                        .build()
+                )
+                .build()
+            workManager.enqueueUniqueWork(UNIQUE_WORK_NAME, ExistingWorkPolicy.APPEND, request)
+        }
+    }
+}

--- a/app/src/test/java/com/mydeck/app/io/db/BookmarkDaoTest.kt
+++ b/app/src/test/java/com/mydeck/app/io/db/BookmarkDaoTest.kt
@@ -94,6 +94,7 @@ class BookmarkDaoTest {
                     isDeleted = false,
                     isMarked = false,
                     isArchived = false,
+                    isLocalDeleted = false,
                     labels = listOf("label1", "label2"),
                     readProgress = index * 3,
                     wordCount = 100 + index * 10,


### PR DESCRIPTION
### Motivation
- Provide an optimistic offline-first experience by queuing local bookmark state changes when the device is offline and syncing them later. 
- Ensure delete operations take precedence (delete supremacy) and prevent conflicting queued updates from being applied after a local delete. 
- Hide soft-deleted items from UI queries while the deletion is pending server confirmation and persist the queue with a DB migration.

### Description
- Add a pending-action model and DAO: `PendingActionEntity` and `PendingActionDao`, and payload DTOs `ProgressPayload` and `TogglePayload` to represent queued actions and their serialized payloads (`app/src/main/java/.../PendingActionEntity.kt`, `PendingActionDao.kt`, `PendingActionPayloads.kt`).
- Implement `ActionSyncWorker` to drain the queue and apply actions to the API with transient/permanent error handling and `ExistingWorkPolicy.APPEND` enqueue semantics (`app/src/main/java/.../ActionSyncWorker.kt`).
- Make repository updates optimistic: `BookmarkRepositoryImpl` now updates local DB immediately and queues actions (coalescing via `findAction`/`updateAction`), and enqueues the `ActionSyncWorker` instead of calling the API synchronously for marks/archives/read-progress/deletes (`app/src/main/java/.../BookmarkRepositoryImpl.kt`).
- Add soft-delete support and DB migration: add `isLocalDeleted` to `BookmarkEntity`, filter UI-facing DAO queries to exclude `isLocalDeleted == 1`, add `softDelete` DAO method, add `pending_actions` table and index, bump DB `version` to `5` and include migration `4->5`, and register `PendingActionDao` in `DatabaseModule` (`app/src/main/java/.../BookmarkEntity.kt`, `BookmarkDao.kt`, `MyDeckDatabase.kt`, `DatabaseModule.kt`, `Converters.kt`).

### Testing
- No automated tests were executed as part of this change; the change set includes a small unit test fixture update to set `isLocalDeleted = false` in `BookmarkDaoTest` but tests were not run. 
- Manual validation recommendations: run unit tests and integration tests around `BookmarkDao`, `PendingActionDao`, and `ActionSyncWorker` and exercise offline toggle/delete flows to verify coalescing, delete supremacy, and WorkManager retry behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983bc0c169c83309c39be6460ccf777)