### PR TITLE
Add unified offline content architecture spec and implementation plan

### DIFF
--- a/docs/specs/unified-offline-content-impl-plan.md
+++ b/docs/specs/unified-offline-content-impl-plan.md
@@ -1,0 +1,447 @@
+# Implementation Plan: Unified Offline Content Architecture
+
+## Overview
+
+This plan implements the architecture defined in `unified-offline-content-spec.md`.
+It replaces the two-tier (text-only / full) managed offline design from
+`feature/sync-multipart-v012` with a single-tier model where a bookmark either has a
+full offline package (text + images) or does not.
+
+Each slice is scoped to be independently mergeable. Later slices depend on earlier ones
+where noted.
+
+**Model guidance key:**
+- **Haiku** — Mechanical, well-bounded changes; pattern-following edits; string/resource
+  additions; simple UI removals.
+- **Sonnet** — Moderate complexity; targeted refactors touching multiple files; Compose
+  UI work; state transition logic; worker/ViewModel coordination with clear direction.
+- **Opus** — High complexity; new subsystems; multiple interacting policies with edge
+  cases; architecture-level decisions embedded in implementation; annotation-aware
+  package replacement.
+
+---
+
+## Slice 1: Formalize Content State Semantics
+
+**Goal:** Document and enforce the updated meaning of `DOWNLOADED + hasResources=false`
+(on-demand text cache) vs. `DOWNLOADED + hasResources=true` (full offline package).
+No schema change required.
+
+**Scope:**
+- Add KDoc to `BookmarkEntity.ContentState`, `ContentPackageEntity`, and
+  `BookmarkListItemEntity` clarifying the two `DOWNLOADED` sub-states and their
+  acquisition paths.
+- Add a top-level comment block in `ContentPackageManager` clarifying that
+  `hasResources=false` packages are on-demand text caches, not managed offline content.
+- Audit any code that reads `contentState == DOWNLOADED` and does not also check
+  `hasResources` — flag any places where the distinction matters for correctness.
+  (This is a read-only audit; fixes happen in later slices.)
+
+**Files touched:** `BookmarkEntity.kt`, `ContentPackageEntity.kt`,
+`BookmarkListItemEntity.kt`, `ContentPackageManager.kt`
+
+**Does not change:** Schema, DB migrations, any behavior.
+
+**Recommended model: Haiku.** Pure documentation and annotation work on already-read
+files. Pattern is clear.
+
+---
+
+## Slice 2: Update Bookmark Card Icon Logic
+
+**Goal:** Shift icon semantics so that the outline icon means "on-demand text cache"
+and the filled icon means "full offline package." The actual icon assets and conditions
+are largely the same; only the label/description and any `hasResources`-based branching
+in list item rendering need updating.
+
+**Scope:**
+- Update `BookmarkCard` (and any mosaic/grid/compact layout variants) icon derivation
+  logic: `hasResources=false → outline`, `hasResources=true → filled`, `null → no icon`.
+- Update any content descriptions or accessibility strings for these icons to reflect
+  the new semantics ("Text available" vs. "Available offline").
+- Add the new string resources to all language files (English text as placeholder per
+  CLAUDE.md localization requirements).
+- Remove any code that previously distinguished "text-only managed offline" from
+  "on-demand cache" in the icon layer (if such branching exists beyond `hasResources`).
+
+**Files touched:** Bookmark card Composable(s), string resources in all language files.
+
+**Depends on:** Slice 1 (semantic clarity).
+
+**Recommended model: Haiku.** Bounded UI logic change with mechanical string resource
+additions.
+
+---
+
+## Slice 3: Remove Per-Article Image Toggle
+
+**Goal:** Remove the cycling image toggle from `BookmarkDetailDialog` and all backing
+logic. This is a removal slice; no new behavior is added.
+
+**Scope:**
+- Remove the image toggle row from `BookmarkDetailDialog` metadata section.
+- Remove the backing ViewModel action and state that drove the toggle.
+- Remove the `downloadImagesWithArticles` preference key from `SettingsDataStore`.
+- Remove any settings migration or default value for `downloadImagesWithArticles`.
+- Do NOT remove `ContentPackageManager.deleteResources()` yet — that is Slice 4.
+  Just remove the call sites that were driven by the per-article toggle.
+- Verify that "Remove downloaded content" in the overflow menu still works correctly
+  (it calls `deleteContentForBookmark`, not `deleteResources` — confirm and retain).
+
+**Files touched:** `BookmarkDetailDialog.kt` (or equivalent Composable),
+`BookmarkDetailViewModel.kt`, `SettingsDataStore.kt`, possibly `SyncSettingsViewModel.kt`.
+
+**Depends on:** Slice 1.
+
+**Recommended model: Haiku.** Pure removal. The toggle is self-contained and its call
+sites are limited.
+
+---
+
+## Slice 4: Remove Two-Tier Managed Offline Infrastructure
+
+**Goal:** Remove `ContentPackageManager.deleteResources()`, the HTML URL-rewriting
+downgrade path, the hysteresis watermark pruning, and the text-vs-image batch sizing
+from `BatchArticleLoadWorker`. These are all load-bearing components of the two-tier
+design that has no role in the unified architecture.
+
+**Scope:**
+- Remove `ContentPackageManager.deleteResources()` and the safety check that aborts
+  when relative image URLs are detected.
+- Remove `LoadContentPackageUseCase` logic that routes to `fetchTextOnly` based on
+  `downloadImagesWithArticles`. Workers now always call the full-package fetch path.
+  Note: retain `MultipartSyncClient.fetchTextOnly()` itself — it is still used by
+  the annotation HTML refresh path (`refreshHtmlForAnnotations`).
+- Remove hysteresis high/low watermark fields and the image-only pruning loop from
+  `BatchArticleLoadWorker`.
+- Remove the `restoreDownloadedState` call and the DB query that tracked image bytes
+  separately from text bytes.
+- Remove adaptive batch sizing logic that scaled batch size based on whether images
+  were included.
+- Update `BatchArticleLoadWorker` to always request full packages.
+- Remove or simplify `ContentSyncPolicyEvaluator` if its remaining logic only checks
+  whether automatic content sync is enabled (no longer needs to gate on image mode).
+
+**Files touched:** `ContentPackageManager.kt`, `LoadContentPackageUseCase.kt`,
+`BatchArticleLoadWorker.kt`, `ContentSyncPolicyEvaluator.kt`.
+
+**Depends on:** Slice 3 (callers of `deleteResources` removed first).
+
+**Recommended model: Sonnet.** Multiple files, non-trivial interdependencies between
+worker and use case. Requires understanding what to keep vs. remove without breaking
+the annotation refresh path that shares `fetchTextOnly` at the transport layer.
+
+---
+
+## Slice 5: Simplify Annotation Refresh URL Rewriting
+
+**Goal:** Remove the `hasResources`-based branch in `refreshHtmlForAnnotations` that
+decided whether to rewrite image URLs. Full offline packages always have resources;
+the URL rewriting path is always "use relative URLs."
+
+**Scope:**
+- In `LoadContentPackageUseCase.refreshHtmlForAnnotations`, remove the conditional
+  that checked `hasResources` before applying relative URL rewriting.
+- Full offline packages always use the relative URL path. On-demand text-cached
+  bookmarks (`hasResources=false`) still use the legacy article endpoint refresh path
+  via `LoadArticleUseCase` — confirm this branching is still correct after Slice 4.
+- Update tests for `refreshHtmlForAnnotations` accordingly.
+
+**Files touched:** `LoadContentPackageUseCase.kt`, related unit tests.
+
+**Depends on:** Slice 4.
+
+**Recommended model: Sonnet.** Targeted annotation path change requiring understanding
+of the split between content-package and legacy article refresh flows.
+
+---
+
+## Slice 6: On-Demand Open Queues Full Package When Offline Reading Is Enabled
+
+**Goal:** When offline reading is on and the user opens a bookmark that has no full
+offline package, the reader fetches text immediately for fast open (existing behavior)
+and queues a priority full-package download (text + images).
+
+**Scope:**
+- In `BookmarkDetailViewModel`, after a successful on-demand text fetch, check
+  `offlineReadingEnabled`. If true and the bookmark is within the current policy's
+  eligible scope, enqueue a high-priority `BatchArticleLoadWorker` job for that
+  specific bookmark (single-item batch, REPLACE policy to avoid duplicates).
+- The priority enqueue bypasses the normal batch ordering (newest-first) because the
+  user has expressed explicit interest in this bookmark. WiFi/battery constraints
+  still apply (the WorkManager request carries them).
+- The bookmark transitions: `NOT_ATTEMPTED → DOWNLOADED(hasResources=false) →
+  DOWNLOADED(hasResources=true)` as text is cached then the full package arrives.
+- The bookmark card icon updates accordingly (outline → filled) when the package
+  commits.
+
+**Files touched:** `BookmarkDetailViewModel.kt`, `BatchArticleLoadWorker.kt` (if a
+single-bookmark enqueue path is not already present).
+
+**Depends on:** Slice 4.
+
+**Recommended model: Sonnet.** State transition logic requiring coordination between
+ViewModel, WorkManager enqueue, and existing policy evaluator.
+
+---
+
+## Slice 7: Offline Management Policy Engine
+
+**Goal:** Replace the single image-only storage cap with a three-policy selector
+(Storage Limit, Newest N, Date Range rolling window), a secondary storage cap for
+Policies B and C, and the eligibility/pruning logic that each policy requires.
+
+**Scope:**
+
+### Data layer
+- Add to `SettingsDataStore`:
+  - `offlineReadingEnabled: Boolean`
+  - `offlinePolicy: Enum { STORAGE_LIMIT, NEWEST_N, DATE_RANGE }`
+  - `offlinePolicyStorageLimit: Long`
+  - `offlinePolicyNewestN: Int`
+  - `offlinePolicyDateRangeWindow: Duration`
+  - `offlineMaxStorageCap: Long`
+- Rename `includeArchivedContentInSync` → `includeArchivedInOfflineScope`.
+- Keep `clearContentOnArchive`, `wifiOnly`, `allowOnBatterySaver`.
+- Remove `downloadImagesWithArticles` (already removed in Slice 3),
+  `contentSyncMode` enum.
+
+### Policy engine
+- Create `OfflinePolicyEvaluator` (replaces `ContentSyncPolicyEvaluator`):
+  - `isEligible(bookmark): Boolean` — applies the active policy's eligibility
+    predicate plus scope (include archived toggle).
+  - `shouldPrune(): Boolean` — checks if current usage exceeds the active policy
+    threshold.
+  - `selectForPruning(n: Int): List<String>` — returns oldest-first bookmark IDs
+    to evict until under threshold.
+- Policy A (Storage Limit): eligibility = always true within scope; prune when
+  total package bytes > limit; evict oldest-first by `created`.
+- Policy B (Newest N): eligibility = rank by `created` desc, top N within scope;
+  prune when count > N; evict oldest-first.
+- Policy C (Date Range): eligibility = `created >= now - window`; prune when any
+  package's bookmark has aged out of the window; evict aged-out packages.
+- Secondary cap check runs before policy-based pruning for Policies B and C.
+
+### Worker
+- Update `BatchArticleLoadWorker` to use `OfflinePolicyEvaluator` for eligibility
+  checks and pruning decisions.
+- Pruning loop: query eligible packages sorted by `created` asc, call
+  `ContentPackageManager.deleteContentForBookmark()` on oldest until under threshold.
+
+**Files touched:** `SettingsDataStore.kt`, new `OfflinePolicyEvaluator.kt`,
+`BatchArticleLoadWorker.kt`, DB migration if preference schema is stored in Room
+(otherwise DataStore migration), `ContentPackageManager.kt` (prune call sites).
+
+**Depends on:** Slices 4 and 5.
+
+**Recommended model: Opus.** New subsystem with multiple interacting policies and
+edge cases: concurrent pruning and download, policy transitions (user changes policy
+mid-session), eligibility changes when scope setting changes, interaction between
+secondary cap and primary policy. Requires careful design of the evaluator interface
+to keep each policy implementation testable in isolation.
+
+---
+
+## Slice 8: Settings Screen Redesign
+
+**Goal:** Replace the existing content sync section with the offline reading section
+as specified in `unified-offline-content-spec.md`. This is primarily a Compose UI
+slice; the data layer is in place after Slice 7.
+
+**Scope:**
+- Remove: content sync mode radio group, date-range scheduling section, download images
+  toggle, accordions/collapsible sections.
+- Add: offline reading master toggle; policy selector (radio group); storage limit
+  picker; newest-N picker; date-range window picker; secondary storage cap picker
+  (conditional on policy); include archived toggle; clear-on-archive toggle;
+  Wi-Fi only and battery-saver toggles (retained); one-time manual date-range
+  download button (see Slice 9).
+- Settings screen collapses substantially when offline reading is off.
+- Sync status section updates per spec (different fields shown when offline on vs. off).
+- String resources for all new UI labels added to all language files.
+- Update user guide (`settings.md`) to reflect the new layout.
+
+**Files touched:** Sync settings Composable(s), `SyncSettingsViewModel.kt`,
+string resource files (all languages), `app/src/main/assets/guide/en/settings.md`.
+
+**Depends on:** Slice 7.
+
+**Recommended model: Sonnet.** Large Compose UI change but well-specified. The main
+risk is getting conditional visibility right for the collapsed state; the ViewModel
+logic is straightforward read/write of preference keys.
+
+---
+
+## Slice 9: One-Time Manual Date-Range Download
+
+**Goal:** Add a "Download content for date range" action that triggers a one-time
+batch download for bookmarks added within a user-specified from/to date range.
+This is distinct from the ongoing rolling-window Policy C.
+
+**Scope:**
+- Add a date range picker dialog triggered from the settings screen button.
+- On confirm, enqueue a `BatchArticleLoadWorker` with date-range input parameters
+  (from/to Instant), bypassing the active management policy's eligibility predicate
+  but still respecting WiFi/battery constraints. Show a constraint-override dialog
+  if constraints would block the download (matching existing date-range sync behavior).
+- Content downloaded by a one-time sync is subject to normal eviction by the active
+  management policy on subsequent maintenance runs.
+- This replaces the old date-range scheduling path from the prior branch.
+
+**Files touched:** Settings Composable (date picker dialog), `BatchArticleLoadWorker.kt`
+(accept optional explicit date range override), `SyncSettingsViewModel.kt`.
+
+**Depends on:** Slice 8.
+
+**Recommended model: Sonnet.** Moderate complexity; the worker change is a parameter
+addition, the UI is a standard date picker + constraint dialog pattern already present
+in the codebase.
+
+---
+
+## Slice 10: Offline Reading Enable/Disable Lifecycle
+
+**Goal:** Implement the full lifecycle: enabling offline reading starts the background
+worker, disabling offline reading immediately purges all managed offline content
+(`hasResources=true` packages) and cancels any pending work.
+
+**Scope:**
+- When `offlineReadingEnabled` transitions to `true`: enqueue `BatchArticleLoadWorker`
+  with current policy constraints.
+- When `offlineReadingEnabled` transitions to `false`:
+  - Cancel any pending `BatchArticleLoadWorker` work.
+  - Query all `DOWNLOADED` bookmarks with `hasResources=true`.
+  - Call `ContentPackageManager.deleteContentForBookmark()` for each.
+  - On-demand text caches (`hasResources=false`) are NOT purged.
+- Purge runs on a `CoroutineScope` tied to the settings ViewModel, not a worker
+  (it is synchronous from the user's perspective — settings screen should show progress
+  if the library is large).
+- After purge, update sync status display.
+
+**Files touched:** `SyncSettingsViewModel.kt`, `ContentPackageManager.kt`,
+`BookmarkDao.kt` (query for hasResources=true packages).
+
+**Depends on:** Slices 7 and 8.
+
+**Recommended model: Sonnet.** Lifecycle transitions with clear rules; the main concern
+is that the purge does not race with an in-progress download worker.
+
+---
+
+## Slice 11: Bookmark Detail Dialog Offline Status
+
+**Goal:** Update the Bookmark Detail dialog to show explicit offline status text per
+spec, and confirm the "Remove downloaded content" overflow menu item works correctly
+for both `hasResources=true` and `hasResources=false` packages.
+
+**Scope:**
+- Replace icon-only offline indicator in the detail dialog with explicit status text:
+  "Offline content: Not kept / Text cached / Available / Refresh pending."
+- Confirm `deleteContentForBookmark()` is called (not `deleteResources()`) by the
+  overflow menu item — both `hasResources` states should be fully purged by this action.
+- The overflow menu item should be visible whenever `contentState == DOWNLOADED`,
+  regardless of `hasResources` value.
+- Add/update string resources for all status labels in all language files.
+- Update user guide (`your-bookmarks.md`) if the detail dialog section describes
+  offline state.
+
+**Files touched:** Bookmark detail dialog Composable(s), `BookmarkDetailViewModel.kt`,
+string resources (all languages), `app/src/main/assets/guide/en/your-bookmarks.md`.
+
+**Depends on:** Slice 3 (image toggle removed), Slice 10 (lifecycle stable).
+
+**Recommended model: Haiku.** Mostly a UI text change and menu item audit with string
+resource additions.
+
+---
+
+## Slice 12: Migration from Prior Settings
+
+**Goal:** Ensure users upgrading from `feature/sync-multipart-v012` or earlier get a
+sensible default state.
+
+**Scope:**
+- If prior `contentSyncMode == AUTOMATIC`: migrate to `offlineReadingEnabled = true`,
+  `offlinePolicy = STORAGE_LIMIT`, `offlinePolicyStorageLimit = 500 MB` (sensible default).
+- If prior `contentSyncMode != AUTOMATIC`: migrate to `offlineReadingEnabled = false`.
+- `includeArchivedContentInSync` value migrates to `includeArchivedInOfflineScope`.
+- Existing `DOWNLOADED + hasResources=true` packages require no migration; they are
+  valid full offline packages.
+- Existing `DOWNLOADED + hasResources=false` packages become on-demand text caches;
+  no migration required.
+- Log migration in a one-time DataStore preferences migration block.
+
+**Files touched:** `SettingsDataStore.kt` (migration logic), possibly a `MigrationHelper`
+class if the codebase has a pattern for this.
+
+**Depends on:** Slice 7 (new preference keys exist).
+
+**Recommended model: Haiku.** Mechanical mapping of old preference values to new ones.
+Edge cases are limited; the migration table is fully specified above.
+
+---
+
+## Slice 13: Unit Test Coverage
+
+**Goal:** Add unit tests for the new `OfflinePolicyEvaluator` and the updated
+`BatchArticleLoadWorker` pruning and eligibility logic. Update tests invalidated by
+Slices 4 and 5.
+
+**Scope:**
+- `OfflinePolicyEvaluator` unit tests: each policy's `isEligible`, `shouldPrune`,
+  and `selectForPruning` with boundary conditions (count at N, count at N+1; storage
+  at limit, storage over limit; bookmark just within window, bookmark just outside
+  window).
+- Secondary cap interaction tests for Policies B and C.
+- `BatchArticleLoadWorker` integration tests: policy check → download → prune cycle.
+- Remove or update tests that exercised `deleteResources`, the hysteresis pruning loop,
+  or the `downloadImagesWithArticles` conditional.
+- Annotation refresh tests: confirm `refreshHtmlForAnnotations` no longer branches on
+  `hasResources`.
+
+**Files touched:** Test files under `app/src/test/` and `app/src/androidTest/`.
+
+**Depends on:** Slices 4, 5, 7.
+
+**Recommended model: Opus.** Policy boundary condition tests require careful thought
+about exactly what each policy guarantees. Getting the pruning selection logic right
+under concurrent modifications (new bookmarks arriving while pruning) needs thorough
+test design. Annotation refresh test update requires understanding the full refresh path.
+
+---
+
+## Dependency Graph
+
+```
+Slice 1 (semantics doc)
+  └─ Slice 2 (card icons)
+  └─ Slice 3 (remove image toggle)
+       └─ Slice 4 (remove two-tier infra)
+            └─ Slice 5 (annotation refresh simplification)
+            └─ Slice 6 (on-demand → queue full package)
+            └─ Slice 7 (policy engine)
+                 └─ Slice 8 (settings UI)
+                      └─ Slice 9 (one-time date-range action)
+                      └─ Slice 10 (enable/disable lifecycle)
+                           └─ Slice 11 (detail dialog status)
+                 └─ Slice 12 (settings migration)
+  Slice 13 (tests) — depends on 4, 5, 7; can run after each
+```
+
+Slices 2 and 3 are independent of each other and can be done in parallel.
+Slices 5 and 6 are independent of each other after Slice 4.
+Slices 9, 10, and 12 are independent of each other after Slice 7/8.
+Slice 13 work can begin after Slice 4 and continue incrementally through Slice 7.
+
+---
+
+## Build Verification (per CLAUDE.md)
+
+After each slice:
+```
+./gradlew :app:assembleDebugAll
+./gradlew :app:testDebugUnitTestAll
+./gradlew :app:lintDebugAll
+```
+
+All three must pass before committing a slice.

