### PR TITLE
Fix dialog loop, avoid repeated sync on foreground, and prevent content loss on bookmark upsert

### DIFF
--- a/app/src/main/java/com/mydeck/app/MainActivity.kt
+++ b/app/src/main/java/com/mydeck/app/MainActivity.kt
@@ -23,8 +23,10 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
+import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import com.mydeck.app.domain.model.Theme
+import com.mydeck.app.domain.usecase.FullSyncUseCase
 import com.mydeck.app.ui.detail.BookmarkDetailScreen
 import com.mydeck.app.ui.list.BookmarkListScreen
 import com.mydeck.app.ui.navigation.AccountSettingsRoute
@@ -55,11 +57,24 @@ class MainActivity : ComponentActivity() {
     @Inject
     lateinit var settingsDataStore: SettingsDataStore
 
+    @Inject
+    lateinit var fullSyncUseCase: FullSyncUseCase
+
     private lateinit var intentState: MutableState<Intent?>
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+
+        if (savedInstanceState == null) {
+            lifecycleScope.launch {
+                if (settingsDataStore.isSyncOnAppOpenEnabled()) {
+                    Timber.d("App Open: Triggering Full Sync")
+                    fullSyncUseCase.performFullSync()
+                }
+            }
+        }
+
         setContent {
             val viewModel = hiltViewModel<MainViewModel>()
             val theme = viewModel.theme.collectAsState()

--- a/app/src/main/java/com/mydeck/app/domain/BookmarkRepositoryImpl.kt
+++ b/app/src/main/java/com/mydeck/app/domain/BookmarkRepositoryImpl.kt
@@ -670,7 +670,7 @@ class BookmarkRepositoryImpl @Inject constructor(
 
                     // Update locally
                     val updatedBookmark = bookmark.copy(labels = updatedLabels)
-                    bookmarkDao.insertBookmark(updatedBookmark)
+                    bookmarkDao.upsertBookmark(updatedBookmark)
 
                     // Update on server - use addLabels and removeLabels
                     try {
@@ -720,7 +720,7 @@ class BookmarkRepositoryImpl @Inject constructor(
 
                     // Update locally
                     val updatedBookmark = bookmark.copy(labels = updatedLabels)
-                    bookmarkDao.insertBookmark(updatedBookmark)
+                    bookmarkDao.upsertBookmark(updatedBookmark)
 
                     // Update on server - use removeLabels
                     try {


### PR DESCRIPTION
### Motivation
- Prevent the add-bookmark dialog from reappearing after process recreation by ensuring shared intent text is consumed from `SavedStateHandle` when read. 
- Ensure the "sync on app open" behavior only runs once for a real app cold start instead of whenever a screen-scoped ViewModel is recreated. 
- Avoid accidental deletion of `article_content` rows caused by `REPLACE` semantics deleting bookmark rows and triggering cascade deletes.

### Description
- Consume and remove the shared intent string from `SavedStateHandle` in `BookmarkListViewModel` by reading `savedStateHandle.get<String>("sharedText")`, calling `savedStateHandle.remove(...)`, and using the extracted value to open the dialog; also removed the `FullSyncUseCase` dependency from the ViewModel (`app/src/main/java/com/mydeck/app/ui/list/BookmarkListViewModel.kt`).
- Move the sync-on-open trigger into `MainActivity.onCreate` and guard it behind a cold-start check (`savedInstanceState == null`) with `lifecycleScope.launch` and `settingsDataStore.isSyncOnAppOpenEnabled()` to only invoke `fullSyncUseCase.performFullSync()` on real app starts (`app/src/main/java/com/mydeck/app/MainActivity.kt`).
- Replace `INSERT ... ON CONFLICT REPLACE` behavior for single bookmark writes with an `IGNORE`+`UPDATE` upsert flow to avoid deleting rows (and cascading article content deletes); added `insertBookmarkIgnore`, `updateBookmark`, `upsertBookmark`, and adjusted `insertBookmarkWithArticleContent` to perform ignore+update and to upsert properly (`app/src/main/java/com/mydeck/app/io/db/dao/BookmarkDao.kt`).
- Updated repository usages to call `upsertBookmark(...)` where previously `insertBookmark(...)` was used for metadata edits so label rename/delete paths preserve article content (`app/src/main/java/com/mydeck/app/domain/BookmarkRepositoryImpl.kt`).

### Testing
- No automated unit or instrumentation tests were executed for this change. 
- Performed repository-wide textual checks to confirm references were updated and compiled edits were applied (searches and file inspections); no build or runtime verification was performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984c74170708330839c0a6044725479)