### PR TITLE
Feature/intra page link nav

### DIFF
--- a/app/src/main/assets/html_template_black.html
+++ b/app/src/main/assets/html_template_black.html
@@ -113,6 +113,9 @@
         a:visited {
           color: var(--link-visited-color);
         }
+        a[href^="#"] {
+          text-decoration-style: dashed;
+        }
         a:hover {
           color: var(--link-hover-color);
           text-decoration-color: var(--link-hover-color);

--- a/app/src/main/assets/html_template_dark.html
+++ b/app/src/main/assets/html_template_dark.html
@@ -113,6 +113,9 @@
         a:visited {
           color: var(--link-visited-color);
         }
+        a[href^="#"] {
+          text-decoration-style: dashed;
+        }
         a:hover {
           color: var(--link-hover-color);
           text-decoration-color: var(--link-hover-color);

--- a/app/src/main/assets/html_template_light.html
+++ b/app/src/main/assets/html_template_light.html
@@ -113,6 +113,9 @@
         a:visited {
           color: var(--link-visited-color);
         }
+        a[href^="#"] {
+          text-decoration-style: dashed;
+        }
         a:hover {
           color: var(--link-hover-color);
           text-decoration-color: var(--link-hover-color);

--- a/app/src/main/assets/html_template_sepia.html
+++ b/app/src/main/assets/html_template_sepia.html
@@ -113,6 +113,9 @@
         a:visited {
           color: var(--link-visited-color);
         }
+        a[href^="#"] {
+          text-decoration-style: dashed;
+        }
         a:hover {
           color: var(--link-hover-color);
           text-decoration-color: var(--link-hover-color);

--- a/app/src/main/java/com/mydeck/app/MainViewModel.kt
+++ b/app/src/main/java/com/mydeck/app/MainViewModel.kt
@@ -9,6 +9,7 @@ import com.mydeck.app.domain.model.Theme
 import com.mydeck.app.io.prefs.SettingsDataStore
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import javax.inject.Inject
@@ -17,8 +18,11 @@ import javax.inject.Inject
 class MainViewModel @Inject constructor(
     val settingsDataStore: SettingsDataStore
 ): ViewModel() {
-    val isReady: StateFlow<Boolean> = settingsDataStore.themeFlow
-        .map { true }
+    val isReady: StateFlow<Boolean> = combine(
+        settingsDataStore.themeFlow,
+        settingsDataStore.lightAppearanceFlow,
+        settingsDataStore.darkAppearanceFlow,
+    ) { _, _, _ -> true }
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.Eagerly,
@@ -31,19 +35,19 @@ class MainViewModel @Inject constructor(
         } ?: Theme.SYSTEM
     }.stateIn(
         scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(5000),
+        started = SharingStarted.Eagerly,
         initialValue = Theme.SYSTEM
     )
 
     val lightAppearance = settingsDataStore.lightAppearanceFlow.stateIn(
         scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(5000),
+        started = SharingStarted.Eagerly,
         initialValue = LightAppearance.PAPER
     )
 
     val darkAppearance = settingsDataStore.darkAppearanceFlow.stateIn(
         scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(5000),
+        started = SharingStarted.Eagerly,
         initialValue = DarkAppearance.DARK
     )
 }

--- a/app/src/main/java/com/mydeck/app/ui/detail/BookmarkDetailScreen.kt
+++ b/app/src/main/java/com/mydeck/app/ui/detail/BookmarkDetailScreen.kt
@@ -1213,6 +1213,7 @@ fun BookmarkDetailContent(
     onClickToggleArchive: (String, Boolean) -> Unit = { _, _ -> },
     scrollState: ScrollState = rememberScrollState()
 ) {
+    val coroutineScope = rememberCoroutineScope()
     val hasArticleContent = uiState.bookmark.articleContent != null
     val isArticle = uiState.bookmark.type == BookmarkDetailViewModel.Bookmark.Type.ARTICLE
     val needsRestore = isArticle && hasArticleContent && initialReadProgress > 0 && initialReadProgress <= 100
@@ -1428,6 +1429,12 @@ fun BookmarkDetailContent(
                             onLinkLongPress = onLinkLongPress,
                             onTextSelectionCaptured = onTextSelectionCaptured,
                             onAnnotationClicked = onAnnotationClicked,
+                            onFragmentScroll = { absoluteY ->
+                                coroutineScope.launch {
+                                    val targetScroll = (absoluteY + articleTopOffsetPx).toInt().coerceIn(0, scrollState.maxValue)
+                                    scrollState.animateScrollTo(targetScroll)
+                                }
+                            },
                             onVideoEnterFullscreen = onVideoEnterFullscreen,
                             onVideoExitFullscreen = onVideoExitFullscreen,
                         )

--- a/app/src/main/java/com/mydeck/app/ui/detail/WebViewTocBridge.kt
+++ b/app/src/main/java/com/mydeck/app/ui/detail/WebViewTocBridge.kt
@@ -1,0 +1,115 @@
+package com.mydeck.app.ui.detail
+
+import android.os.Handler
+import android.os.Looper
+import android.webkit.JavascriptInterface
+import timber.log.Timber
+
+/**
+ * JavaScript-to-native bridge for fragment link (TOC) navigation in the reader WebView.
+ *
+ * Registered on the WebView as "MyDeckTocBridge".
+ * Called from injected JavaScript when the user taps an in-page anchor link.
+ */
+class WebViewTocBridge(
+    private val onFragmentScroll: (absoluteY: Int) -> Unit,
+) {
+    @JavascriptInterface
+    fun onFragmentLinkTapped(absoluteY: Int) {
+        // @JavascriptInterface methods run on a background thread.
+        Handler(Looper.getMainLooper()).post {
+            Timber.d("[TocNav] Fragment link tapped, absoluteY=%d", absoluteY)
+            onFragmentScroll(absoluteY)
+        }
+    }
+
+    companion object {
+        const val BRIDGE_NAME = "MyDeckTocBridge"
+
+        /**
+         * Returns JavaScript to inject after page load.
+         *
+         * Attaches click interceptors to all <a href="#..."> elements in the
+         * document. On click, prevents the WebView's own fragment-scroll attempt
+         * (which is a no-op because Compose owns the scroll), resolves the target
+         * element's absolute Y position, and reports it to Kotlin via the bridge.
+         *
+         * Uses an attribute selector `[id="targetId"]` rather than querySelector
+         * with a CSS ID selector (`#uY.XlwQ.foo`) because dots in the Readeck-
+         * prefixed IDs would be misinterpreted as class selectors.
+         */
+        fun injectFragmentLinkInterceptor(): String {
+            return """
+                (function() {
+                    'use strict';
+                    if (window.mydeckTocInstalled) return;
+                    window.mydeckTocInstalled = true;
+
+                    var tocBridge = window['${BRIDGE_NAME}'];
+                    console.log('[TocNav] Injecting fragment link interceptor, bridge=' + (tocBridge ? 'found' : 'MISSING'));
+                    if (!tocBridge) return;
+
+                    var container = document.querySelector('.container') || document.body;
+                    container.addEventListener('click', function(e) {
+                        var target = e.target;
+                        // Walk up from the tapped element to find an anchor link with a fragment href.
+                        while (target && target !== container) {
+                            if (target.tagName && target.tagName.toLowerCase() === 'a') {
+                                var href = target.getAttribute('href');
+                                if (href && href.charAt(0) === '#' && href.length > 1) {
+                                    break;
+                                }
+                                return; // anchor without fragment href — let it propagate normally
+                            }
+                            target = target.parentElement;
+                        }
+                        if (!target || target === container) return;
+
+                        var href = target.getAttribute('href');
+                        console.log('[TocNav] Fragment link clicked href=' + href);
+                        var targetId = href.slice(1);
+                        // Try exact id match first.
+                        var el = document.querySelector('[id="' + targetId + '"]');
+                        if (!el) {
+                            // Readeck strips id attributes from headings but keeps fragment hrefs
+                            // in the TOC. Fall back to matching headings by normalized text.
+                            // The fragment suffix (after stripping the per-article prefix like
+                            // "eK.sfkN.") encodes the heading text with underscores for spaces
+                            // and other chars removed, e.g. "CutTrim_With_Re-encoding" matches
+                            // the heading "Cut/Trim With Re-encoding".
+                            var dotIdx = targetId.indexOf('.');
+                            var secondDotIdx = dotIdx >= 0 ? targetId.indexOf('.', dotIdx + 1) : -1;
+                            var semantic = secondDotIdx >= 0 ? targetId.slice(secondDotIdx + 1) : targetId;
+                            var normalizedTarget = semantic.replace(/_/g, ' ').toLowerCase().replace(/[^a-z0-9 ]/g, '').replace(/\s+/g, ' ').trim();
+                            var headings = document.querySelectorAll('h1,h2,h3,h4,h5,h6');
+                            for (var hi = 0; hi < headings.length; hi++) {
+                                var hText = (headings[hi].textContent || '').toLowerCase().replace(/[^a-z0-9 ]/g, '').replace(/\s+/g, ' ').trim();
+                                if (hText === normalizedTarget) {
+                                    el = headings[hi];
+                                    console.log('[TocNav] Matched heading by text for id=' + targetId);
+                                    break;
+                                }
+                            }
+                        }
+                        if (!el) {
+                            console.log('[TocNav] Target element not found for id=' + targetId);
+                            return;
+                        }
+                        e.preventDefault();
+                        e.stopPropagation();
+                        var rect = el.getBoundingClientRect();
+                        // window.scrollY is always 0 because Compose owns the scroll.
+                        // Multiply by devicePixelRatio to convert CSS pixels to physical
+                        // pixels, which is what scrollState.animateScrollTo expects.
+                        var absoluteY = Math.round((rect.top + window.scrollY) * window.devicePixelRatio);
+                        console.log('[TocNav] Scrolling to absoluteY=' + absoluteY);
+                        tocBridge.onFragmentLinkTapped(absoluteY);
+                    }, false);
+
+                    var links = document.querySelectorAll('a[href^="#"]');
+                    console.log('[TocNav] Found ' + links.length + ' fragment links');
+                })();
+            """.trimIndent()
+        }
+    }
+}

--- a/app/src/main/java/com/mydeck/app/ui/detail/components/BookmarkDetailWebViews.kt
+++ b/app/src/main/java/com/mydeck/app/ui/detail/components/BookmarkDetailWebViews.kt
@@ -21,6 +21,7 @@ import com.mydeck.app.domain.model.SelectionData
 import com.mydeck.app.ui.detail.WebViewAnnotationBridge
 import com.mydeck.app.ui.detail.WebViewImageBridge
 import com.mydeck.app.ui.detail.WebViewAnnotationTapBridge
+import com.mydeck.app.ui.detail.WebViewTocBridge
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -106,6 +107,7 @@ fun BookmarkDetailArticle(
     onLinkLongPress: (linkUrl: String, linkText: String) -> Unit = { _, _ -> },
     onTextSelectionCaptured: (SelectionData) -> Unit = {},
     onAnnotationClicked: (String) -> Unit = {},
+    onFragmentScroll: (absoluteY: Int) -> Unit = {},
     onVideoEnterFullscreen: (View, android.webkit.WebChromeClient.CustomViewCallback?) -> Unit = { _, _ -> },
     onVideoExitFullscreen: (VideoFullscreenDismissSource) -> Unit = {},
 ) {
@@ -140,6 +142,7 @@ fun BookmarkDetailArticle(
     val json = remember { Json { ignoreUnknownKeys = true } }
     val latestSelectionHandler = rememberUpdatedState(onTextSelectionCaptured)
     val latestAnnotationClickHandler = rememberUpdatedState(onAnnotationClicked)
+    val latestFragmentScrollHandler = rememberUpdatedState(onFragmentScroll)
     val latestTypographySettings = rememberUpdatedState(uiState.typographySettings)
     val latestThemePalette = rememberUpdatedState(readerThemePalette)
     val latestThemeScript = rememberUpdatedState(WebViewThemeBridge.applyTheme(readerThemePalette))
@@ -404,6 +407,14 @@ fun BookmarkDetailArticle(
                             ),
                             WebViewAnnotationTapBridge.BRIDGE_NAME
                         )
+                        addJavascriptInterface(
+                            WebViewTocBridge(
+                                onFragmentScroll = { absoluteY ->
+                                    latestFragmentScrollHandler.value(absoluteY)
+                                }
+                            ),
+                            WebViewTocBridge.BRIDGE_NAME
+                        )
                         webChromeClient = object : android.webkit.WebChromeClient() {
                             override fun onShowCustomView(
                                 view: View?,
@@ -428,7 +439,7 @@ fun BookmarkDetailArticle(
 
                             override fun onConsoleMessage(consoleMessage: ConsoleMessage): Boolean {
                                 val message = consoleMessage.message()
-                                if (message.contains("[AnnotationTap]")) {
+                                if (message.contains("[AnnotationTap]") || message.contains("[TocNav]")) {
                                     Timber.d(
                                         "%s line=%d source=%s",
                                         message,
@@ -499,6 +510,8 @@ fun BookmarkDetailArticle(
                                 webView.evaluateJavascript(imageJs, null)
                                 val annotationJs = WebViewAnnotationBridge.injectAnnotationInteractions()
                                 webView.evaluateJavascript(annotationJs, null)
+                                val tocJs = WebViewTocBridge.injectFragmentLinkInterceptor()
+                                webView.evaluateJavascript(tocJs, null)
                             }
 
                             private fun reportReadyIfNeeded(webView: WebView?) {

--- a/docs/specs/original-webview-no-theme.md
+++ b/docs/specs/original-webview-no-theme.md
@@ -1,0 +1,38 @@
+# Original Web View — No App Theme Applied (Known Limitation)
+
+**Status:** Documented, not fixed (2026-04-10)
+
+---
+
+## 1. Behaviour
+
+When a bookmark is opened in "View Original" mode (`BookmarkDetailOriginalWebView`), the web page does not follow the app's chosen theme (Sepia, Dark, Black, Paper). It also does not reliably follow the system light/dark setting.
+
+---
+
+## 2. Why
+
+"View Original" loads the bookmark's source URL directly in a plain WebView — it is a lightweight in-app browser, not a Readeck-extracted reader. The page appearance is entirely controlled by the remote site's CSS. The app has no opportunity to inject its own styles.
+
+There is a partial mitigation available: `WebSettingsCompat.setForceDark()` (deprecated in API 33, superseded by the `prefers-color-scheme` media query approach) can instruct the WebView to apply an automatic algorithmic dark mode inversion when the system is in dark mode. However:
+
+- It does not apply app-specific themes (Sepia is a warm light theme with no equivalent web API).
+- The algorithmic inversion produces poor results on many sites (inverted images, broken colour contrast).
+- Sites that already implement `prefers-color-scheme` handle dark mode themselves; forcing it double-inverts them.
+- The API is deprecated and its replacement (`WebSettings.setAlgorithmicDarkeningAllowed`) behaves differently across API levels.
+
+---
+
+## 3. Decision
+
+Leave "View Original" as a raw browser experience. The user has explicitly chosen to leave the reader and view the original page; it is reasonable for that page to look like itself.
+
+**If revisited:** The least-risky improvement would be to enable `setAlgorithmicDarkeningAllowed(true)` when the system is in dark mode, accepting that some sites will look worse but most will look better. This would apply only to system dark mode — not to app-level Sepia/Dark/Black — and should be treated as a separate feature decision.
+
+---
+
+## 4. Files Relevant
+
+| File | Notes |
+|------|-------|
+| `ui/detail/components/BookmarkDetailWebViews.kt` | `BookmarkDetailOriginalWebView` composable — the plain WebView for original mode. |

--- a/docs/specs/startup-theme-flash-fix.md
+++ b/docs/specs/startup-theme-flash-fix.md
@@ -1,0 +1,70 @@
+# Startup Theme Flash Fix — Technical Specification
+
+**Status:** Implemented (2026-04-10)
+**Affects:** All non-Paper/non-System-light startup scenarios (Sepia, Dark, Black)
+
+---
+
+## 1. Problem
+
+When the app starts with the theme set to Sepia, Dark, or Black, the top app bar flashes the wrong colour for one frame immediately after the splash screen exits. The wrong colour matches the system light/dark setting (white in light mode, dark-grey in dark mode) rather than the user's chosen app theme.
+
+The bug does **not** reproduce when the theme is Paper with System or Light mode, because the Paper colour scheme (`#F9F9F9`) is close enough to white that no flash is visible.
+
+---
+
+## 2. Root Cause
+
+`MainViewModel.isReady` gates the splash screen on only `themeFlow`:
+
+```kotlin
+val isReady: StateFlow<Boolean> = settingsDataStore.themeFlow
+    .map { true }
+    .stateIn(started = SharingStarted.Eagerly, initialValue = false)
+```
+
+The `theme`, `lightAppearance`, and `darkAppearance` StateFlows all use `SharingStarted.WhileSubscribed(5000)` and carry default initial values (`Theme.SYSTEM`, `LightAppearance.PAPER`, `DarkAppearance.DARK`). They only begin collecting from DataStore once `collectAsState()` subscribes to them inside `setContent`.
+
+The result: `isReady` becomes true as soon as `themeFlow` emits (very fast). The splash screen exits. `setContent` runs and subscribes to all three flows — but those flows haven't loaded their DataStore values yet, so they return their defaults. Compose renders the first frame using `Theme.SYSTEM + PAPER + DARK`, which resolves to the wrong appearance for users who have configured Sepia or Black. The correct appearance loads on the next DataStore emission (milliseconds later), but the damage is visible as a one-frame flash.
+
+---
+
+## 3. Fix
+
+Two changes to `MainViewModel`:
+
+1. **Change `isReady` to wait for all three flows** — splash screen is held until `themeFlow`, `lightAppearanceFlow`, and `darkAppearanceFlow` have all emitted at least once.
+
+2. **Change `theme`, `lightAppearance`, `darkAppearance` to `SharingStarted.Eagerly`** — they begin collecting from DataStore immediately (before `setContent` subscribes), so their values are already loaded when `isReady` becomes true. When Compose renders its first frame, `collectAsState()` picks up the already-loaded values rather than the defaults.
+
+```kotlin
+val isReady: StateFlow<Boolean> = combine(
+    settingsDataStore.themeFlow,
+    settingsDataStore.lightAppearanceFlow,
+    settingsDataStore.darkAppearanceFlow,
+) { _, _, _ -> true }
+    .stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.Eagerly,
+        initialValue = false
+    )
+
+val theme = settingsDataStore.themeFlow.map { ... }
+    .stateIn(started = SharingStarted.Eagerly, initialValue = Theme.SYSTEM)
+
+val lightAppearance = settingsDataStore.lightAppearanceFlow
+    .stateIn(started = SharingStarted.Eagerly, initialValue = LightAppearance.PAPER)
+
+val darkAppearance = settingsDataStore.darkAppearanceFlow
+    .stateIn(started = SharingStarted.Eagerly, initialValue = DarkAppearance.DARK)
+```
+
+The additional DataStore reads are negligible — all three keys are in the same Preferences DataStore file, which is read once on first access and cached in memory thereafter. The splash screen duration is not perceptibly affected.
+
+---
+
+## 4. Files Affected
+
+| File | Change |
+|------|--------|
+| `MainViewModel.kt` | `isReady` waits for all three flows; `theme`/`lightAppearance`/`darkAppearance` use `Eagerly`. |

--- a/docs/specs/toc-fragment-link-navigation-spec.md
+++ b/docs/specs/toc-fragment-link-navigation-spec.md
@@ -1,6 +1,6 @@
 # In-Article Fragment Link Navigation — Technical Specification
 
-**Status:** Ready for implementation
+**Status:** Implemented (2026-04-10)
 **Date:** 2026-04-04
 **Supersedes:** `_notes/toc-fragment-link-navigation-spec.md`
 
@@ -8,7 +8,7 @@
 
 ## 1. Purpose
 
-Enable same-page anchor links (e.g. table-of-contents links) to work in the reader WebView. Currently, tapping a TOC link does nothing. This spec describes why that happens and exactly how to fix it, with full code-level detail.
+Enable same-page anchor links (e.g. table-of-contents links) to work in the reader WebView. Tapping a TOC link now scrolls the article to the target heading. Intrapage links are visually distinguished from external links via a dashed underline.
 
 ---
 
@@ -18,12 +18,6 @@ Article HTML returned by the Readeck API can include a table of contents generat
 
 ```html
 <a href="#uY.XlwQ.Seek_Using_-ss_Parameter">Seek Using -ss Parameter</a>
-```
-
-The target heading carries a matching `id` attribute:
-
-```html
-<h2 id="uY.XlwQ.Seek_Using_-ss_Parameter">Seek Using -ss Parameter</h2>
 ```
 
 Readeck's sanitiser prefixes IDs and fragment hrefs with a per-article token (e.g. `uY.XlwQ.`) to prevent ID collisions when multiple articles are rendered in the same page. The prefix does not affect correctness on Android because each article is loaded in its own WebView.
@@ -50,150 +44,92 @@ No Compose layout changes are required. The `scrollState` is already a parameter
 
 ### 4.2 New file: `WebViewTocBridge.kt`
 
-Create `app/src/main/java/com/mydeck/app/ui/detail/WebViewTocBridge.kt`. Following the pattern of `WebViewAnnotationTapBridge`, the bridge class owns the `@JavascriptInterface` method and the companion object holds the injected JS and bridge name constant.
+`app/src/main/java/com/mydeck/app/ui/detail/WebViewTocBridge.kt`
 
-```kotlin
-package com.mydeck.app.ui.detail
+The bridge class owns the `@JavascriptInterface` method. The companion object holds the injected JS and bridge name constant. The JS uses a delegated click listener on `.container` (the same pattern as `WebViewAnnotationBridge`) rather than attaching listeners to individual `<a>` elements — this avoids losing listeners when the DOM is updated by annotation refresh.
 
-import android.os.Handler
-import android.os.Looper
-import android.webkit.JavascriptInterface
-import timber.log.Timber
+Key implementation details that differ from the original spec:
 
-/**
- * JavaScript-to-native bridge for fragment link (TOC) navigation in the reader WebView.
- *
- * Registered on the WebView as "MyDeckTocBridge".
- * Called from injected JavaScript when the user taps an in-page anchor link.
- */
-class WebViewTocBridge(
-    private val onFragmentScroll: (absoluteY: Int) -> Unit,
-) {
-    @JavascriptInterface
-    fun onFragmentLinkTapped(absoluteY: Int) {
-        // @JavascriptInterface methods run on a background thread.
-        Handler(Looper.getMainLooper()).post {
-            Timber.d("[TocNav] Fragment link tapped, absoluteY=%d", absoluteY)
-            onFragmentScroll(absoluteY)
-        }
-    }
+1. **Delegated listener on `.container`**, not per-element listeners. Matches the annotation bridge pattern and survives DOM mutations.
 
-    companion object {
-        const val BRIDGE_NAME = "MyDeckTocBridge"
+2. **`window.mydeckTocInstalled` guard** prevents duplicate listener registration when `applyReaderEnhancements` fires twice (once from `onPageCommitVisible`, once from `onPageFinished`).
 
-        /**
-         * Returns JavaScript to inject after page load.
-         *
-         * Attaches click interceptors to all <a href="#..."> elements in the
-         * document. On click, prevents the WebView's own fragment-scroll attempt
-         * (which is a no-op because Compose owns the scroll), resolves the target
-         * element's absolute Y position, and reports it to Kotlin via the bridge.
-         *
-         * Uses an attribute selector `[id="targetId"]` rather than querySelector
-         * with a CSS ID selector (`#uY.XlwQ.foo`) because dots in the Readeck-
-         * prefixed IDs would be misinterpreted as class selectors.
-         */
-        fun injectFragmentLinkInterceptor(): String {
-            return """
-                (function() {
-                    'use strict';
-                    var links = document.querySelectorAll('a[href^="#"]');
-                    links.forEach(function(a) {
-                        a.addEventListener('click', function(e) {
-                            e.preventDefault();
-                            e.stopPropagation();
-                            var href = a.getAttribute('href');
-                            if (!href || href.length < 2) return;
-                            var targetId = href.slice(1);
-                            var el = document.querySelector('[id="' + targetId + '"]');
-                            if (!el) return;
-                            var rect = el.getBoundingClientRect();
-                            // window.scrollY is always 0 because Compose owns the
-                            // scroll, but include it for correctness.
-                            var absoluteY = Math.round(rect.top + window.scrollY);
-                            MyDeckTocBridge.onFragmentLinkTapped(absoluteY);
-                        }, true);
-                    });
-                })();
-            """.trimIndent()
-        }
-    }
-}
-```
+3. **Bridge availability check**: `window['MyDeckTocBridge']` is tested before use; if missing, the IIFE exits cleanly with a log.
+
+4. **`devicePixelRatio` conversion**: `getBoundingClientRect().top` returns CSS pixels. `scrollState.animateScrollTo` expects physical pixels. The JS multiplies by `window.devicePixelRatio` before sending to Kotlin.
+
+5. **Heading text fallback**: Readeck's sanitiser strips `id` attributes from headings. `querySelector('[id="..."]')` therefore returns null for TOC targets even though the TOC `href` is correct. When the id lookup fails, the JS strips the per-article prefix from the fragment ID (e.g. `eK.sfkN.CutTrim_With_Re-encoding` → `CutTrim_With_Re-encoding`), normalises underscores to spaces and removes non-alphanumeric characters, then matches the first heading whose normalised text content equals the normalised fragment. This correctly maps `CutTrim_With_Re-encoding` to the heading `<h2>Cut/Trim With Re-encoding</h2>`.
 
 ### 4.3 Changes to `BookmarkDetailWebViews.kt`
 
-**File:** `app/src/main/java/com/mydeck/app/ui/detail/components/BookmarkDetailWebViews.kt`
-
-Three changes are required, all within `BookmarkDetailArticle`:
+Three changes within `BookmarkDetailArticle`:
 
 #### 4.3.1 Add callback parameter
-
-Add an `onFragmentScroll` parameter to `BookmarkDetailArticle` alongside the existing `onAnnotationClicked`, `onImageTapped`, etc.:
 
 ```kotlin
 onFragmentScroll: (absoluteY: Int) -> Unit = {},
 ```
 
-Place it after `onAnnotationClicked`.
+Placed after `onAnnotationClicked`. Default is a no-op so no existing call sites break.
 
-#### 4.3.2 Register the bridge on the WebView
+#### 4.3.2 Capture callback with `rememberUpdatedState`
 
-In the `AndroidView` `factory` block, after the existing `addJavascriptInterface` call for `WebViewAnnotationTapBridge`, add:
+```kotlin
+val latestFragmentScrollHandler = rememberUpdatedState(onFragmentScroll)
+```
+
+Added alongside `latestAnnotationClickHandler`. The bridge lambda references `latestFragmentScrollHandler.value` rather than capturing `onFragmentScroll` directly, matching the annotation bridge pattern and ensuring the lambda always calls the current callback without holding a stale reference.
+
+#### 4.3.3 Register the bridge on the WebView
+
+In the `AndroidView` `factory` block, after the `WebViewAnnotationTapBridge` registration:
 
 ```kotlin
 addJavascriptInterface(
     WebViewTocBridge(
         onFragmentScroll = { absoluteY ->
-            coroutineScope.launch {
-                scrollState.animateScrollTo(absoluteY)
-            }
+            latestFragmentScrollHandler.value(absoluteY)
         }
     ),
     WebViewTocBridge.BRIDGE_NAME
 )
 ```
 
-Note: `coroutineScope` and `scrollState` are both captured by the lambda closure. `coroutineScope` is already in scope from `rememberCoroutineScope()` at line 143 of the file. `scrollState` is a parameter of `BookmarkDetailArticle`.
-
-#### 4.3.3 Inject the JS in `applyReaderEnhancements`
-
-In `applyReaderEnhancements(webView: WebView)` (currently at line 472), add the fragment interceptor after the existing injections:
+#### 4.3.4 Inject the JS in `applyReaderEnhancements`
 
 ```kotlin
-private fun applyReaderEnhancements(webView: WebView) {
-    val typographyJs = WebViewTypographyBridge.applyTypography(latestTypographySettings.value)
-    applyTheme(webView)
-    webView.evaluateJavascript(typographyJs, null)
-    val imageJs = WebViewImageBridge.injectImageInterceptor()
-    webView.evaluateJavascript(imageJs, null)
-    val annotationJs = WebViewAnnotationBridge.injectAnnotationInteractions()
-    webView.evaluateJavascript(annotationJs, null)
-    // NEW: fragment link (TOC) interceptor
-    val tocJs = WebViewTocBridge.injectFragmentLinkInterceptor()
-    webView.evaluateJavascript(tocJs, null)
-}
+val tocJs = WebViewTocBridge.injectFragmentLinkInterceptor()
+webView.evaluateJavascript(tocJs, null)
 ```
 
-`applyReaderEnhancements` is called in both `onPageCommitVisible` and `onPageFinished`, so the interceptor is registered on both paths.
+Added after the annotation JS injection. `applyReaderEnhancements` is called in both `onPageCommitVisible` and `onPageFinished`; the `window.mydeckTocInstalled` guard prevents double-registration.
 
 ### 4.4 Changes to `BookmarkDetailScreen.kt`
 
-**File:** `app/src/main/java/com/mydeck/app/ui/detail/BookmarkDetailScreen.kt`
-
-Pass the callback through from `BookmarkDetailArticle`'s call site. Locate where `BookmarkDetailArticle` is called inside `BookmarkDetailArticleContent` (or equivalent) and add:
+`coroutineScope` is added via `rememberCoroutineScope()` at the top of `BookmarkDetailContent`. The `onFragmentScroll` callback is wired at the `BookmarkDetailArticle` call site, adding `articleTopOffsetPx` (the physical-pixel offset of the WebView's top edge within the scroll container) to the raw Y value before scrolling:
 
 ```kotlin
 onFragmentScroll = { absoluteY ->
     coroutineScope.launch {
-        scrollState.animateScrollTo(absoluteY)
+        val targetScroll = (absoluteY + articleTopOffsetPx).toInt().coerceIn(0, scrollState.maxValue)
+        scrollState.animateScrollTo(targetScroll)
     }
 }
 ```
 
-The `scrollState` is already available at that call site (it is threaded into `BookmarkDetailArticle` as a parameter). `coroutineScope` is available via `rememberCoroutineScope()`.
+This offset is required because `absoluteY` is relative to the WebView's own coordinate space; `scrollState` is relative to the top of the entire scroll container (which includes the article header above the WebView).
 
-**Optional offset:** Subtract the top-bar height (in pixels) from `absoluteY` before scrolling to leave visual breathing room above the heading, consistent with how annotation scrolling targets are handled. This is a polish decision — the basic implementation does not require it.
+### 4.5 Visual styling of intrapage links
+
+A CSS rule is added to all four HTML templates (`html_template_light.html`, `html_template_dark.html`, `html_template_black.html`, `html_template_sepia.html`) to visually distinguish intrapage links from external links:
+
+```css
+a[href^="#"] {
+  text-decoration-style: dashed;
+}
+```
+
+All other link properties (colour, underline offset, thickness) are inherited from the base `a` rule. This applies to all `href="#..."` links — TOC links, Wikipedia footnote citations, and any other same-page anchors — which is intentional: all are navigable within the page.
 
 ---
 
@@ -213,43 +149,30 @@ The `scrollState` is already available at that call site (it is threaded into `B
 | File | Change |
 |------|--------|
 | `ui/detail/WebViewTocBridge.kt` | **New file.** Bridge class + `injectFragmentLinkInterceptor()` JS. |
-| `ui/detail/components/BookmarkDetailWebViews.kt` | Add `onFragmentScroll` param; register `WebViewTocBridge`; call `injectFragmentLinkInterceptor()` in `applyReaderEnhancements()`. |
-| `ui/detail/BookmarkDetailScreen.kt` | Pass `onFragmentScroll` callback at `BookmarkDetailArticle` call site. |
+| `ui/detail/components/BookmarkDetailWebViews.kt` | Add `onFragmentScroll` param + `rememberUpdatedState`; register `WebViewTocBridge`; call `injectFragmentLinkInterceptor()` in `applyReaderEnhancements()`. |
+| `ui/detail/BookmarkDetailScreen.kt` | Add `rememberCoroutineScope()`; pass `onFragmentScroll` callback with `articleTopOffsetPx` offset at `BookmarkDetailArticle` call site. |
+| `assets/html_template_light.html` | Add `a[href^="#"]` dashed underline rule. |
+| `assets/html_template_dark.html` | Add `a[href^="#"]` dashed underline rule. |
+| `assets/html_template_black.html` | Add `a[href^="#"]` dashed underline rule. |
+| `assets/html_template_sepia.html` | Add `a[href^="#"]` dashed underline rule. |
 
 ---
 
-## 7. Implementation Plan
+## 7. Implementation Notes (Post-Hoc)
 
-Execute steps in order. Each step is self-contained and builds cleanly on the previous one.
+Issues discovered during implementation that were not anticipated in the original spec:
 
-### Step 1 — Create `WebViewTocBridge.kt`
+### JS listener strategy
+The original spec used per-element `addEventListener` on each `a[href^="#"]`. This was replaced with a single delegated listener on `.container`, matching the annotation bridge's proven pattern. Benefits: survives DOM mutations, no duplicate listeners on double-injection, simpler.
 
-Create the new file at `app/src/main/java/com/mydeck/app/ui/detail/WebViewTocBridge.kt` with the full class body from section 4.2.
+### CSS pixel vs physical pixel mismatch
+`getBoundingClientRect().top` returns CSS pixels. `scrollState.animateScrollTo` takes physical pixels. The original spec omitted the `devicePixelRatio` multiplication, which would cause the scroll to undershoot by the display density factor (3× on a typical device).
 
-**Verify:** The file compiles independently. No other files changed yet.
+### `onFragmentScroll` callback bypass
+The bridge must call through `latestFragmentScrollHandler.value` (a `rememberUpdatedState` wrapper), not directly call `scrollState.animateScrollTo`. The `BookmarkDetailScreen.kt` callback adds the `articleTopOffsetPx` offset that maps WebView-relative Y to scroll-container-relative Y. Bypassing it causes scrolls to land in the wrong position.
 
-### Step 2 — Wire bridge and callback in `BookmarkDetailWebViews.kt`
-
-1. Add `import com.mydeck.app.ui.detail.WebViewTocBridge` to the import block.
-2. Add `onFragmentScroll: (absoluteY: Int) -> Unit = {}` to `BookmarkDetailArticle`'s parameter list, after `onAnnotationClicked`.
-3. In the `AndroidView` factory block, after the `WebViewAnnotationTapBridge` registration, add the `WebViewTocBridge` registration (code in section 4.3.2).
-4. In `applyReaderEnhancements`, add the two lines that call `injectFragmentLinkInterceptor()` (section 4.3.3).
-
-**Verify:** Project compiles. The new parameter has a default value so no existing call sites break.
-
-### Step 3 — Pass callback in `BookmarkDetailScreen.kt`
-
-Find the call site(s) of `BookmarkDetailArticle` inside `BookmarkDetailScreen.kt` and add `onFragmentScroll` (section 4.4).
-
-**Verify:** Project compiles. Run the app on a debug build; open an article with a TOC (e.g. a long Wikipedia article cached or fetched via Readeck); tap a TOC link; confirm the article scrolls to the correct heading.
-
-### Step 4 — Build validation
-
-```
-./gradlew :app:assembleDebugAll
-./gradlew :app:testDebugUnitTestAll
-./gradlew :app:lintDebugAll
-```
+### Readeck strips heading IDs
+Readeck's sanitiser removes `id` attributes from heading elements, keeping them only on wrapper `<div>` containers. A `querySelector('[id="..."]')` lookup therefore fails for TOC targets even though the TOC `href` value is correct. The heading text normalisation fallback is required for correct operation with real Readeck content.
 
 ---
 
@@ -259,9 +182,3 @@ Find the call site(s) of `BookmarkDetailArticle` inside `BookmarkDetailScreen.kt
 - Back-navigation after following a TOC link (user can scroll back manually).
 - Highlighting the active TOC entry.
 - Multi-column or paginated reading modes (not implemented in this app).
-
----
-
-## 9. Model Complexity Assessment
-
-This is a **Sonnet-class task** (mid-tier model sufficient). The implementation is three small, well-bounded changes across three files with no new architecture, no new data models, and no async complexity beyond a single `coroutineScope.launch`. The primary risk is an incorrect lambda capture (e.g. stale `scrollState`), but the existing annotation tap and search-scroll patterns demonstrate the correct idiom to follow. A capable model reading this spec alongside the three target files can complete the implementation correctly in a single pass without further research.


### PR DESCRIPTION
## Summary

- Tapping a same-page anchor link (TOC entry, Wikipedia footnote citation, etc.) in the article reader now scrolls to the correct heading
- Intrapage links (`href="#..."`) are visually distinguished from external links by a dashed underline across all four reader themes (light, dark, black, sepia)
- Fixed a one-frame flash of the wrong top bar colour at startup when the app theme is Sepia, Dark, or Black

## How it works

**Intrapage link navigation:** A JS click interceptor is injected into the article WebView via a new `WebViewTocBridge`. When a fragment link is tapped, the JS resolves the target element's Y position and reports it to Kotlin, which drives `scrollState.animateScrollTo()` — the same scroll path used by annotation jump-to. Two non-obvious issues were resolved:
- Readeck's sanitiser strips `id` attributes from headings, so the JS falls back to matching headings by normalised text content when the id lookup fails
- `getBoundingClientRect()` returns CSS pixels; the JS multiplies by `window.devicePixelRatio` before sending to Kotlin

**Startup theme flash:** `MainViewModel.isReady` previously unblocked the splash screen as soon as `themeFlow` alone emitted, while `lightAppearance` and `darkAppearance` were still loading. Compose rendered its first frame with default values (Paper/Dark), causing a flash. The fix holds the splash screen until all three appearance flows have loaded, and starts them `Eagerly` so values are ready before the first frame.

## Test plan

- [ ] Open an article with a table of contents — tap a TOC link and confirm it scrolls to the correct heading
- [ ] Tap a footnote citation link — confirm it scrolls to the footnotes section
- [ ] Verify intrapage links show a dashed underline in all four reader themes
- [ ] Verify external links are unaffected (solid underline, open in Chrome Custom Tab)
- [ ] With app theme set to Sepia, Dark, or Black: cold-start the app and confirm no wrong-colour flash on the top bar
- [ ] With app theme set to System (Paper/Dark): cold-start and confirm no regression