--- a/docs/specs/unified-offline-content-impl-plan.md
+++ b/docs/specs/unified-offline-content-impl-plan.md
@@ -73,28 +73,41 @@ additions.
 
 ---
 
-## Slice 3: Remove Per-Article Image Toggle
+## Slice 3: Remove Per-Bookmark Content Management UI and Dead Code
 
-**Goal:** Remove the cycling image toggle from `BookmarkDetailDialog` and all backing
-logic. This is a removal slice; no new behavior is added.
+**Goal:** Remove the per-article image toggle and fully clean up the incomplete removal
+of the per-bookmark "Remove downloaded content" action. Content lifecycle is the system's
+responsibility; no per-bookmark download or removal actions belong in the UI. This is a
+removal slice; no new behavior is added.
 
 **Scope:**
-- Remove the image toggle row from `BookmarkDetailDialog` metadata section.
-- Remove the backing ViewModel action and state that drove the toggle.
-- Remove the `downloadImagesWithArticles` preference key from `SettingsDataStore`.
-- Remove any settings migration or default value for `downloadImagesWithArticles`.
+- Remove the image toggle row from `BookmarkDetailDialog` metadata section and its
+  backing ViewModel action and state.
+- Remove the `downloadImagesWithArticles` preference key from `SettingsDataStore` and
+  any associated migration or default value.
+- Remove `BookmarkDetailViewModel.onRemoveDownloadedContent()` and
+  `BookmarkListViewModel.onRemoveDownloadedContent()` — these are dead ViewModel methods
+  left over from an incomplete removal on the branch.
+- Remove the `onRemoveDownloadedContent` callback parameter and all propagation through
+  the composable chain: `BookmarkDetailScreen`, `BookmarkDetailTopBar`,
+  `BookmarkDetailMenu`, `BookmarkCard`, `BookmarkCards`, `BookmarkListScreen`,
+  `BookmarkDetailsDialog`.
+- Remove any string resources associated with the "Remove downloaded content" menu item
+  label from all language files.
 - Do NOT remove `ContentPackageManager.deleteResources()` yet — that is Slice 4.
