### PR TITLE
Fix read/unread icon and text state in reading view menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ Thumbs.db
 \#recycle/
 
 screenshots/
+app/githubRelease/

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         applicationId = "com.mydeck.app"
         minSdk = 24
         targetSdk = 35
-        versionCode = 800
-        versionName = "0.8.0"
+        versionCode = 910
+        versionName = "0.9.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/mydeck/app/ui/detail/components/BookmarkDetailMenu.kt
+++ b/app/src/main/java/com/mydeck/app/ui/detail/components/BookmarkDetailMenu.kt
@@ -118,8 +118,8 @@ fun BookmarkDetailMenu(
             DropdownMenuItem(
                 text = {
                     Text(
-                        if (uiState.bookmark.isRead) stringResource(R.string.action_mark_unread)
-                        else stringResource(R.string.action_mark_read)
+                        if (uiState.bookmark.isRead) stringResource(R.string.action_mark_read)
+                        else stringResource(R.string.action_mark_unread)
                     )
                 },
                 onClick = {
@@ -128,7 +128,7 @@ fun BookmarkDetailMenu(
                 },
                 leadingIcon = {
                     Icon(
-                        if (uiState.bookmark.isRead) Icons.Outlined.CheckCircle else Icons.Filled.CheckCircle,
+                        if (uiState.bookmark.isRead) Icons.Filled.CheckCircle else Icons.Outlined.CheckCircle,
                         contentDescription = null
                     )
                 }


### PR DESCRIPTION
- Fix icon logic: show filled check circle when bookmark is read, outlined when unread
- Fix text logic: show 'Read' when bookmark is read, 'Unread' when unread
- Add app/githubRelease/ to .gitignore to prevent build artifacts from being committed
- Update version to 0.9.1 for bug fix release

Fixes issue where reading view menu showed opposite state from list view