### PR TITLE
Fix/reflow text disappearing

### DIFF
--- a/app/src/main/java/com/mydeck/app/ui/detail/components/BookmarkDetailWebViews.kt
+++ b/app/src/main/java/com/mydeck/app/ui/detail/components/BookmarkDetailWebViews.kt
@@ -249,6 +249,12 @@ fun BookmarkDetailArticle(
                             object : WebView.VisualStateCallback() {
                                 override fun onComplete(requestId: Long) {
                                     webView.requestLayout()
+                                    // Diagnostic: compare JS content height vs View height
+                                    webView.evaluateJavascript(
+                                        "(document.documentElement.scrollHeight)"
+                                    ) { jsHeight ->
+                                        Timber.d("ReflowDiag: JS scrollHeight=$jsHeight, view height=${webView.height}, view measuredHeight=${webView.measuredHeight}")
+                                    }
                                 }
                             }
                         )
@@ -382,7 +388,7 @@ fun BookmarkDetailArticle(
                         settings.mediaPlaybackRequiresUserGesture = true
                         settings.useWideViewPort = false
                         settings.loadWithOverviewMode = false
-                        setLayerType(View.LAYER_TYPE_HARDWARE, null)
+                        setLayerType(View.LAYER_TYPE_NONE, null)
                         settings.defaultTextEncodingName = "utf-8"
                         isVerticalScrollBarEnabled = false
                         isHorizontalScrollBarEnabled = false
@@ -859,7 +865,7 @@ fun BookmarkDetailOriginalWebView(
                         settings.mediaPlaybackRequiresUserGesture = false
                         settings.useWideViewPort = true
                         settings.loadWithOverviewMode = true
-                        setLayerType(View.LAYER_TYPE_HARDWARE, null)
+                        setLayerType(View.LAYER_TYPE_NONE, null)
                         settings.defaultTextEncodingName = "utf-8"
                         isVerticalScrollBarEnabled = false
                         isHorizontalScrollBarEnabled = false

--- a/app/src/main/java/com/mydeck/app/ui/detail/components/BookmarkDetailWebViews.kt
+++ b/app/src/main/java/com/mydeck/app/ui/detail/components/BookmarkDetailWebViews.kt
@@ -249,12 +249,6 @@ fun BookmarkDetailArticle(
                             object : WebView.VisualStateCallback() {
                                 override fun onComplete(requestId: Long) {
                                     webView.requestLayout()
-                                    // Diagnostic: compare JS content height vs View height
-                                    webView.evaluateJavascript(
-                                        "(document.documentElement.scrollHeight)"
-                                    ) { jsHeight ->
-                                        Timber.d("ReflowDiag: JS scrollHeight=$jsHeight, view height=${webView.height}, view measuredHeight=${webView.measuredHeight}")
-                                    }
                                 }
                             }
                         )

--- a/app/src/main/java/com/mydeck/app/ui/detail/components/BookmarkDetailWebViews.kt
+++ b/app/src/main/java/com/mydeck/app/ui/detail/components/BookmarkDetailWebViews.kt
@@ -189,7 +189,11 @@ fun BookmarkDetailArticle(
         uiState.bookmark.embed
     ) {
         content.value = uiState.bookmark.getContent(uiState.template, isSystemInDarkMode)
-        webViewRef.value?.settings?.textZoom = uiState.typographySettings.fontSizePercent
+        webViewRef.value?.let { webView ->
+            if (webView.settings.textZoom != uiState.typographySettings.fontSizePercent) {
+                webView.settings.textZoom = uiState.typographySettings.fontSizePercent
+            }
+        }
     }
 
     LaunchedEffect(content.value) {
@@ -228,12 +232,30 @@ fun BookmarkDetailArticle(
         webViewRef.value?.let { webView ->
             // Font size still uses textZoom so body text and in-article headings
             // scale together under the current simplified reader model.
-            webView.settings.textZoom = uiState.typographySettings.fontSizePercent
-            // Small delay to let any pending content load finish
-            delay(150)
+            // Guard to avoid spurious relayouts.
+            if (webView.settings.textZoom != uiState.typographySettings.fontSizePercent) {
+                webView.settings.textZoom = uiState.typographySettings.fontSizePercent
+            }
+            // Small delay to let textZoom take effect before applying CSS typography
+            delay(50)
             withContext(Dispatchers.Main) {
                 val js = WebViewTypographyBridge.applyTypography(uiState.typographySettings)
-                webView.evaluateJavascript(js, null)
+                webView.evaluateJavascript(js) {
+                    // Force Compose to re-measure after WebView reflows.
+                    // Use postVisualStateCallback for reliable timing (API 23+).
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                        webView.postVisualStateCallback(
+                            System.currentTimeMillis(),
+                            object : WebView.VisualStateCallback() {
+                                override fun onComplete(requestId: Long) {
+                                    webView.requestLayout()
+                                }
+                            }
+                        )
+                    } else {
+                        webView.postDelayed({ webView.requestLayout() }, 100)
+                    }
+                }
             }
         }
     }
@@ -607,7 +629,10 @@ fun BookmarkDetailArticle(
                 webViewRef.value = it
                 onWebViewChanged(it)
             }
-            it.settings.textZoom = uiState.typographySettings.fontSizePercent
+            // Guard textZoom to avoid spurious relayouts on every recomposition
+            if (it.settings.textZoom != uiState.typographySettings.fontSizePercent) {
+                it.settings.textZoom = uiState.typographySettings.fontSizePercent
+            }
             it.setBackgroundColor(android.graphics.Color.parseColor(readerThemePalette.bodyBackgroundColor))
         }
             )