-  Just remove the call sites that were driven by the per-article toggle.
-- Verify that "Remove downloaded content" in the overflow menu still works correctly
-  (it calls `deleteContentForBookmark`, not `deleteResources` — confirm and retain).
+- Do NOT remove `ContentPackageManager.deletePackage()` — it is still needed by the
+  policy pruning worker and archive auto-clear.
 
-**Files touched:** `BookmarkDetailDialog.kt` (or equivalent Composable),
-`BookmarkDetailViewModel.kt`, `SettingsDataStore.kt`, possibly `SyncSettingsViewModel.kt`.
+**Files touched:** `BookmarkDetailDialog.kt`, `BookmarkDetailViewModel.kt`,
+`BookmarkListViewModel.kt`, `BookmarkDetailScreen.kt`, `BookmarkDetailTopBar.kt`,
+`BookmarkDetailMenu.kt`, `BookmarkCard.kt`, `BookmarkCards.kt`, `BookmarkListScreen.kt`,
+`SettingsDataStore.kt`, string resource files (all languages).
 
 **Depends on:** Slice 1.
 
-**Recommended model: Haiku.** Pure removal. The toggle is self-contained and its call
-sites are limited.
+**Recommended model: Haiku.** Pure removal across many files, but each change is
+mechanical — delete parameter declarations, remove propagation, remove method bodies.
+No logic decisions required.
 
 ---
 
