### PR TITLE
Fix log file size limit calculation in MyDeckApplication

### DIFF
--- a/app/src/main/java/com/mydeck/app/MyDeckApplication.kt
+++ b/app/src/main/java/com/mydeck/app/MyDeckApplication.kt
@@ -69,7 +69,7 @@ class MyDeckApplication : Application() {
                         fileName = LOGFILE
                         dir = it.absolutePath
                         fileLimit = 3
-                        sizeLimit = 128
+                        sizeLimit = 128 * 1024 // 128 KB in bytes
                         appendToFile = true
                     }
                 }
@@ -81,7 +81,7 @@ class MyDeckApplication : Application() {
                         fileName = LOGFILE
                         dir = it.absolutePath
                         fileLimit = 3
-                        sizeLimit = 128
+                        sizeLimit = 128 * 1024 // 128 KB in bytes
                         appendToFile = true
                     }
                 }


### PR DESCRIPTION
## Summary
Fixed the log file size limit configuration to correctly specify 128 KB instead of 128 bytes by converting the value to bytes and adding clarifying comments.

## Changes
- Updated `sizeLimit` from `128` to `128 * 1024` in two logging configurations (debug and release builds)
- Added inline comments clarifying that the value represents 128 KB in bytes
- This ensures log files are properly rotated at 128 KB instead of the previous 128 bytes limit

## Details
The original code set `sizeLimit = 128`, which was interpreted as 128 bytes - far too small for practical logging. The fix multiplies by 1024 to convert to the intended 128 KB limit, making log rotation behavior more reasonable and preventing excessive file churn.

https://claude.ai/code/session_01LbMyTbouPGq999Br8XVuEZ