--- a/app/src/main/java/com/mydeck/app/ui/list/BookmarkCard.kt
+++ b/app/src/main/java/com/mydeck/app/ui/list/BookmarkCard.kt
@@ -828,9 +828,11 @@ private fun BookmarkGridCardMobilePortrait(
                         )
                         bookmark.readingTime?.let {
                             Text(
-                                text = " · $it min",
+                                text = "$it min",
                                 style = MaterialTheme.typography.labelMedium,
-                                maxLines = 1
+                                maxLines = 1,
+                                softWrap = false,
+                                modifier = Modifier.padding(start = 4.dp)
                             )
                         }
                         BookmarkDownloadStatusIndicator(
@@ -1126,9 +1128,11 @@ private fun BookmarkGridCardNarrow(
                     )
                     bookmark.readingTime?.let {
                         Text(
-                            text = " · $it min",
+                            text = "$it min",
                             style = MaterialTheme.typography.labelMedium,
-                            maxLines = 1
+                            maxLines = 1,
+                            softWrap = false,
+                            modifier = Modifier.padding(start = 4.dp)
                         )
                     }
                     BookmarkDownloadStatusIndicator(
@@ -1425,9 +1429,11 @@ private fun BookmarkGridCardWide(
                     )
                     bookmark.readingTime?.let {
                         Text(
-                            text = " · $it min",
+                            text = "$it min",
                             style = MaterialTheme.typography.labelMedium,
-                            maxLines = 1
+                            maxLines = 1,
+                            softWrap = false,
+                            modifier = Modifier.padding(start = 4.dp)
                         )
                     }
                     BookmarkDownloadStatusIndicator(
@@ -1754,9 +1760,11 @@ private fun BookmarkCompactCardNarrow(
                 )
                 bookmark.readingTime?.let {
                     Text(
-                        text = " · $it min",
+                        text = "$it min",
                         style = MaterialTheme.typography.labelMedium,
-                        maxLines = 1
+                        maxLines = 1,
+                        softWrap = false,
+                        modifier = Modifier.padding(start = 4.dp)
                     )
                 }
                 BookmarkDownloadStatusIndicator(
@@ -2028,9 +2036,11 @@ private fun BookmarkCompactCardWide(
                 )
                 bookmark.readingTime?.let {
                     Text(
-                        text = " · $it min",
+                        text = "$it min",
                         style = MaterialTheme.typography.labelMedium,
-                        maxLines = 1
+                        maxLines = 1,
+                        softWrap = false,
+                        modifier = Modifier.padding(start = 4.dp)
                     )
                 }
                 BookmarkDownloadStatusIndicator(

--- a/docs/archive/reflow-text-disappearing-fix.md
+++ b/docs/archive/reflow-text-disappearing-fix.md
@@ -1,6 +1,6 @@
 # Fix: Text Disappearing in Reader View During Typography Changes
 
-**Status:** Fix applied, confirmation pending
+**Status:** Fixed (confirmed 2026-04-09)
 **Reported:** 2026-03-23
 **Affects:** v0.11.1 and current (`main`)
 **Branch:** `fix/reader-text-disappearing`
@@ -156,7 +156,7 @@ Over 130 logged typography changes across multiple articles:
 - View heights reached up to **797,829 device pixels** (277,506 CSS pixels) without truncation — far exceeding the ~8,192–16,384 CSS pixel GPU texture limit that would have applied under `LAYER_TYPE_HARDWARE`
 - Rapid typography toggling (10+ changes in 2 seconds) showed no stale measurements
 
-**Conclusion:** The GPU texture limit from `LAYER_TYPE_HARDWARE` was almost certainly the primary cause. Fixes #1 and #2 are good defensive improvements but were not sufficient on their own. Developer testing shows the issue is resolved; confirmation from the original reporter is pending.
+**Conclusion:** The GPU texture limit from `LAYER_TYPE_HARDWARE` was almost certainly the primary cause. Fixes #1 and #2 are good defensive improvements but were not sufficient on their own. Developer testing shows the issue is resolved; confirmed fixed by original reporter on 2026-04-09.
 
 ## Testing Plan
 

--- a/docs/archive/reflow-text-disappearing-fix.md
+++ b/docs/archive/reflow-text-disappearing-fix.md
@@ -165,3 +165,27 @@ Over 130 logged typography changes across multiple articles:
 - Rapidly toggle settings to stress the race condition
 - Test on both phone and emulator (different screen densities)
 - Verify no regression in scroll-position restoration or search highlighting
+
+## Removed Diagnostic Code
+
+**Removed:** Diagnostic logging that called `evaluateJavascript("(document.documentElement.scrollHeight)")` on every typography change in `BookmarkDetailWebViews.kt` (~lines 252–258).
+
+**Purpose:** This code was added during debugging to validate that the fixes were working correctly by comparing JS-measured height (`document.documentElement.scrollHeight`) against Android View height (`view.height` / `view.measuredHeight`). It logged results via Timber as "ReflowDiag" entries.
+
+**Why removed:** 
+- The diagnostic work is complete — 130+ logged typography changes showed zero measurement desyncs and confirmed the fix works
+- Each `evaluateJavascript()` call adds an extra JS round-trip and UI thread callback
+- On long articles or rapid typography toggling, this creates unnecessary overhead and potential jank
+- Not needed in production; removal keeps code clean and performance optimal
+
+**Code removed:**
+```kotlin
+// Diagnostic: compare JS content height vs View height
+webView.evaluateJavascript(
+    "(document.documentElement.scrollHeight)"
+) { jsHeight ->
+    Timber.d("ReflowDiag: JS scrollHeight=$jsHeight, view height=${webView.height}, view measuredHeight=${webView.measuredHeight}")
+}
+```
+
+**The three core fixes remain intact** (guards on `textZoom`, `postVisualStateCallback`, `LAYER_TYPE_NONE`).

--- a/docs/specs/reflow-text-disappearing-fix.md
+++ b/docs/specs/reflow-text-disappearing-fix.md
@@ -1,6 +1,6 @@
 # Fix: Text Disappearing in Reader View During Typography Changes
 
-**Status:** Implementation in progress
+**Status:** Fix applied, confirmation pending
 **Reported:** 2026-03-23
 **Affects:** v0.11.1 and current (`main`)
 **Branch:** `fix/reader-text-disappearing`
@@ -131,17 +131,32 @@ LaunchedEffect(uiState.typographySettings) {
 }
 ```
 
-### 3. Evaluate `LAYER_TYPE_SOFTWARE` fallback (deferred)
+### 3. Remove forced hardware layer type (critical fix)
 
-**Status:** Deferred — only implement if fixes #1 and #2 prove insufficient.
+The WebView is inside a Compose `verticalScroll` Column, so it renders its entire content height at once. `LAYER_TYPE_HARDWARE` forces the entire View into a single GPU texture. Most mobile GPUs have a maximum texture dimension of 8,192–16,384 CSS pixels. When a long article with large font and wide width exceeds that limit, rendering stops abruptly mid-content — producing exactly the "text cut off with blank space below" symptom.
+
+**Fix:** Change `setLayerType(View.LAYER_TYPE_HARDWARE, null)` to `setLayerType(View.LAYER_TYPE_NONE, null)` in both WebView factory blocks (article and embed). `LAYER_TYPE_NONE` uses standard hardware-accelerated display list rendering with automatic tiling — no single-texture ceiling.
+
+Do **not** use `LAYER_TYPE_SOFTWARE` — that would allocate a massive bitmap in RAM and likely OOM on long articles.
 
 ## Implementation Status
 
 | Fix | Status | Location | Notes |
 |-----|--------|----------|-------|
-| 1. Guard `textZoom` | ✅ Implemented | `BookmarkDetailWebViews.kt` ~line 610 | Prevents spurious relayouts on every recomposition |
-| 2. `postVisualStateCallback` | ✅ Implemented | `BookmarkDetailWebViews.kt` ~lines 227-239 | Uses proven pattern from content-ready detection |
-| 3. Software layer fallback | ⏸️ Deferred | - | Only if fixes 1+2 insufficient |
+| 1. Guard `textZoom` | ✅ Implemented | `BookmarkDetailWebViews.kt` ~line 633 | Prevents spurious relayouts on every recomposition |
+| 2. `postVisualStateCallback` | ✅ Implemented | `BookmarkDetailWebViews.kt` ~lines 243-258 | Uses proven pattern from content-ready detection |
+| 3. `LAYER_TYPE_NONE` | ✅ Implemented | `BookmarkDetailWebViews.kt` lines 391, 868 | Most likely primary fix — eliminates GPU texture size limit |
+
+## Diagnostic Results (2026-04-08)
+
+After applying all three fixes, diagnostic logging was added to compare JS `document.documentElement.scrollHeight` against the Android View's `height` and `measuredHeight` after each typography change.
+
+Over 130 logged typography changes across multiple articles:
+- **Zero measurement desyncs** — JS height and View height maintained a consistent ratio (~2.875x, matching device density) in every single entry
+- View heights reached up to **797,829 device pixels** (277,506 CSS pixels) without truncation — far exceeding the ~8,192–16,384 CSS pixel GPU texture limit that would have applied under `LAYER_TYPE_HARDWARE`
+- Rapid typography toggling (10+ changes in 2 seconds) showed no stale measurements
+
+**Conclusion:** The GPU texture limit from `LAYER_TYPE_HARDWARE` was almost certainly the primary cause. Fixes #1 and #2 are good defensive improvements but were not sufficient on their own. Developer testing shows the issue is resolved; confirmation from the original reporter is pending.
 
 ## Testing Plan
 

--- a/docs/specs/reflow-text-disappearing-fix.md
+++ b/docs/specs/reflow-text-disappearing-fix.md
@@ -1,8 +1,9 @@
 # Fix: Text Disappearing in Reader View During Typography Changes
 
-**Status:** Diagnosed, not yet implemented
+**Status:** Implementation in progress
 **Reported:** 2026-03-23
-**Affects:** v0.11.1 and current (`feature/sync-multipart-v012`)
+**Affects:** v0.11.1 and current (`main`)
+**Branch:** `fix/reader-text-disappearing`
 
 ## Problem
 
@@ -52,13 +53,13 @@ Key files:
 
 The WebView's measured content height gets calculated too short and then "sticks" — the article renders but is clipped partway through. Contributing factors:
 
-1. **`textZoom` in the `update` block** (line ~593) fires on every Compose recomposition, not just on actual changes. Each assignment triggers an internal WebView relayout.
+1. **`textZoom` in the `update` block** (line ~610) fires on every Compose recomposition, not just on actual changes. Each assignment triggers an internal WebView relayout.
 
-2. **Typography JS runs after a 150ms delay** (LaunchedEffect at line ~215). This creates a window where `textZoom` has changed but CSS properties (line-height, hyphens, font-family) haven't caught up — the WebView is in an inconsistent layout state.
+2. **Typography JS runs after a 150ms delay** (LaunchedEffect at lines ~227-239). This creates a window where `textZoom` has changed but CSS properties (line-height, hyphens, font-family) haven't caught up — the WebView is in an inconsistent layout state.
 
-3. **No `requestLayout()` after JS typography changes.** After `evaluateJavascript` modifies `body.style.*`, the WebView reflows internally but doesn't tell Compose it needs re-measurement.
+3. **No `requestLayout()` after JS typography changes.** After `evaluateJavascript` modifies `body.style.*`, the WebView reflows internally but doesn't tell Compose it needs re-measurement. The `postVisualStateCallback` pattern is already used successfully elsewhere in the file (lines ~491-502 for content ready detection).
 
-4. **`LAYER_TYPE_HARDWARE`** (line ~351) can cause the WebView to skip repainting after content reflow, a known Android WebView issue especially pre-API 30.
+4. **`LAYER_TYPE_HARDWARE`** (line ~363) can cause the WebView to skip repainting after content reflow, a known Android WebView issue especially pre-API 30.
 
 5. **Bundled font loading** (`@font-face` from `file:///android_asset/`) is asynchronous. With `font-display: swap`, the WebView may measure with a fallback font, then reflow when the real font loads — another window for height miscalculation.
 
@@ -95,48 +96,52 @@ update = {
 }
 ```
 
-### 2. Force re-layout after typography JS (primary fix)
+### 2. Force re-layout after typography JS using `postVisualStateCallback` (primary fix)
 
-After `evaluateJavascript` in the typography LaunchedEffect, force the WebView to re-measure:
+After `evaluateJavascript` in the typography LaunchedEffect, use the WebView's own signal that it has finished painting to trigger re-measurement. This is the same pattern already used successfully in `reportReadyIfNeeded()` (lines ~491-502).
 
 ```kotlin
 LaunchedEffect(uiState.typographySettings) {
     webViewRef.value?.let { webView ->
-        webView.settings.textZoom = uiState.typographySettings.fontSizePercent
-        delay(50)  // reduced from 150ms
+        // Guard textZoom to avoid spurious relayouts
+        if (webView.settings.textZoom != uiState.typographySettings.fontSizePercent) {
+            webView.settings.textZoom = uiState.typographySettings.fontSizePercent
+        }
+        // Reduced delay from 150ms - just enough for textZoom to take effect
+        delay(50)
         withContext(Dispatchers.Main) {
             val js = WebViewTypographyBridge.applyTypography(uiState.typographySettings)
             webView.evaluateJavascript(js) {
-                // Force Compose to re-measure after WebView reflows
-                webView.requestLayout()
+                // Use postVisualStateCallback for reliable timing (API 23+)
+                // Fallback to postDelayed for older devices
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                    val requestId = System.currentTimeMillis()
+                    webView.postVisualStateCallback(requestId,
+                        object : WebView.VisualStateCallback() {
+                            override fun onComplete(requestId: Long) {
+                                webView.requestLayout()
+                            }
+                        })
+                } else {
+                    webView.postDelayed({ webView.requestLayout() }, 100)
+                }
             }
         }
     }
 }
 ```
 
-### 3. Consider `postVisualStateCallback` for reliable timing
+### 3. Evaluate `LAYER_TYPE_SOFTWARE` fallback (deferred)
 
-Instead of arbitrary delays, use the WebView's own signal that it has finished painting:
+**Status:** Deferred — only implement if fixes #1 and #2 prove insufficient.
 
-```kotlin
-webView.evaluateJavascript(js) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-        webView.postVisualStateCallback(System.currentTimeMillis(),
-            object : WebView.VisualStateCallback() {
-                override fun onComplete(requestId: Long) {
-                    webView.requestLayout()
-                }
-            })
-    } else {
-        webView.postDelayed({ webView.requestLayout() }, 100)
-    }
-}
-```
+## Implementation Status
 
-### 4. Evaluate `LAYER_TYPE_SOFTWARE` fallback (if above insufficient)
-
-If hardware layer continues to cause stale rendering, consider software rendering as a targeted fallback during typography transitions.
+| Fix | Status | Location | Notes |
+|-----|--------|----------|-------|
+| 1. Guard `textZoom` | ✅ Implemented | `BookmarkDetailWebViews.kt` ~line 610 | Prevents spurious relayouts on every recomposition |
+| 2. `postVisualStateCallback` | ✅ Implemented | `BookmarkDetailWebViews.kt` ~lines 227-239 | Uses proven pattern from content-ready detection |
+| 3. Software layer fallback | ⏸️ Deferred | - | Only if fixes 1+2 insufficient |
 
 ## Testing Plan
 


### PR DESCRIPTION
## Summary

- **Fix text disappearing/truncation in reader view** when using certain typography combinations (wide width, large font, hyphenation). The root cause was `setLayerType(View.LAYER_TYPE_HARDWARE)` forcing the entire unbounded-height WebView into a single GPU texture — long articles exceeded the GPU max texture size (~8192–16384 CSS px) and rendering silently clipped mid-content.
- Changed both WebView factories (article and embed) to `LAYER_TYPE_NONE`, which uses standard hardware-accelerated display list rendering with automatic tiling and no single-texture ceiling.
- Added defensive improvements: guarded `textZoom` assignment to prevent spurious relayouts on recomposition, and added `postVisualStateCallback` + `requestLayout()` after typography JS to ensure Compose re-measures after WebView reflows.

## Test plan

- [x] Reproduced with the original debug article (New Lines Magazine ~3100 words) using wide width + Literata + 105% font + hyphenation on
- [x] Diagnostic logging confirmed zero measurement desyncs across 130+ typography changes, with view heights up to 797K device px
- [x] Rapid typography toggling (10+ changes in 2 seconds) showed no stale measurements
- [x] Confirmed fixed by original bug reporter
- [ ] Verify no regression in scroll-position restoration (regression exists, predated this branch)
- [x] Verify no regression in article search highlighting
- [x] Test on tablet / different screen densities

🤖 Generated with [Claude Code](https://claude.com/claude-code)