@@ -339,22 +352,20 @@ is that the purge does not race with an in-progress download worker.
 ## Slice 11: Bookmark Detail Dialog Offline Status
 
 **Goal:** Update the Bookmark Detail dialog to show explicit offline status text per
-spec, and confirm the "Remove downloaded content" overflow menu item works correctly
-for both `hasResources=true` and `hasResources=false` packages.
+spec. No per-bookmark content action is added — status display is purely informational.
 
 **Scope:**
 - Replace icon-only offline indicator in the detail dialog with explicit status text:
   "Offline content: Not kept / Text cached / Available / Refresh pending."
-- Confirm `deleteContentForBookmark()` is called (not `deleteResources()`) by the
-  overflow menu item — both `hasResources` states should be fully purged by this action.
-- The overflow menu item should be visible whenever `contentState == DOWNLOADED`,
-  regardless of `hasResources` value.
+- Confirm no per-bookmark content removal action exists in the dialog or its overflow
+  menu after Slice 3. The detail overflow menu retains only actions unrelated to content
+  lifecycle management (e.g. share, open in browser, edit metadata, delete bookmark).
 - Add/update string resources for all status labels in all language files.
 - Update user guide (`your-bookmarks.md`) if the detail dialog section describes
   offline state.
 
-**Files touched:** Bookmark detail dialog Composable(s), `BookmarkDetailViewModel.kt`,
-string resources (all languages), `app/src/main/assets/guide/en/your-bookmarks.md`.
+**Files touched:** Bookmark detail dialog Composable(s), string resources (all languages),
+`app/src/main/assets/guide/en/your-bookmarks.md`.
 
 **Depends on:** Slice 3 (image toggle removed), Slice 10 (lifecycle stable).
 

