### PR TITLE
Show base server URL in Account settings (hide /api)

### DIFF
--- a/app/src/main/java/com/mydeck/app/ui/settings/AccountSettingsViewModel.kt
+++ b/app/src/main/java/com/mydeck/app/ui/settings/AccountSettingsViewModel.kt
@@ -75,7 +75,7 @@ class AccountSettingsViewModel @Inject constructor(
             _uiState.update {
                 it.copy(
                     isLoggedIn = !token.isNullOrBlank(),
-                    url = url ?: "https://"
+                    url = toDisplayUrl(url)
                 )
             }
         }
@@ -281,6 +281,15 @@ class AccountSettingsViewModel @Inject constructor(
             url = "$url/api"
         }
         return url
+    }
+
+    private fun toDisplayUrl(rawUrl: String?): String {
+        if (rawUrl.isNullOrBlank()) {
+            return "https://"
+        }
+        return rawUrl
+            .trimEnd('/')
+            .removeSuffix("/api")
     }
 
     private fun isValidUrlForCurrentSettings(url: String?): Boolean {

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -7,7 +7,7 @@
     <string name="settings_account_subtitle_default">Nicht eingeloggt</string>
     <string name="accountsettings_topbar_title">Konto</string>
     <string name="account_settings_topbar_title">Readeck URL</string>
-    <string name="account_settings_url_placeholder">https://readeck.example.com/api</string>
+    <string name="account_settings_url_placeholder">https://readeck.example.com</string>
     <string name="account_settings_url_label">Readeck URL</string>
     <string name="account_settings_username_placeholder">Benutzername</string>
     <string name="account_settings_username_label">Benutzername</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -7,7 +7,7 @@
     <string name="settings_account_subtitle_default">Sesión no iniciada</string>
     <string name="accountsettings_topbar_title">Cuenta</string>
     <string name="account_settings_topbar_title">URL de MyDeck</string>
-    <string name="account_settings_url_placeholder">https://readeck.example.com/api</string>
+    <string name="account_settings_url_placeholder">https://readeck.example.com</string>
     <string name="account_settings_url_label">URL de MyDeck</string>
     <string name="account_settings_username_placeholder">identificador</string>
     <string name="account_settings_username_label">Identificador</string>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -6,7 +6,7 @@
     <string name="settings_account_subtitle_default">Sesión non iniciada</string>
     <string name="accountsettings_topbar_title">Conta</string>
     <string name="account_settings_topbar_title">URL de MyDeck</string>
-    <string name="account_settings_url_placeholder">https://readeck.example.com/api</string>
+    <string name="account_settings_url_placeholder">https://readeck.example.com</string>
     <string name="account_settings_url_label">URL de MyDeck</string>
     <string name="account_settings_username_placeholder">identificador</string>
     <string name="account_settings_username_label">Identificador</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -17,7 +17,7 @@
     <string name="settings_account_subtitle_default">未登录</string>
     <string name="accountsettings_topbar_title">账号</string>
     <string name="account_settings_topbar_title">Readeck URL</string>
-    <string name="account_settings_url_placeholder">https://readeck.example.com/api</string>
+    <string name="account_settings_url_placeholder">https://readeck.example.com</string>
     <string name="account_settings_url_label">Readeck URL</string>
     <string name="account_settings_username_placeholder">用户名</string>
     <string name="account_settings_username_label">用户名</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,7 +6,7 @@
     <string name="settings_account_subtitle_default">Not logged in</string>
     <string name="accountsettings_topbar_title">Account</string>
     <string name="account_settings_topbar_title">Readeck URL</string>
-    <string name="account_settings_url_placeholder">https://readeck.example.com/api</string>
+    <string name="account_settings_url_placeholder">https://readeck.example.com</string>
     <string name="account_settings_url_label">Readeck URL</string>
     <string name="account_settings_username_placeholder">email@example.com</string>
     <string name="account_settings_username_label">Email Address</string>

--- a/app/src/test/java/com/mydeck/app/ui/settings/AccountSettingsViewModelTest.kt
+++ b/app/src/test/java/com/mydeck/app/ui/settings/AccountSettingsViewModelTest.kt
@@ -99,6 +99,25 @@ class AccountSettingsViewModelTest {
         assertTrue(uiState.isLoggedIn) // Should be true since token is not empty
     }
 
+
+    @Test
+    fun `initial uiState should strip api suffix from saved url for display`() = runTest {
+        every { settingsDataStore.urlFlow } returns MutableStateFlow("https://example.com/api")
+        every { settingsDataStore.tokenFlow } returns MutableStateFlow("valid-token")
+        viewModel = AccountSettingsViewModel(
+            settingsDataStore = settingsDataStore,
+            userRepository = userRepository,
+            oauthDeviceAuthUseCase = oauthDeviceAuthUseCase,
+            bookmarkRepository = bookmarkRepository,
+            context = context,
+            applicationScope = applicationScope
+        )
+
+        advanceUntilIdle()
+
+        assertEquals("https://example.com", viewModel.uiState.value.url)
+    }
+
     private fun assertInitialUiState(settingsUiState: AccountSettingsViewModel.AccountSettingsUiState) {
         assertEquals("", settingsUiState.url)
         assertNull(settingsUiState.urlError)


### PR DESCRIPTION
### Motivation
- The Account screen currently displays the internal API URL (e.g. `https://read.example.com/api`), which confuses users because they enter the base host URL on the welcome screen (e.g. `https://read.example.com`).
- The goal is to display the base server URL in Settings | Account while preserving the app's internal behavior of appending `/api` for authentication calls.

### Description
- Added a `toDisplayUrl` helper in `AccountSettingsViewModel` and use it during initialization to strip any trailing `/api` for display in the UI while returning `"https://"` for empty values.
- Kept existing behavior for authentication by leaving `normalizeApiUrl` unchanged so internal calls continue to append `/api` as needed.
- Updated the `account_settings_url_placeholder` text in default and localized string resources to show the base URL format (removed `/api`).
- Added a unit test `initial uiState should strip api suffix from saved url for display` to verify a saved URL ending in `/api` is presented without `/api` in `uiState`.

### Testing
- Added `AccountSettingsViewModel` unit test that verifies stripping of `/api` for display (`app/src/test/java/.../AccountSettingsViewModelTest.kt`).
- Attempted to run `./gradlew testDebugUnitTest --tests com.mydeck.app.ui.settings.AccountSettingsViewModelTest`, but the test run could not complete in this environment due to a Gradle/Android toolchain error (`What went wrong: 25.0.1`), so automated tests did not finish here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d02b61e008330a7c59dfbc68e65cd)