### PR TITLE
feat(reader): extend image gallery lightbox to Pictures bookmarks

### DIFF
--- a/app/src/main/java/com/mydeck/app/ui/detail/components/BookmarkDetailWebViews.kt
+++ b/app/src/main/java/com/mydeck/app/ui/detail/components/BookmarkDetailWebViews.kt
@@ -149,7 +149,8 @@ fun BookmarkDetailArticle(
                     WebView(context).apply {
                         val isVideo = uiState.bookmark.type == BookmarkDetailViewModel.Bookmark.Type.VIDEO
                         val isArticle = uiState.bookmark.type == BookmarkDetailViewModel.Bookmark.Type.ARTICLE
-                        settings.javaScriptEnabled = isVideo || isArticle  // Enable JS for articles (needed for search)
+                        val isPhoto = uiState.bookmark.type == BookmarkDetailViewModel.Bookmark.Type.PHOTO
+                        settings.javaScriptEnabled = isVideo || isArticle || isPhoto  // Enable JS for articles (search) and photos (lightbox)
                         settings.domStorageEnabled = isVideo
                         settings.mediaPlaybackRequiresUserGesture = true
                         settings.useWideViewPort = false


### PR DESCRIPTION
Enable JavaScript in the WebView for PHOTO-type bookmarks so that the
existing WebViewImageBridge image interceptor fires when the user taps
the photo. No new infrastructure is needed — the JS bridge registration,
injectImageInterceptor() call in onPageFinished, onImageTapped callback
wiring, and ImageGalleryOverlay display logic all already handled every
bookmark type; only JS execution was gated to VIDEO and ARTICLE.

https://claude.ai/code/session_0111BA1Rm3NM5dBsDf2UnAzK