--- a/docs/specs/unified-offline-content-impl-plan.md
+++ b/docs/specs/unified-offline-content-impl-plan.md
@@ -259,7 +259,15 @@ slice; the data layer is in place after Slice 7.
 - Settings screen collapses substantially when offline reading is off.
 - Sync status section updates per spec (different fields shown when offline on vs. off).
 - String resources for all new UI labels added to all language files.
-- Update user guide (`settings.md`) to reflect the new layout.
+- **Material You compliance:** Bring the full settings screen to Material You parity.
+  The existing Bookmark Sync section is already correct and serves as the reference.
+  All sections below it must use consistent Material 3 components (`ListItem`,
+  `SwitchPreference`, `DropdownMenuBox`, etc.) with correct surface tiers, container
+  colors, and content color tokens. No custom-styled controls should remain.
+- **User guide:** Update `app/src/main/assets/guide/en/settings.md` to document the
+  offline reading toggle, the three management policies, the one-time date-range download
+  action, and the archive scope options. Update `your-bookmarks.md` to document the
+  updated bookmark card icons (outline = text cached, filled = fully available offline).
 
 **Files touched:** Sync settings Composable(s), `SyncSettingsViewModel.kt`,
 string resource files (all languages), `app/src/main/assets/guide/en/settings.md`.

--- a/docs/specs/unified-offline-content-spec.md
+++ b/docs/specs/unified-offline-content-spec.md
@@ -1,0 +1,441 @@
+# Spec: Unified Offline Content Architecture
+
+## Status
+
+Draft. Supersedes `managed-offline-reading-spec.md` and `granular-offline-content-management-spec.md`
+as the forward-looking design for offline content in MyDeck.
+
+The multipart transport infrastructure from `feature/sync-multipart-v012` is retained as-is.
+This spec redefines what is built on top of it.
+
+---
+
+## Origin
+
+`managed-offline-reading-spec.md` established a policy-driven offline reading model and
+identified the two-tier content design (text-only with lazy images / full with local images)
+as the foundation. After working through implementation implications, it became clear that
+the two-tier design creates more complexity than it resolves:
+
+- A fragile three-step sequence (HTML refresh → URL rewriting → image deletion) is required
+  to downgrade a full package to text-only.
+- A backfill worker path is required to upgrade text-only packages to full packages.
+- `ContentPackageManager.deleteResources()` has a safety abort condition that can stall
+  storage pruning.
+- Hysteresis watermark logic in `BatchArticleLoadWorker` tracks image bytes separately from
+  text bytes, with a restore path back to text-only state.
+- The reader and annotation refresh paths must branch on whether resources are present.
+
+This spec collapses the two tiers. A bookmark either has a full offline content package
+(text + images) or it does not. There is no managed text-only offline state.
+
+---
+
+## Design Principles
+
+### 1. Offline content is binary: full package or nothing
+
+In offline reading mode, managed content always includes both text and images. There is no
+"text-only offline" tier. A bookmark is either fully downloaded or not downloaded.
+
+### 2. On-demand text caching is a performance optimization, not offline content
+
+When a user opens a bookmark that has no local package, the reader fetches HTML from the
+network and stores it locally. This text cache exists for fast re-open performance and is
+not "offline content" in the managed sense. It is not subject to offline storage policies.
+
+### 3. Network-first is the default; offline reading is opt-in
+
+The default experience is network-first: bookmark metadata syncs automatically, articles
+open over the network, and the reader caches text locally for performance. Offline reading
+is an optional background maintenance policy.
+
+### 4. Storage management operates at the bookmark level, not the resource level
+
+When a management policy requires pruning, whole offline packages are evicted (oldest first),
+not individual image files from otherwise-retained packages. This keeps the content state
+machine simple and makes storage behavior predictable.
+
+---
+
+## Content States
+
+The existing `BookmarkEntity.ContentState` enum is retained without schema change:
+
+```
+NOT_ATTEMPTED      — no package, no cache
+DOWNLOADED         — content is present locally
+DIRTY              — content is present but needs refresh (e.g. annotations changed)
+PERMANENT_NO_CONTENT — server has confirmed no extractable content for this bookmark
+```
+
+The distinction between "text-cached on demand" and "full offline package" is expressed
+through the existing `ContentPackageEntity.hasResources` field, which already flows to
+`BookmarkListItemEntity.hasResources` for list display:
+
+| ContentState  | hasResources | Meaning                                               |
+|---------------|--------------|-------------------------------------------------------|
+| NOT_ATTEMPTED | null         | No local content                                      |
+| DOWNLOADED    | false        | Text cached on-demand; images lazy-load from network  |
+| DOWNLOADED    | true         | Full offline package (text + images); managed offline |
+| DIRTY         | false        | Stale text cache; needs refresh                       |
+| DIRTY         | true         | Stale full package; needs refresh                     |
+| PERMANENT...  | null         | No content available from server                      |
+
+`DOWNLOADED + hasResources=false` replaces what would otherwise be a new `TEXT_CACHED` enum
+value. Since the alternative architecture eliminates the managed text-only offline state,
+this combination has a single, unambiguous meaning going forward: the text was cached
+on-demand when the user opened the article. No DB schema migration is required.
+
+---
+
+## Modes of Operation
+
+### Default Mode (offline reading disabled)
+
+- No background content downloading.
+- Opening a bookmark fetches HTML from the network. Text is stored locally
+  (`DOWNLOADED, hasResources=false`) for fast re-open. Images lazy-load from the network.
+- Text cache is retained indefinitely until the user explicitly removes it (via "Remove
+  downloaded content" in the bookmark detail overflow menu) or archives the bookmark
+  with auto-clear enabled. It is not auto-pruned by any background process. LRU or
+  age-based eviction is deferred as a potential future enhancement.
+- `BookmarkListItemEntity.hasResources = false` → outline download icon on bookmark cards.
+
+### Offline Reading Mode (enabled via settings)
+
+- Background worker (`BatchArticleLoadWorker`) proactively downloads full packages
+  (text + images) for eligible bookmarks, newest-first by date added, subject to the
+  active management policy.
+- WiFi-only and battery-saver constraints apply to the background worker, not to
+  on-demand article opens.
+- When the user opens a bookmark not yet downloaded (beyond current policy range or not
+  yet reached by the worker), the reader fetches text from the network immediately
+  (fast open) and queues a full package download (text + images) as a priority task.
+  The bookmark transitions: `NOT_ATTEMPTED → DOWNLOADED(hasResources=false) →
+  DOWNLOADED(hasResources=true)` as first the text is cached, then the full package
+  arrives. This means any bookmark the user actively opens while online and offline
+  reading is enabled will naturally acquire a full offline package regardless of whether
+  it is within the current policy range.
+- `BookmarkListItemEntity.hasResources = true` → filled download icon on bookmark cards.
+- Disabling offline reading purges all managed offline content (`hasResources=true`
+  packages) immediately. On-demand text caches (`hasResources=false`) are retained
+  per the default-mode rules above.
+
+---
+
+## Bookmark Card Icons
+
+| State                              | Icon                        |
+|------------------------------------|-----------------------------|
+| No local content (NOT_ATTEMPTED)   | None                        |
+| Text cached on-demand (DOWNLOADED, hasResources=false) | Outline download icon |
+| Full offline package (DOWNLOADED, hasResources=true)   | Filled download icon  |
+| DIRTY (either sub-state)           | Same icon as DOWNLOADED sub-state; no separate dirty indicator on cards |
+
+This extends the icon system from `granular-offline-content-management-spec.md` with one
+semantic shift: the outline icon's meaning changes from "managed text-only offline" to
+"on-demand text cache."
+
+---
+
+## Offline Management Policies
+
+All three policies share the same download mechanism: fetch full packages newest-first.
+They differ only in how eligibility and the pruning threshold are defined.
+
+### Policy A: Storage Limit
+
+- Download newest-first until total offline storage (text + images combined) reaches
+  the configured cap.
+- When new bookmarks arrive and the cap would be exceeded: drop offline content for the
+  oldest eligible bookmark(s) until under the cap.
+- Cap options: 100 MB, 250 MB, 500 MB, 1 GB, 2 GB, Unlimited.
+- No secondary storage cap applies to this policy; the cap is the only limit.
+
+### Policy B: Newest N Bookmarks
+
+- Maintain full offline packages for the N most recently added eligible bookmarks.
+- When the count would exceed N (new bookmark added, or eligibility changes): drop
+  offline content for the oldest bookmark above the limit.
+- N options: 10, 25, 50, 100, 250, 500, All eligible.
+- A secondary maximum storage cap may optionally be configured as a safeguard:
+  "Never exceed X GB regardless of count." Defaults to Unlimited.
+
+### Policy C: Added Within Last N Days / Weeks / Months
+
+- Maintain full offline packages for bookmarks added within a rolling time window.
+- Content for bookmarks older than the window is pruned during the next maintenance run.
+- Window options: 1 week, 2 weeks, 1 month, 3 months, 6 months, 1 year.
+- A secondary maximum storage cap may optionally be configured as a safeguard.
+  Defaults to Unlimited.
+
+### Secondary Storage Cap
+
+The secondary cap applies only to Policies B and C. It acts as a hard ceiling: pruning
+runs to satisfy the cap before policy-based maintenance runs. Storage-Limit (Policy A)
+already defines the space budget directly; adding a secondary cap to it would be
+redundant and confusing, so it is not offered for Policy A.
+
+### Policy Selector
+
+The three policies are presented as a single radio-button selector. One policy is always
+active when offline reading is enabled.
+
+---
+
+## One-Time Manual Sync by Date Range
+
+In addition to the ongoing management policies, a one-time manual batch download action
+is available. The user specifies a from-date and to-date, and the app downloads full
+packages for all eligible bookmarks added within that range, subject to the current
+WiFi and battery constraints.
+
+This is a manual action, not an ongoing management policy. Content downloaded via a
+one-time sync is subject to the same eviction rules as content downloaded by the active
+management policy (it may be pruned if the policy threshold is later exceeded). The
+action appears in the settings screen as a button, separate from the policy selector.
+
+This restores the date-range download capability that existed pre-branch while keeping
+it distinct from the ongoing rolling-window policy.
+
+---
+
+## Offline Scope and Archive Handling
+
+### Scope
+
+Two scope options control which bookmarks are eligible for offline management:
+
+- **My List**: Only non-archived bookmarks. When a bookmark is archived, it becomes
+  ineligible; its managed offline content (`hasResources=true` package) is purged if
+  `clearContentOnArchive` is enabled.
+- **My List + Archived**: Both non-archived and archived bookmarks are eligible.
+
+### Auto-Clear on Archive
+
+A separate toggle: `clearContentOnArchive`. When enabled, archiving any bookmark removes
+its full offline package (and its on-demand text cache) and resets `contentState` to
+`NOT_ATTEMPTED`. Un-archiving does not trigger a re-download; the bookmark re-enters the
+normal download queue at its natural newest-first position.
+
+---
+
+## Bookmark Type Handling
+
+### Article Bookmarks
+
+Standard handling: full package = HTML text + inline image resources. Both text and images
+are stored and served from the local package.
+
+### Picture Bookmarks
+
+Full package = primary image + any associated text/caption HTML. Pictures always download
+their primary image; this is unchanged. The management policies apply in the same way as
+articles. Icon logic is the same.
+
+### Video Bookmarks
+
+Full package = HTML content (which may include a transcript, captions, or text extracted
+via a custom content script) plus any inline images in that text. The video itself is not
+stored (embed-based; the player requires network access). A user opening a video bookmark
+while offline with a downloaded package can read any text content, but cannot play the
+video. The icon and state machine are the same as other bookmark types. The download action
+does not attempt to fetch or cache video media files.
+
+---
+
+## Per-Article Image Toggle: Removed
+
+The per-article cycling icon in the Bookmark Detail dialog (toggle between "images stored
+locally" and "images lazy-loaded") is removed. It is not needed under this architecture.
+
+Users who want images for a specific article that was not downloaded by the active policy
+can simply open the article while online when offline reading is enabled — a full package
+(text + images) will be queued immediately on open, as described in the Offline Reading
+Mode section above.
+
+Users who want to remove offline content for a specific article can use the "Remove
+downloaded content" action in the bookmark detail overflow menu. This resets the bookmark
+to `NOT_ATTEMPTED`, and the full package will be re-downloaded by the next maintenance run
+if the bookmark is still within policy range.
+
+Retaining the toggle would require keeping:
+- `ContentPackageManager.deleteResources()` and its safety abort on relative URL detection.
+- The HTML refresh + URL rewriting sequence to restore absolute image URLs before deletion.
+- The text-only vs. full-resource branch in `refreshHtmlForAnnotations`.
+- A second sub-state within `DOWNLOADED` content that the batch worker, reader, and
+  annotation pipeline must all handle separately.
+
+The simplification gained by removal outweighs the marginal per-article control lost.
+
+---
+
+## Annotation Implications
+
+The annotation pipeline is unchanged in structure. The simplification is in the
+`refreshHtmlForAnnotations` path:
+
+- Full offline packages always have resources. The URL rewriting path in `refreshHtmlForAnnotations`
+  always uses relative URLs for offline packages. The branch that checked `hasResources`
+  to decide whether to rewrite URLs is no longer needed.
+- For on-demand text-cached bookmarks (`hasResources=false`), annotation refresh uses the
+  legacy article endpoint path (`LoadArticleUseCase`) as today.
+- The annotation snapshot caching logic (`BookmarkDetailViewModel`) is unchanged.
+- When the background worker downloads a full package for a bookmark that has local
+  annotation modifications (e.g., the user created a highlight while reading the text-cached
+  version), the worker must detect the `DIRTY` state and re-apply annotation enrichment
+  rather than overwriting with a clean server package. This is the same safeguard that
+  exists in the current branch.
+
+---
+
+## What Is Removed from the Current Branch
+
+The following are explicitly removed as part of implementing this architecture:
+
+- `fetchTextOnly()` worker path in `BatchArticleLoadWorker` (the method may remain in
+  `MultipartSyncClient` for annotation refresh use only).
+- `ContentPackageManager.deleteResources()` and its associated safety check.
+- HTML URL rewriting for the full → text-only downgrade path.
+- Hysteresis watermark image pruning in `BatchArticleLoadWorker`.
+- Adaptive batch sizing based on text-vs-image mode.
+- Per-article image toggle UI in `BookmarkDetailDialog` and its backing ViewModel logic.
+- `downloadImagesWithArticles` preference key.
+- Bookmark-card offline state badges that distinguish text-only from full packages in a
+  managed-offline context (replaced by the outline/filled icon distinction described above).
+
+---
+
+## Settings Layout
+
+```
+Offline Reading
+  [✓] Enable offline reading
+
+  Keep offline:
+  ( ) Newest N bookmarks          [100 ▼]
+  ( ) Added within last            [3 months ▼]
+  (●) Storage limit               [1 GB ▼]
+
+  Maximum storage cap             [Unlimited ▼]
+  (only shown for Newest N and Date Range policies)
+
+  Include archived bookmarks                  [OFF]
+  Clear offline content when archiving        [OFF]
+  Wi-Fi only                                  [OFF]
+  Allow on battery saver                      [ON]
+
+  [  Download content for date range...  ]
+  (opens date picker; one-time manual action)
+```
+
+---
+
+## Settings Keys
+
+### Remove
+- `downloadImagesWithArticles: Boolean`
+- `contentSyncMode: Enum` (automatic/manual/date-range as a scheduling concept)
+- `dateRangeParams` as a user-facing scheduling concept (retained internally for one-time sync)
+
+### Keep (rename where appropriate)
+- `syncFrequency`
+- `wifiOnly: Boolean`
+- `allowOnBatterySaver: Boolean`
+- `includeArchivedInOfflineScope: Boolean` (was `includeArchivedContentInSync`)
+- `clearContentOnArchive: Boolean`
+
+### Add
+- `offlineReadingEnabled: Boolean`
+- `offlinePolicy: Enum { STORAGE_LIMIT, NEWEST_N, DATE_RANGE }`
+- `offlinePolicyStorageLimit: Long` (bytes)
+- `offlinePolicyNewestN: Int`
+- `offlinePolicyDateRangeWindow: Duration`
+- `offlineMaxStorageCap: Long` (secondary cap; Policies B and C only; default: Long.MAX_VALUE)
+
+---
+
+## Bookmark Detail Dialog Offline Status
+
+Replace any icon-only indicator with explicit status text:
+
+- `Offline content: Not kept` — NOT_ATTEMPTED, offline reading off
+- `Offline content: Text cached` — DOWNLOADED, hasResources=false
+- `Offline content: Available` — DOWNLOADED, hasResources=true
+- `Offline content: Refresh pending` — DIRTY (either sub-state)
+
+The "Remove downloaded content" overflow menu item remains, visible when
+`contentState == DOWNLOADED` regardless of `hasResources` value.
+
+---
+
+## Sync Status Display
+
+When offline reading is off:
+- Last bookmark sync time
+- Next scheduled sync
+
+When offline reading is on (additional fields):
+- Total bookmarks / My List count / Archived count
+- Bookmarks with full offline content available
+- Offline storage used
+- Last offline content maintenance time
+
+Low-value diagnostic counters (download failed, no article content) are not surfaced
+in the main settings screen.
+
+---
+
+## Migration
+
+1. Fresh installs: offline reading defaults to off; no managed offline content.
+2. Existing installs with automatic content sync enabled: migrate to offline reading on,
+   policy set to Storage Limit at the user's current or a sensible default cap.
+3. Existing `DOWNLOADED + hasResources=true` packages remain valid; no re-download needed.
+4. Existing `DOWNLOADED + hasResources=false` packages remain as on-demand text caches;
+   they are not purged unless the user explicitly removes them or archives the bookmark.
+5. The `downloadImagesWithArticles` preference is removed; its previous value does not
+   need migration (the new architecture always downloads images in offline mode).
+
+---
+
+## Future Considerations
+
+### LRU / age-based eviction of on-demand text caches
+
+In the default (offline reading off) mode, the on-demand text cache grows without bound.
+For users with large libraries who open many articles, this could accumulate significant
+storage over time. Future options:
+
+- Evict on-demand caches older than N days.
+- Keep at most N on-demand caches (LRU).
+- Let the user configure a separate cache size limit.
+
+These are deferred; "remove downloaded content" and "clear all offline content" in settings
+cover the explicit management case in the near term.
+
+### Collections-based offline scope
+
+When Readeck collections are implemented in MyDeck, a fourth management policy becomes
+viable: the user designates a collection (defined by a set of filter criteria) as the
+offline scope. The app maintains full offline packages for all bookmarks matching that
+collection. This would be an ongoing active management policy with very fine-grained
+control. The architecture described in this spec accommodates this straightforwardly:
+the eligibility predicate in `BatchArticleLoadWorker` simply becomes a collection query
+rather than a date-range or count check. Implementation is deferred until the collections
+feature exists.
+
+### Custom date/time range as an ongoing rolling policy
+
+The one-time manual date-range sync described above uses an explicit from/to date pair.
+A rolling variant (e.g., "bookmarks added between 6 months ago and 3 months ago") is
+technically feasible but creates a window that may grow stale without user attention.
+Policy C (rolling time window from today) is the cleaner ongoing variant; the custom
+from/to range is most useful as a one-time backfill tool.
+
+---
+
+## Open Questions
+
+None unresolved at time of writing.

--- a/docs/specs/unified-offline-content-spec.md
+++ b/docs/specs/unified-offline-content-spec.md
@@ -302,6 +302,15 @@ The following are explicitly removed as part of implementing this architecture:
 - Adaptive batch sizing based on text-vs-image mode.
 - Per-article image toggle UI in `BookmarkDetailDialog` and its backing ViewModel logic.
 - `downloadImagesWithArticles` preference key.
+- Per-bookmark "Remove downloaded content" action: the UI element was removed from the
+  branch but the removal was incomplete. The following dead code must be fully cleaned up:
+  `BookmarkDetailViewModel.onRemoveDownloadedContent()`,
+  `BookmarkListViewModel.onRemoveDownloadedContent()`, the `onRemoveDownloadedContent`
+  callback parameter and its propagation through the full composable chain
+  (`BookmarkDetailScreen`, `BookmarkDetailTopBar`, `BookmarkDetailMenu`, `BookmarkCard`,
+  `BookmarkCards`, `BookmarkListScreen`, `BookmarkDetailsDialog`), and any associated
+  string resources. `ContentPackageManager.deletePackage()` itself is retained — it is
+  still called by the policy pruning worker and by archive auto-clear.
 - Bookmark-card offline state badges that distinguish text-only from full packages in a
   managed-offline context (replaced by the outline/filled icon distinction described above).
 
@@ -390,8 +399,10 @@ Replace any icon-only indicator with explicit status text:
 - `Offline content: Available` — DOWNLOADED, hasResources=true
 - `Offline content: Refresh pending` — DIRTY (either sub-state)
 
-The "Remove downloaded content" overflow menu item remains, visible when
-`contentState == DOWNLOADED` regardless of `hasResources` value.
+No per-bookmark content removal action is exposed in the detail dialog or its overflow
+menu. Content lifecycle is managed entirely by the system (policy-based background worker,
+archive auto-clear, global clear in settings). The status display above is purely
+informational.
 
 ---
 

--- a/docs/specs/unified-offline-content-spec.md
+++ b/docs/specs/unified-offline-content-spec.md
@@ -307,6 +307,31 @@ The following are explicitly removed as part of implementing this architecture:
 
 ---
 
+## Settings Screen UI Requirements
+
+### Material You Compliance
+
+The sync settings screen must be updated to be fully Material You compliant as part of
+this implementation. The existing **Bookmark Sync** section already uses correct Material
+You styling and serves as the reference. All new and existing sections below it must be
+brought to the same standard: consistent typography scale, proper use of
+`ListItem`/`SwitchPreference`/`DropdownMenuBox` Material 3 components, correct surface
+tiers and container colors, and appropriate use of `contentColor`/`containerColor` tokens.
+No custom-styled controls that deviate from the Material 3 component set should remain
+after this work.
+
+### User Guide
+
+The `app/src/main/assets/guide/en/settings.md` user guide must be updated to reflect all
+changes to sync and offline reading settings introduced by this spec. The update should
+cover: the offline reading toggle and what enabling/disabling it does, the three management
+policies and how to choose between them, the one-time date-range download action, the
+archive scope options, and the "Remove downloaded content" action in the bookmark detail
+menu. Changes to bookmark card icons (outline vs. filled) should be documented in
+`your-bookmarks.md`.
+
+---
+
 ## Settings Layout
 
 ```


### PR DESCRIPTION
## Summary

- Adds `docs/specs/unified-offline-content-spec.md`: architecture proposal for a simplified offline content model. Collapses the two-tier (text-only / full) managed offline design into a single full-package-only tier. Covers content state semantics, three management policies (storage limit, newest-N, rolling date-range window), bookmark card icon behaviour, annotation implications, Material You compliance requirement, user guide update requirement, settings layout, migration strategy, and future considerations (collections-based scope, on-demand cache eviction).
- Adds `docs/specs/unified-offline-content-impl-plan.md`: 13-slice implementation plan with model recommendations (Haiku / Sonnet / Opus) for each slice. Includes a full dead-code cleanup slice for the incomplete removal of per-bookmark content management actions from the branch.

## Key design decisions

- A bookmark either has a full offline content package (text + images) or nothing — no managed text-only tier.
- On-demand text caching (for reader open performance) is retained but is distinct from managed offline content, expressed via the existing `hasResources` field rather than a new DB enum value.
- Three management policies offered as a radio selector: storage limit, newest-N bookmarks, bookmarks added within a rolling time window. Policies B and C support an optional secondary storage cap.
- All per-bookmark content download/removal UI actions are removed. Content lifecycle is entirely system-managed.
- One-time manual date-range download retained as a settings action (not an ongoing policy).

## Test plan

- [ ] Review spec for alignment with the unified offline content paradigm
- [ ] Review implementation plan slice ordering and model recommendations
- [ ] Confirm slice 3 dead-code file list matches current branch state

https://claude.ai/code/session_017MmFgCXCCArrdtLs5B9pcU