### PR TITLE
Add swipe actions for bookmark cards

### DIFF
--- a/app/src/main/assets/guide/en/settings.md
+++ b/app/src/main/assets/guide/en/settings.md
@@ -66,6 +66,16 @@ The **User Interface Settings** screen controls the app's appearance.
 - **Fullscreen while reading** — when enabled, article reading view hides the system bars and top bar after a short delay so the page can use the full screen. Swipe from the edge or tap near the top edge to reveal them temporarily.
 - **Keep screen on while reading** — when enabled, the screen stays on while you have a bookmark open in reading view. Enabled by default.
 
+### Swipe actions
+
+Controls the horizontal swipe gesture on bookmark cards.
+
+- **Enable swipe actions** — master switch. When off, swiping cards does nothing and the navigation drawer's left-edge swipe gesture returns.
+- **Swipe right action** — choose what a right swipe does: **Archive**, **Delete**, **Favorite**, or **None** (disables the right direction only).
+- **Swipe left action** — choose what a left swipe does: **Archive**, **Delete**, **Favorite**, or **None** (disables the left direction only).
+
+Setting a direction to **None** leaves the other direction active.
+
 ## Logs
 
 The **Logs** screen shows the app's log output, which can be useful for troubleshooting. From this screen you can:

--- a/app/src/main/assets/guide/en/your-bookmarks.md
+++ b/app/src/main/assets/guide/en/your-bookmarks.md
@@ -77,6 +77,23 @@ Each card has four action buttons:
 
 See [Organizing](./organizing.md) for more on how favorites, archive, labels, and deletion work across your whole collection.
 
+## Swipe Actions on Cards
+
+In single-column layouts you can swipe a bookmark card left or right to archive or delete it without tapping the icon buttons.
+
+- **Swipe right** — archives the bookmark (default)
+- **Swipe left** — deletes the bookmark (default)
+
+The action triggers once you drag the card past its mid-point. Release before that and the card snaps back with no effect.
+
+Deleting via swipe shows the same **"Bookmark deleted — UNDO"** snackbar as the trash icon, so you can reverse an accidental deletion.
+
+**Layout availability:** Swipe is active in the Compact layout and in single-column phone portrait view. It is not available in the multi-column Mosaic or Grid layouts (tablet or landscape) — use the icon buttons in those layouts instead.
+
+**Navigation drawer:** When swipe actions are enabled, the left-edge drag gesture that normally opens the navigation drawer is suppressed to avoid conflicts. Use the hamburger button in the top bar to open the drawer instead. If you disable swipe actions in settings, the drawer edge-swipe returns.
+
+To change which action each direction triggers — or to turn swipe off entirely — go to **Settings → UI Settings → Swipe actions**.
+
 ## Long-press Context Menu
 
 Long-pressing on a bookmark card opens a context menu dialog. The dialog header shows the bookmark URL or image source — tap the header to expand truncated text, tap again to collapse.

--- a/app/src/main/java/com/mydeck/app/domain/model/SwipeAction.kt
+++ b/app/src/main/java/com/mydeck/app/domain/model/SwipeAction.kt
@@ -1,0 +1,8 @@
+package com.mydeck.app.domain.model
+
+enum class SwipeAction {
+    ARCHIVE,
+    DELETE,
+    FAVORITE,
+    NONE
+}

--- a/app/src/main/java/com/mydeck/app/domain/model/SwipeConfig.kt
+++ b/app/src/main/java/com/mydeck/app/domain/model/SwipeConfig.kt
@@ -1,0 +1,15 @@
+package com.mydeck.app.domain.model
+
+data class SwipeConfig(
+    val enabled: Boolean,
+    val leftAction: SwipeAction,
+    val rightAction: SwipeAction
+) {
+    companion object {
+        val Default = SwipeConfig(
+            enabled = true,
+            leftAction = SwipeAction.DELETE,
+            rightAction = SwipeAction.ARCHIVE
+        )
+    }
+}

--- a/app/src/main/java/com/mydeck/app/io/prefs/SettingsDataStore.kt
+++ b/app/src/main/java/com/mydeck/app/io/prefs/SettingsDataStore.kt
@@ -6,6 +6,8 @@ import com.mydeck.app.domain.model.BookmarkShareFormat
 import com.mydeck.app.domain.model.DarkAppearance
 import com.mydeck.app.domain.model.HighlightsSyncMetadata
 import com.mydeck.app.domain.model.LightAppearance
+import com.mydeck.app.domain.model.SwipeAction
+import com.mydeck.app.domain.model.SwipeConfig
 import com.mydeck.app.domain.model.Theme
 import com.mydeck.app.domain.model.TypographySettings
 import com.mydeck.app.domain.sync.ContentSyncConstraints
@@ -118,6 +120,12 @@ interface SettingsDataStore {
     val fullscreenWhileReadingFlow: StateFlow<Boolean>
     suspend fun saveFullscreenWhileReading(enabled: Boolean)
     suspend fun isFullscreenWhileReading(): Boolean
+
+    // Swipe action preferences
+    val swipeConfigFlow: StateFlow<SwipeConfig>
+    suspend fun saveSwipeEnabled(enabled: Boolean)
+    suspend fun saveSwipeLeftAction(action: SwipeAction)
+    suspend fun saveSwipeRightAction(action: SwipeAction)
 
     // Server info caching
     suspend fun saveServerInfo(info: CachedServerInfo)

--- a/app/src/main/java/com/mydeck/app/io/prefs/SettingsDataStoreImpl.kt
+++ b/app/src/main/java/com/mydeck/app/io/prefs/SettingsDataStoreImpl.kt
@@ -15,6 +15,8 @@ import com.mydeck.app.domain.model.DarkAppearance
 import com.mydeck.app.domain.model.HighlightsSyncMetadata
 import com.mydeck.app.domain.model.LightAppearance
 import com.mydeck.app.domain.model.ReaderFontFamily
+import com.mydeck.app.domain.model.SwipeAction
+import com.mydeck.app.domain.model.SwipeConfig
 import com.mydeck.app.domain.model.TextWidth
 import com.mydeck.app.domain.model.Theme
 import com.mydeck.app.domain.model.TypographySettings
@@ -116,6 +118,10 @@ class SettingsDataStoreImpl @Inject constructor(@ApplicationContext private val 
     private val KEY_SERVER_INFO_RELEASE = stringPreferencesKey("server_info_release")
     private val KEY_SERVER_INFO_BUILD = stringPreferencesKey("server_info_build")
     private val KEY_SERVER_INFO_FEATURES = stringPreferencesKey("server_info_features")
+
+    private val KEY_SWIPE_ENABLED = booleanPreferencesKey("swipe_enabled")
+    private val KEY_SWIPE_LEFT_ACTION = stringPreferencesKey("swipe_left_action")
+    private val KEY_SWIPE_RIGHT_ACTION = stringPreferencesKey("swipe_right_action")
 
     init {
         migrateLegacySepiaSetting(encryptedSharedPreferences)
@@ -390,6 +396,27 @@ class SettingsDataStoreImpl @Inject constructor(@ApplicationContext private val 
 
     override suspend fun isFullscreenWhileReading(): Boolean {
         return userPreferences.getBoolean(KEY_FULLSCREEN_WHILE_READING.name, false)
+    }
+
+    override suspend fun saveSwipeEnabled(enabled: Boolean) {
+        userPreferences.edit {
+            putBoolean(KEY_SWIPE_ENABLED.name, enabled)
+        }
+        _swipeConfigFlow.value = readSwipeConfig()
+    }
+
+    override suspend fun saveSwipeLeftAction(action: SwipeAction) {
+        userPreferences.edit {
+            putString(KEY_SWIPE_LEFT_ACTION.name, action.name)
+        }
+        _swipeConfigFlow.value = readSwipeConfig()
+    }
+
+    override suspend fun saveSwipeRightAction(action: SwipeAction) {
+        userPreferences.edit {
+            putString(KEY_SWIPE_RIGHT_ACTION.name, action.name)
+        }
+        _swipeConfigFlow.value = readSwipeConfig()
     }
 
     override suspend fun setSyncOnAppOpenEnabled(isEnabled: Boolean) {
@@ -826,6 +853,29 @@ class SettingsDataStoreImpl @Inject constructor(@ApplicationContext private val 
         }
         _typographySettingsFlow.value = sanitizedSettings
     }
+
+    private fun readSwipeConfig(): SwipeConfig {
+        val enabled = userPreferences.getBoolean(KEY_SWIPE_ENABLED.name, SwipeConfig.Default.enabled)
+        val leftAction = userPreferences.getString(KEY_SWIPE_LEFT_ACTION.name, null)?.let { value ->
+            try {
+                SwipeAction.valueOf(value)
+            } catch (_: IllegalArgumentException) {
+                SwipeConfig.Default.leftAction
+            }
+        } ?: SwipeConfig.Default.leftAction
+        val rightAction = userPreferences.getString(KEY_SWIPE_RIGHT_ACTION.name, null)?.let { value ->
+            try {
+                SwipeAction.valueOf(value)
+            } catch (_: IllegalArgumentException) {
+                SwipeConfig.Default.rightAction
+            }
+        } ?: SwipeConfig.Default.rightAction
+        return SwipeConfig(enabled = enabled, leftAction = leftAction, rightAction = rightAction)
+    }
+
+    private val _swipeConfigFlow = MutableStateFlow(readSwipeConfig())
+
+    override val swipeConfigFlow: StateFlow<SwipeConfig> = _swipeConfigFlow.asStateFlow()
 
     private fun readLineSpacingPercent(): Int {
         if (userPreferences.contains(KEY_TYPO_LINE_SPACING_PERCENT.name)) {

--- a/app/src/main/java/com/mydeck/app/ui/list/BookmarkListScreen.kt
+++ b/app/src/main/java/com/mydeck/app/ui/list/BookmarkListScreen.kt
@@ -4,6 +4,8 @@ package com.mydeck.app.ui.list
 
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -79,6 +81,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalConfiguration
@@ -104,6 +108,8 @@ import com.mydeck.app.domain.model.BookmarkListItem
 import com.mydeck.app.domain.model.DrawerPreset
 import com.mydeck.app.domain.model.LayoutMode
 import com.mydeck.app.domain.model.SortOption
+import com.mydeck.app.domain.model.SwipeAction
+import com.mydeck.app.domain.model.SwipeConfig
 import com.mydeck.app.ui.components.FilterBar
 import com.mydeck.app.ui.components.FilterBottomSheet
 import com.mydeck.app.ui.components.ShareBookmarkChooser
@@ -150,6 +156,7 @@ fun BookmarkListScreen(
     val labelsWithCounts = viewModel.labelsWithCounts.collectAsState()
     val isLabelsSheetOpen = viewModel.isLabelsSheetOpen.collectAsState()
     val pendingDeletionBookmarkIds = viewModel.pendingDeletionBookmarkIds.collectAsState()
+    val swipeConfig = viewModel.swipeConfig.collectAsState()
 
     var showLayoutMenu by remember { mutableStateOf(false) }
     var showSortMenu by remember { mutableStateOf(false) }
@@ -650,10 +657,24 @@ fun BookmarkListScreen(
             }
         }
     ) { padding ->
+        val hasPendingDeletion = pendingDeletionBookmarkIds.value.isNotEmpty()
         Column(
             modifier = Modifier
                 .padding(padding)
                 .fillMaxWidth()
+                // Any touch in content area confirms a pending delete (snackbar's
+                // Undo lives in its own Scaffold slot and is excluded). Initial-pass
+                // observer that never consumes — children still receive the event.
+                .pointerInput(hasPendingDeletion) {
+                    if (!hasPendingDeletion) return@pointerInput
+                    awaitEachGesture {
+                        awaitFirstDown(
+                            requireUnconsumed = false,
+                            pass = PointerEventPass.Initial,
+                        )
+                        dismissPendingDeleteSnackbar()
+                    }
+                }
         ) {
             // FilterBar: visible when filters are active beyond preset defaults, not in label mode
             if (!isLabelMode) {
@@ -696,6 +717,7 @@ fun BookmarkListScreen(
                                 layoutMode = layoutMode.value,
                                 bookmarks = uiState.bookmarks,
                                 pendingDeletionBookmarkIds = pendingDeletionBookmarkIds.value.toSet(),
+                                swipeConfig = swipeConfig.value,
                                 onClickBookmark = onClickBookmark,
                                 onClickDelete = onClickDelete,
                                 onClickArchive = onClickArchive,
@@ -977,6 +999,7 @@ fun BookmarkListView(
     layoutMode: LayoutMode = LayoutMode.GRID,
     bookmarks: List<BookmarkListItem>,
     pendingDeletionBookmarkIds: Set<String> = emptySet(),
+    swipeConfig: SwipeConfig = SwipeConfig.Default,
     isMultiColumn: Boolean = LocalIsWideLayout.current,
     onClickBookmark: (String) -> Unit,
     onClickDelete: (String) -> Unit,
@@ -1028,74 +1051,82 @@ fun BookmarkListView(
                 verticalArrangement = Arrangement.spacedBy(spacing),
                 contentPadding = PaddingValues(horizontal = spacing),
             ) {
-                itemsIndexed(bookmarks) { index, bookmark ->
+                itemsIndexed(bookmarks, key = { _, bookmark -> bookmark.id }) { index, bookmark ->
                     val isPendingDeletion = bookmark.id in pendingDeletionBookmarkIds
                     val confirmDelete: (String) -> Unit = { _ -> onUserInteraction() }
                     val noop: (String) -> Unit = {}
                     val noop2: (String, Boolean) -> Unit = { _, _ -> }
                     val noop2s: (String, String) -> Unit = { _, _ -> }
                     val noopShare: (String, String) -> Unit = { _, _ -> }
-                    Box(modifier = Modifier.alpha(if (isPendingDeletion) 0.38f else 1f)) {
-                    when (layoutMode) {
-                        LayoutMode.GRID -> BookmarkGridCard(
-                            bookmark = bookmark,
-                            onClickCard = if (isPendingDeletion) confirmDelete else onClickBookmark,
-                            onClickDelete = if (isPendingDeletion) noop else onClickDelete,
-                            onClickArchive = if (isPendingDeletion) noop2 else onClickArchive,
-                            onClickFavorite = if (isPendingDeletion) noop2 else onClickFavorite,
-                            onClickLabel = if (isPendingDeletion) noop else onClickLabel,
-                            onClickOpenUrl = if (isPendingDeletion) noop else onClickOpenUrl,
-                            onClickOpenInBrowser = if (isPendingDeletion) noop else onClickOpenInBrowser,
-                            onClickCopyLink = if (isPendingDeletion) noop else onClickCopyLink,
-                            onClickCopyLinkText = if (isPendingDeletion) noop else onClickCopyLinkText,
-                            onClickShareLink = if (isPendingDeletion) noopShare else onClickShareLink,
-                            onClickOpenInBrowserFromMenu = if (isPendingDeletion) noop else onClickOpenInBrowserFromMenu,
-                            onClickCopyImage = if (isPendingDeletion) noop else onClickCopyImage,
-                            onClickDownloadLink = if (isPendingDeletion) noop2s else onClickDownloadLink,
-                            onClickDownloadImage = if (isPendingDeletion) noop else onClickDownloadImage,
-                            onClickShareImage = if (isPendingDeletion) noop else onClickShareImage,
-                            isInGrid = true,
-                            index = index + 1,
-                        )
-                        LayoutMode.COMPACT -> BookmarkCompactCard(
-                            bookmark = bookmark,
-                            onClickCard = if (isPendingDeletion) confirmDelete else onClickBookmark,
-                            onClickDelete = if (isPendingDeletion) noop else onClickDelete,
-                            onClickArchive = if (isPendingDeletion) noop2 else onClickArchive,
-                            onClickFavorite = if (isPendingDeletion) noop2 else onClickFavorite,
-                            onClickLabel = if (isPendingDeletion) noop else onClickLabel,
-                            onClickOpenUrl = if (isPendingDeletion) noop else onClickOpenUrl,
-                            onClickOpenInBrowser = if (isPendingDeletion) noop else onClickOpenInBrowser,
-                            onClickCopyLink = if (isPendingDeletion) noop else onClickCopyLink,
-                            onClickCopyLinkText = if (isPendingDeletion) noop else onClickCopyLinkText,
-                            onClickShareLink = if (isPendingDeletion) noopShare else onClickShareLink,
-                            onClickOpenInBrowserFromMenu = if (isPendingDeletion) noop else onClickOpenInBrowserFromMenu,
-                            onClickCopyImage = if (isPendingDeletion) noop else onClickCopyImage,
-                            onClickDownloadLink = if (isPendingDeletion) noop2s else onClickDownloadLink,
-                            onClickDownloadImage = if (isPendingDeletion) noop else onClickDownloadImage,
-                            onClickShareImage = if (isPendingDeletion) noop else onClickShareImage,
-                            index = index + 1,
-                        )
-                        LayoutMode.MOSAIC -> BookmarkMosaicCard(
-                            bookmark = bookmark,
-                            onClickCard = if (isPendingDeletion) confirmDelete else onClickBookmark,
-                            onClickDelete = if (isPendingDeletion) noop else onClickDelete,
-                            onClickArchive = if (isPendingDeletion) noop2 else onClickArchive,
-                            onClickFavorite = if (isPendingDeletion) noop2 else onClickFavorite,
-                            onClickLabel = if (isPendingDeletion) noop else onClickLabel,
-                            onClickOpenUrl = if (isPendingDeletion) noop else onClickOpenUrl,
-                            onClickOpenInBrowser = if (isPendingDeletion) noop else onClickOpenInBrowser,
-                            onClickCopyLink = if (isPendingDeletion) noop else onClickCopyLink,
-                            onClickCopyLinkText = if (isPendingDeletion) noop else onClickCopyLinkText,
-                            onClickShareLink = if (isPendingDeletion) noopShare else onClickShareLink,
-                            onClickOpenInBrowserFromMenu = if (isPendingDeletion) noop else onClickOpenInBrowserFromMenu,
-                            onClickCopyImage = if (isPendingDeletion) noop else onClickCopyImage,
-                            onClickDownloadLink = if (isPendingDeletion) noop2s else onClickDownloadLink,
-                            onClickDownloadImage = if (isPendingDeletion) noop else onClickDownloadImage,
-                            onClickShareImage = if (isPendingDeletion) noop else onClickShareImage,
-                            index = index + 1,
-                        )
-                    }
+                    SwipeWrappedBookmark(
+                        bookmark = bookmark,
+                        isPendingDeletion = isPendingDeletion,
+                        swipeConfig = swipeConfig.copy(enabled = false),
+                        onClickArchive = onClickArchive,
+                        onClickDelete = onClickDelete,
+                        onClickFavorite = onClickFavorite,
+                        modifier = Modifier.animateItem(),
+                    ) {
+                        when (layoutMode) {
+                            LayoutMode.GRID -> BookmarkGridCard(
+                                bookmark = bookmark,
+                                onClickCard = if (isPendingDeletion) confirmDelete else onClickBookmark,
+                                onClickDelete = if (isPendingDeletion) noop else onClickDelete,
+                                onClickArchive = if (isPendingDeletion) noop2 else onClickArchive,
+                                onClickFavorite = if (isPendingDeletion) noop2 else onClickFavorite,
+                                onClickLabel = if (isPendingDeletion) noop else onClickLabel,
+                                onClickOpenUrl = if (isPendingDeletion) noop else onClickOpenUrl,
+                                onClickOpenInBrowser = if (isPendingDeletion) noop else onClickOpenInBrowser,
+                                onClickCopyLink = if (isPendingDeletion) noop else onClickCopyLink,
+                                onClickCopyLinkText = if (isPendingDeletion) noop else onClickCopyLinkText,
+                                onClickShareLink = if (isPendingDeletion) noopShare else onClickShareLink,
+                                onClickOpenInBrowserFromMenu = if (isPendingDeletion) noop else onClickOpenInBrowserFromMenu,
+                                onClickCopyImage = if (isPendingDeletion) noop else onClickCopyImage,
+                                onClickDownloadLink = if (isPendingDeletion) noop2s else onClickDownloadLink,
+                                onClickDownloadImage = if (isPendingDeletion) noop else onClickDownloadImage,
+                                onClickShareImage = if (isPendingDeletion) noop else onClickShareImage,
+                                isInGrid = true,
+                                index = index + 1,
+                            )
+                            LayoutMode.COMPACT -> BookmarkCompactCard(
+                                bookmark = bookmark,
+                                onClickCard = if (isPendingDeletion) confirmDelete else onClickBookmark,
+                                onClickDelete = if (isPendingDeletion) noop else onClickDelete,
+                                onClickArchive = if (isPendingDeletion) noop2 else onClickArchive,
+                                onClickFavorite = if (isPendingDeletion) noop2 else onClickFavorite,
+                                onClickLabel = if (isPendingDeletion) noop else onClickLabel,
+                                onClickOpenUrl = if (isPendingDeletion) noop else onClickOpenUrl,
+                                onClickOpenInBrowser = if (isPendingDeletion) noop else onClickOpenInBrowser,
+                                onClickCopyLink = if (isPendingDeletion) noop else onClickCopyLink,
+                                onClickCopyLinkText = if (isPendingDeletion) noop else onClickCopyLinkText,
+                                onClickShareLink = if (isPendingDeletion) noopShare else onClickShareLink,
+                                onClickOpenInBrowserFromMenu = if (isPendingDeletion) noop else onClickOpenInBrowserFromMenu,
+                                onClickCopyImage = if (isPendingDeletion) noop else onClickCopyImage,
+                                onClickDownloadLink = if (isPendingDeletion) noop2s else onClickDownloadLink,
+                                onClickDownloadImage = if (isPendingDeletion) noop else onClickDownloadImage,
+                                onClickShareImage = if (isPendingDeletion) noop else onClickShareImage,
+                                index = index + 1,
+                            )
+                            LayoutMode.MOSAIC -> BookmarkMosaicCard(
+                                bookmark = bookmark,
+                                onClickCard = if (isPendingDeletion) confirmDelete else onClickBookmark,
+                                onClickDelete = if (isPendingDeletion) noop else onClickDelete,
+                                onClickArchive = if (isPendingDeletion) noop2 else onClickArchive,
+                                onClickFavorite = if (isPendingDeletion) noop2 else onClickFavorite,
+                                onClickLabel = if (isPendingDeletion) noop else onClickLabel,
+                                onClickOpenUrl = if (isPendingDeletion) noop else onClickOpenUrl,
+                                onClickOpenInBrowser = if (isPendingDeletion) noop else onClickOpenInBrowser,
+                                onClickCopyLink = if (isPendingDeletion) noop else onClickCopyLink,
+                                onClickCopyLinkText = if (isPendingDeletion) noop else onClickCopyLinkText,
+                                onClickShareLink = if (isPendingDeletion) noopShare else onClickShareLink,
+                                onClickOpenInBrowserFromMenu = if (isPendingDeletion) noop else onClickOpenInBrowserFromMenu,
+                                onClickCopyImage = if (isPendingDeletion) noop else onClickCopyImage,
+                                onClickDownloadLink = if (isPendingDeletion) noop2s else onClickDownloadLink,
+                                onClickDownloadImage = if (isPendingDeletion) noop else onClickDownloadImage,
+                                onClickShareImage = if (isPendingDeletion) noop else onClickShareImage,
+                                index = index + 1,
+                            )
+                        }
                     }
                 }
             }
@@ -1118,74 +1149,82 @@ fun BookmarkListView(
         }
         Box(modifier = modifier) {
             LazyColumn(state = lazyListState, modifier = Modifier.fillMaxSize()) {
-                itemsIndexed(bookmarks) { index, bookmark ->
+                itemsIndexed(bookmarks, key = { _, bookmark -> bookmark.id }) { index, bookmark ->
                     val isPendingDeletion = bookmark.id in pendingDeletionBookmarkIds
                     val confirmDelete: (String) -> Unit = { _ -> onUserInteraction() }
                     val noop: (String) -> Unit = {}
                     val noop2: (String, Boolean) -> Unit = { _, _ -> }
                     val noop2s: (String, String) -> Unit = { _, _ -> }
                     val noopShare: (String, String) -> Unit = { _, _ -> }
-                    Box(modifier = Modifier.alpha(if (isPendingDeletion) 0.38f else 1f)) {
-                    when (layoutMode) {
-                        LayoutMode.GRID -> BookmarkGridCard(
-                            bookmark = bookmark,
-                            onClickCard = if (isPendingDeletion) confirmDelete else onClickBookmark,
-                            onClickDelete = if (isPendingDeletion) noop else onClickDelete,
-                            onClickArchive = if (isPendingDeletion) noop2 else onClickArchive,
-                            onClickFavorite = if (isPendingDeletion) noop2 else onClickFavorite,
-                            onClickLabel = if (isPendingDeletion) noop else onClickLabel,
-                            onClickOpenUrl = if (isPendingDeletion) noop else onClickOpenUrl,
-                            onClickOpenInBrowser = if (isPendingDeletion) noop else onClickOpenInBrowser,
-                            onClickCopyLink = if (isPendingDeletion) noop else onClickCopyLink,
-                            onClickCopyLinkText = if (isPendingDeletion) noop else onClickCopyLinkText,
-                            onClickShareLink = if (isPendingDeletion) noopShare else onClickShareLink,
-                            onClickOpenInBrowserFromMenu = if (isPendingDeletion) noop else onClickOpenInBrowserFromMenu,
-                            onClickCopyImage = if (isPendingDeletion) noop else onClickCopyImage,
-                            onClickDownloadLink = if (isPendingDeletion) noop2s else onClickDownloadLink,
-                            onClickDownloadImage = if (isPendingDeletion) noop else onClickDownloadImage,
-                            onClickShareImage = if (isPendingDeletion) noop else onClickShareImage,
-                            useMobilePortraitLayout = useMobilePortraitGridLayout,
-                            index = index + 1,
-                        )
-                        LayoutMode.COMPACT -> BookmarkCompactCard(
-                            bookmark = bookmark,
-                            onClickCard = if (isPendingDeletion) confirmDelete else onClickBookmark,
-                            onClickDelete = if (isPendingDeletion) noop else onClickDelete,
-                            onClickArchive = if (isPendingDeletion) noop2 else onClickArchive,
-                            onClickFavorite = if (isPendingDeletion) noop2 else onClickFavorite,
-                            onClickLabel = if (isPendingDeletion) noop else onClickLabel,
-                            onClickOpenUrl = if (isPendingDeletion) noop else onClickOpenUrl,
-                            onClickOpenInBrowser = if (isPendingDeletion) noop else onClickOpenInBrowser,
-                            onClickCopyLink = if (isPendingDeletion) noop else onClickCopyLink,
-                            onClickCopyLinkText = if (isPendingDeletion) noop else onClickCopyLinkText,
-                            onClickShareLink = if (isPendingDeletion) noopShare else onClickShareLink,
-                            onClickOpenInBrowserFromMenu = if (isPendingDeletion) noop else onClickOpenInBrowserFromMenu,
-                            onClickCopyImage = if (isPendingDeletion) noop else onClickCopyImage,
-                            onClickDownloadLink = if (isPendingDeletion) noop2s else onClickDownloadLink,
-                            onClickDownloadImage = if (isPendingDeletion) noop else onClickDownloadImage,
-                            onClickShareImage = if (isPendingDeletion) noop else onClickShareImage,
-                            index = index + 1,
-                        )
-                        LayoutMode.MOSAIC -> BookmarkMosaicCard(
-                            bookmark = bookmark,
-                            onClickCard = if (isPendingDeletion) confirmDelete else onClickBookmark,
-                            onClickDelete = if (isPendingDeletion) noop else onClickDelete,
-                            onClickArchive = if (isPendingDeletion) noop2 else onClickArchive,
-                            onClickFavorite = if (isPendingDeletion) noop2 else onClickFavorite,
-                            onClickLabel = if (isPendingDeletion) noop else onClickLabel,
-                            onClickOpenUrl = if (isPendingDeletion) noop else onClickOpenUrl,
-                            onClickOpenInBrowser = if (isPendingDeletion) noop else onClickOpenInBrowser,
-                            onClickCopyLink = if (isPendingDeletion) noop else onClickCopyLink,
-                            onClickCopyLinkText = if (isPendingDeletion) noop else onClickCopyLinkText,
-                            onClickShareLink = if (isPendingDeletion) noopShare else onClickShareLink,
-                            onClickOpenInBrowserFromMenu = if (isPendingDeletion) noop else onClickOpenInBrowserFromMenu,
-                            onClickCopyImage = if (isPendingDeletion) noop else onClickCopyImage,
-                            onClickDownloadLink = if (isPendingDeletion) noop2s else onClickDownloadLink,
-                            onClickDownloadImage = if (isPendingDeletion) noop else onClickDownloadImage,
-                            onClickShareImage = if (isPendingDeletion) noop else onClickShareImage,
-                            index = index + 1,
-                        )
-                    }
+                    SwipeWrappedBookmark(
+                        bookmark = bookmark,
+                        isPendingDeletion = isPendingDeletion,
+                        swipeConfig = swipeConfig,
+                        onClickArchive = onClickArchive,
+                        onClickDelete = onClickDelete,
+                        onClickFavorite = onClickFavorite,
+                        modifier = Modifier.animateItem(),
+                    ) {
+                        when (layoutMode) {
+                            LayoutMode.GRID -> BookmarkGridCard(
+                                bookmark = bookmark,
+                                onClickCard = if (isPendingDeletion) confirmDelete else onClickBookmark,
+                                onClickDelete = if (isPendingDeletion) noop else onClickDelete,
+                                onClickArchive = if (isPendingDeletion) noop2 else onClickArchive,
+                                onClickFavorite = if (isPendingDeletion) noop2 else onClickFavorite,
+                                onClickLabel = if (isPendingDeletion) noop else onClickLabel,
+                                onClickOpenUrl = if (isPendingDeletion) noop else onClickOpenUrl,
+                                onClickOpenInBrowser = if (isPendingDeletion) noop else onClickOpenInBrowser,
+                                onClickCopyLink = if (isPendingDeletion) noop else onClickCopyLink,
+                                onClickCopyLinkText = if (isPendingDeletion) noop else onClickCopyLinkText,
+                                onClickShareLink = if (isPendingDeletion) noopShare else onClickShareLink,
+                                onClickOpenInBrowserFromMenu = if (isPendingDeletion) noop else onClickOpenInBrowserFromMenu,
+                                onClickCopyImage = if (isPendingDeletion) noop else onClickCopyImage,
+                                onClickDownloadLink = if (isPendingDeletion) noop2s else onClickDownloadLink,
+                                onClickDownloadImage = if (isPendingDeletion) noop else onClickDownloadImage,
+                                onClickShareImage = if (isPendingDeletion) noop else onClickShareImage,
+                                useMobilePortraitLayout = useMobilePortraitGridLayout,
+                                index = index + 1,
+                            )
+                            LayoutMode.COMPACT -> BookmarkCompactCard(
+                                bookmark = bookmark,
+                                onClickCard = if (isPendingDeletion) confirmDelete else onClickBookmark,
+                                onClickDelete = if (isPendingDeletion) noop else onClickDelete,
+                                onClickArchive = if (isPendingDeletion) noop2 else onClickArchive,
+                                onClickFavorite = if (isPendingDeletion) noop2 else onClickFavorite,
+                                onClickLabel = if (isPendingDeletion) noop else onClickLabel,
+                                onClickOpenUrl = if (isPendingDeletion) noop else onClickOpenUrl,
+                                onClickOpenInBrowser = if (isPendingDeletion) noop else onClickOpenInBrowser,
+                                onClickCopyLink = if (isPendingDeletion) noop else onClickCopyLink,
+                                onClickCopyLinkText = if (isPendingDeletion) noop else onClickCopyLinkText,
+                                onClickShareLink = if (isPendingDeletion) noopShare else onClickShareLink,
+                                onClickOpenInBrowserFromMenu = if (isPendingDeletion) noop else onClickOpenInBrowserFromMenu,
+                                onClickCopyImage = if (isPendingDeletion) noop else onClickCopyImage,
+                                onClickDownloadLink = if (isPendingDeletion) noop2s else onClickDownloadLink,
+                                onClickDownloadImage = if (isPendingDeletion) noop else onClickDownloadImage,
+                                onClickShareImage = if (isPendingDeletion) noop else onClickShareImage,
+                                index = index + 1,
+                            )
+                            LayoutMode.MOSAIC -> BookmarkMosaicCard(
+                                bookmark = bookmark,
+                                onClickCard = if (isPendingDeletion) confirmDelete else onClickBookmark,
+                                onClickDelete = if (isPendingDeletion) noop else onClickDelete,
+                                onClickArchive = if (isPendingDeletion) noop2 else onClickArchive,
+                                onClickFavorite = if (isPendingDeletion) noop2 else onClickFavorite,
+                                onClickLabel = if (isPendingDeletion) noop else onClickLabel,
+                                onClickOpenUrl = if (isPendingDeletion) noop else onClickOpenUrl,
+                                onClickOpenInBrowser = if (isPendingDeletion) noop else onClickOpenInBrowser,
+                                onClickCopyLink = if (isPendingDeletion) noop else onClickCopyLink,
+                                onClickCopyLinkText = if (isPendingDeletion) noop else onClickCopyLinkText,
+                                onClickShareLink = if (isPendingDeletion) noopShare else onClickShareLink,
+                                onClickOpenInBrowserFromMenu = if (isPendingDeletion) noop else onClickOpenInBrowserFromMenu,
+                                onClickCopyImage = if (isPendingDeletion) noop else onClickCopyImage,
+                                onClickDownloadLink = if (isPendingDeletion) noop2s else onClickDownloadLink,
+                                onClickDownloadImage = if (isPendingDeletion) noop else onClickDownloadImage,
+                                onClickShareImage = if (isPendingDeletion) noop else onClickShareImage,
+                                index = index + 1,
+                            )
+                        }
                     }
                 }
             }
@@ -1195,6 +1234,73 @@ fun BookmarkListView(
                     .fillMaxHeight(),
                 lazyListState = lazyListState
             )
+        }
+    }
+}
+
+@Composable
+private fun swipeActionA11yLabel(action: SwipeAction): String = when (action) {
+    SwipeAction.ARCHIVE -> stringResource(R.string.swipe_a11y_archive)
+    SwipeAction.DELETE -> stringResource(R.string.swipe_a11y_delete)
+    SwipeAction.FAVORITE -> stringResource(R.string.swipe_a11y_favorite)
+    SwipeAction.NONE -> ""
+}
+
+private fun invokeSwipeAction(
+    action: SwipeAction,
+    bookmark: BookmarkListItem,
+    onClickArchive: (String, Boolean) -> Unit,
+    onClickDelete: (String) -> Unit,
+    onClickFavorite: (String, Boolean) -> Unit,
+) {
+    when (action) {
+        SwipeAction.ARCHIVE -> onClickArchive(bookmark.id, !bookmark.isArchived)
+        SwipeAction.DELETE -> onClickDelete(bookmark.id)
+        SwipeAction.FAVORITE -> onClickFavorite(bookmark.id, !bookmark.isMarked)
+        SwipeAction.NONE -> Unit
+    }
+}
+
+@Composable
+private fun SwipeWrappedBookmark(
+    bookmark: BookmarkListItem,
+    isPendingDeletion: Boolean,
+    swipeConfig: SwipeConfig,
+    onClickArchive: (String, Boolean) -> Unit,
+    onClickDelete: (String) -> Unit,
+    onClickFavorite: (String, Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    val effectiveConfig = if (isPendingDeletion) swipeConfig.copy(enabled = false) else swipeConfig
+    SwipeableCardContainer(
+        config = effectiveConfig,
+        leftAction = effectiveConfig.leftAction,
+        rightAction = effectiveConfig.rightAction,
+        a11yLeftLabel = swipeActionA11yLabel(effectiveConfig.leftAction),
+        a11yRightLabel = swipeActionA11yLabel(effectiveConfig.rightAction),
+        onCommitLeft = {
+            invokeSwipeAction(
+                action = effectiveConfig.leftAction,
+                bookmark = bookmark,
+                onClickArchive = onClickArchive,
+                onClickDelete = onClickDelete,
+                onClickFavorite = onClickFavorite,
+            )
+        },
+        onCommitRight = {
+            invokeSwipeAction(
+                action = effectiveConfig.rightAction,
+                bookmark = bookmark,
+                onClickArchive = onClickArchive,
+                onClickDelete = onClickDelete,
+                onClickFavorite = onClickFavorite,
+            )
+        },
+        modifier = modifier,
+    ) {
+        Box(modifier = Modifier.alpha(if (isPendingDeletion) 0.38f else 1f)) {
+            content()
         }
     }
 }

--- a/app/src/main/java/com/mydeck/app/ui/list/BookmarkListViewModel.kt
+++ b/app/src/main/java/com/mydeck/app/ui/list/BookmarkListViewModel.kt
@@ -18,6 +18,7 @@ import com.mydeck.app.domain.model.DrawerPreset
 import com.mydeck.app.domain.model.FilterFormState
 import com.mydeck.app.domain.model.LayoutMode
 import com.mydeck.app.domain.model.SortOption
+import com.mydeck.app.domain.model.SwipeConfig
 import com.mydeck.app.domain.sync.ConnectivityMonitor
 import com.mydeck.app.domain.content.ContentPackageManager
 import com.mydeck.app.domain.sync.OfflinePolicyEvaluator
@@ -164,6 +165,8 @@ class BookmarkListViewModel @Inject constructor(
 
     val bookmarkCounts: StateFlow<BookmarkCounts> = bookmarkRepository.observeAllBookmarkCounts()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), BookmarkCounts(0, 0, 0, 0))
+
+    val swipeConfig: StateFlow<SwipeConfig> = settingsDataStore.swipeConfigFlow
 
     private val loadBookmarksWorkInfos: StateFlow<List<WorkInfo>> =
         workManager.getWorkInfosForUniqueWorkFlow(LoadBookmarksWorker.UNIQUE_WORK_NAME)

--- a/app/src/main/java/com/mydeck/app/ui/list/SwipeableCardContainer.kt
+++ b/app/src/main/java/com/mydeck/app/ui/list/SwipeableCardContainer.kt
@@ -1,0 +1,349 @@
+package com.mydeck.app.ui.list
+
+import androidx.compose.animation.core.animate
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.draggable
+import androidx.compose.foundation.gestures.rememberDraggableState
+import androidx.compose.foundation.gestures.waitForUpOrCancellation
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.calculateStartPadding
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemGestures
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Archive
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Favorite
+import android.os.Build
+import androidx.compose.material3.Card
+import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.dynamicLightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.lerp as colorLerp
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.semantics.CustomAccessibilityAction
+import androidx.compose.ui.semantics.customActions
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.util.lerp
+import com.mydeck.app.domain.model.EffectiveAppearance
+import com.mydeck.app.domain.model.SwipeAction
+import com.mydeck.app.domain.model.SwipeConfig
+import com.mydeck.app.ui.theme.LocalEffectiveAppearance
+import com.mydeck.app.ui.theme.PaperColorScheme
+import kotlin.math.abs
+import kotlin.math.roundToInt
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+
+@Composable
+fun SwipeableCardContainer(
+    config: SwipeConfig,
+    onCommitLeft: () -> Unit,
+    onCommitRight: () -> Unit,
+    a11yLeftLabel: String,
+    a11yRightLabel: String,
+    leftAction: SwipeAction = config.leftAction,
+    rightAction: SwipeAction = config.rightAction,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    // Edge gating uses enabled veto (see pointerInput below); multi-column callers pass enabled=false.
+    // No early-return for the disabled case: if config flips disabled mid-drag (e.g. delete pending),
+    // we keep the state machinery alive so the snap-back animates instead of jumping to 0.
+    val effectivelyEnabled = config.enabled &&
+        !(leftAction == SwipeAction.NONE && rightAction == SwipeAction.NONE)
+
+    BoxWithConstraints(modifier) {
+        val density = LocalDensity.current
+        val widthPx = with(density) { maxWidth.toPx() }
+        val commitPx = widthPx * 0.5f
+
+        var offsetX by remember { mutableStateOf(0f) }
+        // Holds the active snap-back job so a new drag or commit can cancel it.
+        val animHolder = remember { object { var job: Job? = null } }
+        // Tracks whether we've fired the threshold-crossed haptic for the current excursion.
+        // Resets when offset returns below threshold so re-crossing re-fires haptic.
+        var hapticTriggered by remember { mutableStateOf(false) }
+        val haptic = LocalHapticFeedback.current
+        val scope = rememberCoroutineScope()
+
+        // Long-lived LaunchedEffect must read latest callbacks/actions, not the
+        // values captured at first launch — otherwise a list-slot recomposition
+        // with a new bookmark fires the prior bookmark's handler.
+        val currentLeftAction by rememberUpdatedState(leftAction)
+        val currentRightAction by rememberUpdatedState(rightAction)
+        val currentOnCommitLeft by rememberUpdatedState(onCommitLeft)
+        val currentOnCommitRight by rememberUpdatedState(onCommitRight)
+
+        // If the container flips effectively-disabled while offset is non-zero (e.g. delete
+        // commit stages pending-delete on the same recomposition that disables swipe), let
+        // any in-flight onDragStopped animation finish; only start one here if nothing is
+        // already animating, so the card glides home instead of jumping.
+        LaunchedEffect(effectivelyEnabled) {
+            if (!effectivelyEnabled && offsetX != 0f && animHolder.job?.isActive != true) {
+                animHolder.job = scope.launch {
+                    animate(offsetX, 0f) { value, _ -> offsetX = value }
+                }
+            }
+        }
+
+        // Threshold-crossing haptic only. Commit dispatch lives in onDragStopped
+        // so the user can drag past, back off, and release without firing.
+        LaunchedEffect(commitPx) {
+            snapshotFlow { offsetX }.collect { off ->
+                val past = abs(off) >= commitPx
+                if (past && !hapticTriggered) {
+                    val goingLeft = off < 0f
+                    val action = if (goingLeft) currentLeftAction else currentRightAction
+                    if (effectivelyEnabled && action != SwipeAction.NONE) {
+                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                    }
+                    hapticTriggered = true
+                } else if (!past && hapticTriggered) {
+                    hapticTriggered = false
+                }
+            }
+        }
+
+        val layoutDir = LocalLayoutDirection.current
+        val startInsetPx = with(density) {
+            WindowInsets.systemGestures.asPaddingValues(this)
+                .calculateStartPadding(layoutDir).toPx()
+        }
+
+        // Edge gating: veto draggable via `enabled` when down lands inside the
+        // start system-gesture inset. Cleaner than consuming events — parent
+        // scroll still receives vertical-drag input from the same pointer.
+        var edgeVeto by remember { mutableStateOf(false) }
+
+        val customActionsList = buildList {
+            if (rightAction != SwipeAction.NONE) {
+                add(CustomAccessibilityAction(a11yRightLabel) { onCommitRight(); true })
+            }
+            if (leftAction != SwipeAction.NONE) {
+                add(CustomAccessibilityAction(a11yLeftLabel) { onCommitLeft(); true })
+            }
+        }
+
+        val colorScheme = MaterialTheme.colorScheme
+        val appearance = LocalEffectiveAppearance.current
+        // Archive uses the system's *light* dynamic primary across all themes so
+        // the shade stays consistent regardless of light/dark mode. Sepia bypasses
+        // dynamic color elsewhere and uses its own palette for Archive.
+        val context = LocalContext.current
+        val lightDynamicScheme = remember(context) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                dynamicLightColorScheme(context)
+            } else {
+                PaperColorScheme
+            }
+        }
+
+        Box(Modifier.fillMaxWidth()) {
+            Box(Modifier.matchParentSize()) {
+                val absOffset = abs(offsetX)
+                val activeAction = when {
+                    offsetX > 0f && rightAction != SwipeAction.NONE -> rightAction
+                    offsetX < 0f && leftAction != SwipeAction.NONE -> leftAction
+                    else -> SwipeAction.NONE
+                }
+
+                if (activeAction != SwipeAction.NONE && absOffset > 0f) {
+                    val progress = (absOffset / commitPx).coerceIn(0f, 1f)
+                    val scale = lerp(0.8f, 1.0f, progress)
+                    val surfaceWidthDp = with(density) { absOffset.toDp() }
+                    val surfaceAlignment =
+                        if (offsetX > 0f) Alignment.CenterStart else Alignment.CenterEnd
+
+                    Box(
+                        contentAlignment = Alignment.Center,
+                        modifier = Modifier
+                            .width(surfaceWidthDp)
+                            .fillMaxHeight()
+                            .align(surfaceAlignment)
+                            .background(
+                                color = backgroundColorFor(activeAction, colorScheme, appearance, lightDynamicScheme),
+                                shape = MaterialTheme.shapes.medium,
+                            ),
+                    ) {
+                        // Icon clips as surface narrows at low offsets; alpha ramp masks clipping below notice threshold.
+                        Icon(
+                            imageVector = iconFor(activeAction),
+                            contentDescription = null,
+                            tint = iconTintFor(activeAction, colorScheme, appearance, lightDynamicScheme),
+                            modifier = Modifier.graphicsLayer {
+                                this.alpha = progress
+                                this.scaleX = scale
+                                this.scaleY = scale
+                            },
+                        )
+                    }
+                }
+            }
+
+            Box(
+                modifier = Modifier
+                    .offset { IntOffset(offsetX.roundToInt(), 0) }
+                    .pointerInput(startInsetPx, effectivelyEnabled) {
+                        if (!effectivelyEnabled) return@pointerInput
+                        awaitEachGesture {
+                            val down = awaitFirstDown(requireUnconsumed = false)
+                            edgeVeto = down.position.x < startInsetPx
+                            waitForUpOrCancellation()
+                            edgeVeto = false
+                        }
+                    }
+                    .draggable(
+                        state = rememberDraggableState { delta ->
+                            animHolder.job?.cancel()
+                            offsetX += delta
+                        },
+                        orientation = Orientation.Horizontal,
+                        enabled = effectivelyEnabled && !edgeVeto,
+                        onDragStopped = { velocity ->
+                            val off = offsetX
+                            val goingLeft = off < 0f
+                            val action = if (goingLeft) currentLeftAction else currentRightAction
+                            val shouldCommit =
+                                action != SwipeAction.NONE && abs(off) >= commitPx
+                            animHolder.job?.cancel()
+                            animHolder.job = scope.launch {
+                                if (shouldCommit) {
+                                    if (goingLeft) currentOnCommitLeft() else currentOnCommitRight()
+                                }
+                                animate(
+                                    initialValue = offsetX,
+                                    targetValue = 0f,
+                                    initialVelocity = velocity,
+                                ) { value, _ -> offsetX = value }
+                            }
+                        },
+                    )
+                    .semantics {
+                        if (effectivelyEnabled && customActionsList.isNotEmpty()) {
+                            customActions = customActionsList
+                        }
+                    },
+            ) {
+                content()
+            }
+        }
+    }
+}
+
+private fun backgroundColorFor(
+    action: SwipeAction,
+    cs: ColorScheme,
+    appearance: EffectiveAppearance,
+    lightDynamic: ColorScheme,
+): Color = when (action) {
+    SwipeAction.ARCHIVE -> when (appearance) {
+        // Paper already runs on the light dynamic palette, but we resolve through
+        // lightDynamic here too so the source of truth is identical to Dark/Black.
+        EffectiveAppearance.PAPER -> lightDynamic.primary
+        // Sepia bypasses dynamic color; keep the curated sepia surface.
+        EffectiveAppearance.SEPIA -> cs.secondaryContainer
+        // Dark/Black: use the *light* dynamic primary so the shade matches Paper
+        // rather than the auto-lightened dark-scheme primary.
+        EffectiveAppearance.DARK, EffectiveAppearance.BLACK -> lightDynamic.primary
+    }
+    // Paper/Sepia: soften the plain error toward errorContainer (20%) so it doesn't
+    // read as alarmingly dark on a light surface. Dark/Black use errorContainer.
+    SwipeAction.DELETE -> if (!appearance.isDark) {
+        colorLerp(cs.error, cs.errorContainer, 0.2f)
+    } else {
+        cs.errorContainer
+    }
+    SwipeAction.FAVORITE -> when (appearance) {
+        EffectiveAppearance.PAPER -> cs.tertiary
+        EffectiveAppearance.SEPIA,
+        EffectiveAppearance.DARK,
+        EffectiveAppearance.BLACK -> cs.tertiaryContainer
+    }
+    SwipeAction.NONE -> Color.Transparent
+}
+
+private fun iconTintFor(
+    action: SwipeAction,
+    cs: ColorScheme,
+    appearance: EffectiveAppearance,
+    lightDynamic: ColorScheme,
+): Color = when (action) {
+    SwipeAction.ARCHIVE -> when (appearance) {
+        EffectiveAppearance.PAPER -> lightDynamic.onPrimary
+        EffectiveAppearance.SEPIA -> cs.onSecondaryContainer
+        EffectiveAppearance.DARK, EffectiveAppearance.BLACK -> lightDynamic.onPrimary
+    }
+    SwipeAction.DELETE -> if (!appearance.isDark) cs.onError else cs.onErrorContainer
+    SwipeAction.FAVORITE -> when (appearance) {
+        EffectiveAppearance.PAPER -> cs.onTertiary
+        EffectiveAppearance.SEPIA,
+        EffectiveAppearance.DARK,
+        EffectiveAppearance.BLACK -> cs.onTertiaryContainer
+    }
+    SwipeAction.NONE -> Color.Unspecified
+}
+
+private fun iconFor(action: SwipeAction): ImageVector =
+    when (action) {
+        SwipeAction.ARCHIVE -> Icons.Filled.Archive
+        SwipeAction.DELETE -> Icons.Filled.Delete
+        SwipeAction.FAVORITE -> Icons.Filled.Favorite
+        SwipeAction.NONE -> Icons.Filled.Archive
+    }
+
+@Preview(showBackground = true, widthDp = 360)
+@Composable
+private fun SwipeableCardContainerPreview() {
+    SwipeableCardContainer(
+        config = SwipeConfig.Default,
+        onCommitLeft = {},
+        onCommitRight = {},
+        a11yLeftLabel = "Delete",
+        a11yRightLabel = "Archive",
+    ) {
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+        ) {
+            Text(
+                text = "Sample bookmark card",
+                modifier = Modifier.padding(16.dp),
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/mydeck/app/ui/settings/UiSettingsScreen.kt
+++ b/app/src/main/java/com/mydeck/app/ui/settings/UiSettingsScreen.kt
@@ -18,6 +18,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -32,13 +34,18 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
-import kotlinx.coroutines.flow.collectLatest
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import kotlinx.coroutines.flow.collectLatest
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
@@ -53,6 +60,8 @@ import com.mydeck.app.R
 import com.mydeck.app.domain.model.BookmarkShareFormat
 import com.mydeck.app.domain.model.DarkAppearance
 import com.mydeck.app.domain.model.LightAppearance
+import com.mydeck.app.domain.model.SwipeAction
+import com.mydeck.app.domain.model.SwipeConfig
 import com.mydeck.app.domain.model.Theme
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalPermissionsApi::class)
@@ -62,6 +71,7 @@ fun UiSettingsScreen(
 ) {
     val viewModel: UiSettingsViewModel = hiltViewModel()
     val settingsUiState = viewModel.uiState.collectAsState().value
+    val swipeConfig = viewModel.swipeConfig.collectAsState().value
     val onClickBack: () -> Unit = { viewModel.onClickBack() }
     val onThemeModeSelected: (Theme) -> Unit = { viewModel.onThemeModeSelected(it) }
     val onLightAppearanceSelected: (LightAppearance) -> Unit = { viewModel.onLightAppearanceSelected(it) }
@@ -93,7 +103,11 @@ fun UiSettingsScreen(
         onBookmarkShareFormatSelected = onBookmarkShareFormatSelected,
         onKeepScreenOnWhileReadingToggled = onKeepScreenOnWhileReadingToggled,
         onFullscreenWhileReadingToggled = onFullscreenWhileReadingToggled,
-        settingsUiState = settingsUiState
+        settingsUiState = settingsUiState,
+        swipeConfig = swipeConfig,
+        onSwipeEnabledChange = { viewModel.onSwipeEnabledChange(it) },
+        onSwipeLeftActionChange = { viewModel.onSwipeLeftActionChange(it) },
+        onSwipeRightActionChange = { viewModel.onSwipeRightActionChange(it) },
     )
 }
 
@@ -110,6 +124,10 @@ fun UiSettingsView(
     onKeepScreenOnWhileReadingToggled: (Boolean) -> Unit,
     onFullscreenWhileReadingToggled: (Boolean) -> Unit,
     onClickBack: () -> Unit,
+    swipeConfig: SwipeConfig = SwipeConfig.Default,
+    onSwipeEnabledChange: (Boolean) -> Unit = {},
+    onSwipeLeftActionChange: (SwipeAction) -> Unit = {},
+    onSwipeRightActionChange: (SwipeAction) -> Unit = {},
 ) {
     Scaffold(
         modifier = modifier,
@@ -299,6 +317,45 @@ fun UiSettingsView(
                     )
                 }
             )
+
+            // Swipe actions section
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(0.dp)
+            ) {
+                Text(
+                    text = stringResource(R.string.swipe_settings_section_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.padding(horizontal = 0.dp, vertical = 4.dp)
+                )
+                ListItem(
+                    modifier = Modifier.clickable { onSwipeEnabledChange(!swipeConfig.enabled) },
+                    headlineContent = {
+                        Text(
+                            text = stringResource(R.string.swipe_settings_enable),
+                            style = MaterialTheme.typography.bodyLarge
+                        )
+                    },
+                    trailingContent = {
+                        Switch(
+                            checked = swipeConfig.enabled,
+                            onCheckedChange = onSwipeEnabledChange
+                        )
+                    }
+                )
+                SwipeActionPicker(
+                    label = stringResource(R.string.swipe_settings_left_action),
+                    selected = swipeConfig.leftAction,
+                    enabled = swipeConfig.enabled,
+                    onActionSelected = onSwipeLeftActionChange,
+                )
+                SwipeActionPicker(
+                    label = stringResource(R.string.swipe_settings_right_action),
+                    selected = swipeConfig.rightAction,
+                    enabled = swipeConfig.enabled,
+                    onActionSelected = onSwipeRightActionChange,
+                )
+            }
         }
     }
 }
@@ -328,6 +385,56 @@ fun UiSettingsScreenViewPreview() {
         onKeepScreenOnWhileReadingToggled = {},
         onFullscreenWhileReadingToggled = {},
         settingsUiState = settingsUiState
+    )
+}
+
+@Composable
+private fun SwipeAction.displayName(): String = stringResource(
+    when (this) {
+        SwipeAction.ARCHIVE -> R.string.swipe_action_archive
+        SwipeAction.DELETE -> R.string.swipe_action_delete
+        SwipeAction.FAVORITE -> R.string.swipe_action_favorite
+        SwipeAction.NONE -> R.string.swipe_action_none
+    }
+)
+
+@Composable
+private fun SwipeActionPicker(
+    label: String,
+    selected: SwipeAction,
+    enabled: Boolean,
+    onActionSelected: (SwipeAction) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    ListItem(
+        modifier = Modifier.alpha(if (enabled) 1f else 0.38f),
+        headlineContent = {
+            Text(text = label, style = MaterialTheme.typography.bodyLarge)
+        },
+        trailingContent = {
+            Box {
+                TextButton(
+                    onClick = { if (enabled) expanded = true },
+                    enabled = enabled,
+                ) {
+                    Text(selected.displayName())
+                }
+                DropdownMenu(
+                    expanded = expanded,
+                    onDismissRequest = { expanded = false }
+                ) {
+                    SwipeAction.entries.forEach { action ->
+                        DropdownMenuItem(
+                            text = { Text(action.displayName()) },
+                            onClick = {
+                                onActionSelected(action)
+                                expanded = false
+                            }
+                        )
+                    }
+                }
+            }
+        }
     )
 }
 

--- a/app/src/main/java/com/mydeck/app/ui/settings/UiSettingsViewModel.kt
+++ b/app/src/main/java/com/mydeck/app/ui/settings/UiSettingsViewModel.kt
@@ -12,6 +12,8 @@ import com.mydeck.app.R
 import com.mydeck.app.domain.model.BookmarkShareFormat
 import com.mydeck.app.domain.model.DarkAppearance
 import com.mydeck.app.domain.model.LightAppearance
+import com.mydeck.app.domain.model.SwipeAction
+import com.mydeck.app.domain.model.SwipeConfig
 import com.mydeck.app.domain.model.Theme
 import com.mydeck.app.io.prefs.SettingsDataStore
 import kotlinx.coroutines.channels.Channel
@@ -147,6 +149,20 @@ class UiSettingsViewModel @Inject constructor(
             settingsDataStore.saveFullscreenWhileReading(enabled)
             fullscreenWhileReading.value = settingsDataStore.isFullscreenWhileReading()
         }
+    }
+
+    val swipeConfig: StateFlow<SwipeConfig> = settingsDataStore.swipeConfigFlow
+
+    fun onSwipeEnabledChange(enabled: Boolean) {
+        viewModelScope.launch { settingsDataStore.saveSwipeEnabled(enabled) }
+    }
+
+    fun onSwipeLeftActionChange(action: SwipeAction) {
+        viewModelScope.launch { settingsDataStore.saveSwipeLeftAction(action) }
+    }
+
+    fun onSwipeRightActionChange(action: SwipeAction) {
+        viewModelScope.launch { settingsDataStore.saveSwipeRightAction(action) }
     }
 
     fun onClickBack() {

--- a/app/src/main/java/com/mydeck/app/ui/shell/AppShell.kt
+++ b/app/src/main/java/com/mydeck/app/ui/shell/AppShell.kt
@@ -212,10 +212,15 @@ private fun CompactAppShell(
     // Only allow swipe-to-open drawer gesture on BookmarkListScreen (matches original behavior)
     val currentBackStackEntry = navController.currentBackStackEntryAsState().value
     val isOnBookmarkList = currentBackStackEntry?.destination.matchesRoute<BookmarkListRoute>()
+    val swipeConfig = bookmarkListViewModel.swipeConfig.collectAsState()
 
     ModalNavigationDrawer(
         drawerState = drawerState,
-        gesturesEnabled = isOnBookmarkList,
+        // Suppress drawer-swipe-to-open when card swipe is enabled, but keep gestures
+        // live once the drawer is already open so scrim-tap and swipe-close still work.
+        gesturesEnabled = drawerState.isOpen
+            || !isOnBookmarkList
+            || !swipeConfig.value.enabled,
         drawerContent = {
             AppDrawerContent(
                 drawerPreset = drawerPreset,

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -429,6 +429,17 @@ other{}
     <string name="ui_settings_fullscreen_reading_description">Hides the top bar and system bars while you read</string>
     <string name="ui_settings_keep_screen_on_title">Keep screen on while reading</string>
     <string name="ui_settings_keep_screen_on_description">Prevents the screen from turning off while you read</string>
+    <string name="swipe_settings_section_title">Swipe actions</string>
+    <string name="swipe_settings_enable">Enable swipe actions</string>
+    <string name="swipe_settings_left_action">Swipe left action</string>
+    <string name="swipe_settings_right_action">Swipe right action</string>
+    <string name="swipe_action_archive">Archive</string>
+    <string name="swipe_action_delete">Delete</string>
+    <string name="swipe_action_favorite">Favorite</string>
+    <string name="swipe_action_none">None</string>
+    <string name="swipe_a11y_archive">Archive bookmark</string>
+    <string name="swipe_a11y_delete">Delete bookmark</string>
+    <string name="swipe_a11y_favorite">Toggle favorite</string>
     <string name="select_bookmark">Select a bookmark to read</string>
     <string name="long_press_for_options">Long press for options</string>
     <string name="label_suggestion_hint">Suggestions</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -124,6 +124,17 @@ other{}
     <string name="ui_settings_fullscreen_reading_description">Hides the top bar and system bars while you read</string>
     <string name="ui_settings_keep_screen_on_title">Mantener la pantalla encendida mientras se lee</string>
     <string name="ui_settings_keep_screen_on_description">Evita que la pantalla se apague mientras lees</string>
+    <string name="swipe_settings_section_title">Swipe actions</string>
+    <string name="swipe_settings_enable">Enable swipe actions</string>
+    <string name="swipe_settings_left_action">Swipe left action</string>
+    <string name="swipe_settings_right_action">Swipe right action</string>
+    <string name="swipe_action_archive">Archive</string>
+    <string name="swipe_action_delete">Delete</string>
+    <string name="swipe_action_favorite">Favorite</string>
+    <string name="swipe_action_none">None</string>
+    <string name="swipe_a11y_archive">Archive bookmark</string>
+    <string name="swipe_a11y_delete">Delete bookmark</string>
+    <string name="swipe_a11y_favorite">Toggle favorite</string>
     <string name="action_open_in_browser">Abrir en el navegador</string>
     <string name="detail_view_no_content">No se encontró contenido del artículo</string>
     <string name="auto_sync_notification_rationale_dialog_grant_button">Dar permiso</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -285,6 +285,17 @@
     <string name="ui_settings_fullscreen_reading_description">Hides the top bar and system bars while you read</string>
     <string name="ui_settings_keep_screen_on_title">Keep screen on while reading</string>
     <string name="ui_settings_keep_screen_on_description">Prevents the screen from turning off while you read</string>
+    <string name="swipe_settings_section_title">Swipe actions</string>
+    <string name="swipe_settings_enable">Enable swipe actions</string>
+    <string name="swipe_settings_left_action">Swipe left action</string>
+    <string name="swipe_settings_right_action">Swipe right action</string>
+    <string name="swipe_action_archive">Archive</string>
+    <string name="swipe_action_delete">Delete</string>
+    <string name="swipe_action_favorite">Favorite</string>
+    <string name="swipe_action_none">None</string>
+    <string name="swipe_a11y_archive">Archive bookmark</string>
+    <string name="swipe_a11y_delete">Delete bookmark</string>
+    <string name="swipe_a11y_favorite">Toggle favorite</string>
     <string name="select_bookmark">Select a bookmark to read</string>
     <string name="long_press_for_options">Long press for options</string>
     <string name="label_suggestion_hint">Suggestions</string>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -352,6 +352,17 @@ other{}
     <string name="ui_settings_fullscreen_reading_description">Hides the top bar and system bars while you read</string>
     <string name="ui_settings_keep_screen_on_title">Keep screen on while reading</string>
     <string name="ui_settings_keep_screen_on_description">Prevents the screen from turning off while you read</string>
+    <string name="swipe_settings_section_title">Swipe actions</string>
+    <string name="swipe_settings_enable">Enable swipe actions</string>
+    <string name="swipe_settings_left_action">Swipe left action</string>
+    <string name="swipe_settings_right_action">Swipe right action</string>
+    <string name="swipe_action_archive">Archive</string>
+    <string name="swipe_action_delete">Delete</string>
+    <string name="swipe_action_favorite">Favorite</string>
+    <string name="swipe_action_none">None</string>
+    <string name="swipe_a11y_archive">Archive bookmark</string>
+    <string name="swipe_a11y_delete">Delete bookmark</string>
+    <string name="swipe_a11y_favorite">Toggle favorite</string>
     <string name="select_bookmark">Select a bookmark to read</string>
     <string name="long_press_for_options">Long press for options</string>
     <string name="label_suggestion_hint">Suggestions</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -285,6 +285,17 @@
     <string name="ui_settings_fullscreen_reading_description">Hides the top bar and system bars while you read</string>
     <string name="ui_settings_keep_screen_on_title">Keep screen on while reading</string>
     <string name="ui_settings_keep_screen_on_description">Prevents the screen from turning off while you read</string>
+    <string name="swipe_settings_section_title">Swipe actions</string>
+    <string name="swipe_settings_enable">Enable swipe actions</string>
+    <string name="swipe_settings_left_action">Swipe left action</string>
+    <string name="swipe_settings_right_action">Swipe right action</string>
+    <string name="swipe_action_archive">Archive</string>
+    <string name="swipe_action_delete">Delete</string>
+    <string name="swipe_action_favorite">Favorite</string>
+    <string name="swipe_action_none">None</string>
+    <string name="swipe_a11y_archive">Archive bookmark</string>
+    <string name="swipe_a11y_delete">Delete bookmark</string>
+    <string name="swipe_a11y_favorite">Toggle favorite</string>
     <string name="select_bookmark">Select a bookmark to read</string>
     <string name="long_press_for_options">Long press for options</string>
     <string name="label_suggestion_hint">Suggestions</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -285,6 +285,17 @@
     <string name="ui_settings_fullscreen_reading_description">Hides the top bar and system bars while you read</string>
     <string name="ui_settings_keep_screen_on_title">Keep screen on while reading</string>
     <string name="ui_settings_keep_screen_on_description">Prevents the screen from turning off while you read</string>
+    <string name="swipe_settings_section_title">Swipe actions</string>
+    <string name="swipe_settings_enable">Enable swipe actions</string>
+    <string name="swipe_settings_left_action">Swipe left action</string>
+    <string name="swipe_settings_right_action">Swipe right action</string>
+    <string name="swipe_action_archive">Archive</string>
+    <string name="swipe_action_delete">Delete</string>
+    <string name="swipe_action_favorite">Favorite</string>
+    <string name="swipe_action_none">None</string>
+    <string name="swipe_a11y_archive">Archive bookmark</string>
+    <string name="swipe_a11y_delete">Delete bookmark</string>
+    <string name="swipe_a11y_favorite">Toggle favorite</string>
     <string name="select_bookmark">Select a bookmark to read</string>
     <string name="long_press_for_options">Long press for options</string>
     <string name="label_suggestion_hint">Suggestions</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -285,6 +285,17 @@
     <string name="ui_settings_fullscreen_reading_description">Hides the top bar and system bars while you read</string>
     <string name="ui_settings_keep_screen_on_title">Keep screen on while reading</string>
     <string name="ui_settings_keep_screen_on_description">Prevents the screen from turning off while you read</string>
+    <string name="swipe_settings_section_title">Swipe actions</string>
+    <string name="swipe_settings_enable">Enable swipe actions</string>
+    <string name="swipe_settings_left_action">Swipe left action</string>
+    <string name="swipe_settings_right_action">Swipe right action</string>
+    <string name="swipe_action_archive">Archive</string>
+    <string name="swipe_action_delete">Delete</string>
+    <string name="swipe_action_favorite">Favorite</string>
+    <string name="swipe_action_none">None</string>
+    <string name="swipe_a11y_archive">Archive bookmark</string>
+    <string name="swipe_a11y_delete">Delete bookmark</string>
+    <string name="swipe_a11y_favorite">Toggle favorite</string>
     <string name="select_bookmark">Select a bookmark to read</string>
     <string name="long_press_for_options">Long press for options</string>
     <string name="label_suggestion_hint">Suggestions</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -285,6 +285,17 @@
     <string name="ui_settings_fullscreen_reading_description">Hides the top bar and system bars while you read</string>
     <string name="ui_settings_keep_screen_on_title">Keep screen on while reading</string>
     <string name="ui_settings_keep_screen_on_description">Prevents the screen from turning off while you read</string>
+    <string name="swipe_settings_section_title">Swipe actions</string>
+    <string name="swipe_settings_enable">Enable swipe actions</string>
+    <string name="swipe_settings_left_action">Swipe left action</string>
+    <string name="swipe_settings_right_action">Swipe right action</string>
+    <string name="swipe_action_archive">Archive</string>
+    <string name="swipe_action_delete">Delete</string>
+    <string name="swipe_action_favorite">Favorite</string>
+    <string name="swipe_action_none">None</string>
+    <string name="swipe_a11y_archive">Archive bookmark</string>
+    <string name="swipe_a11y_delete">Delete bookmark</string>
+    <string name="swipe_a11y_favorite">Toggle favorite</string>
     <string name="select_bookmark">Select a bookmark to read</string>
     <string name="long_press_for_options">Long press for options</string>
     <string name="label_suggestion_hint">Suggestions</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -111,6 +111,17 @@
     <string name="ui_settings_fullscreen_reading_description">Hides the top bar and system bars while you read</string>
     <string name="ui_settings_keep_screen_on_title">Keep screen on while reading</string>
     <string name="ui_settings_keep_screen_on_description">Prevents the screen from turning off while you read</string>
+    <string name="swipe_settings_section_title">Swipe actions</string>
+    <string name="swipe_settings_enable">Enable swipe actions</string>
+    <string name="swipe_settings_left_action">Swipe left action</string>
+    <string name="swipe_settings_right_action">Swipe right action</string>
+    <string name="swipe_action_archive">Archive</string>
+    <string name="swipe_action_delete">Delete</string>
+    <string name="swipe_action_favorite">Favorite</string>
+    <string name="swipe_action_none">None</string>
+    <string name="swipe_a11y_archive">Archive bookmark</string>
+    <string name="swipe_a11y_delete">Delete bookmark</string>
+    <string name="swipe_a11y_favorite">Toggle favorite</string>
     <string name="action_favorite">收藏</string>
     <string name="action_archive">存档</string>
     <string name="action_add_to_favorites">添加到收藏</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -125,6 +125,17 @@ other{}
     <string name="ui_settings_fullscreen_reading_description">Hides the top bar and system bars while you read</string>
     <string name="ui_settings_keep_screen_on_title">Keep screen on while reading</string>
     <string name="ui_settings_keep_screen_on_description">Prevents the screen from turning off while you read</string>
+    <string name="swipe_settings_section_title">Swipe actions</string>
+    <string name="swipe_settings_enable">Enable swipe actions</string>
+    <string name="swipe_settings_left_action">Swipe left action</string>
+    <string name="swipe_settings_right_action">Swipe right action</string>
+    <string name="swipe_action_archive">Archive</string>
+    <string name="swipe_action_delete">Delete</string>
+    <string name="swipe_action_favorite">Favorite</string>
+    <string name="swipe_action_none">None</string>
+    <string name="swipe_a11y_archive">Archive bookmark</string>
+    <string name="swipe_a11y_delete">Delete bookmark</string>
+    <string name="swipe_a11y_favorite">Toggle favorite</string>
 
     <!-- Bookmark Card Actions -->
     <string name="action_favorite">Favorite</string>

--- a/app/src/test/java/com/mydeck/app/domain/model/SwipeConfigTest.kt
+++ b/app/src/test/java/com/mydeck/app/domain/model/SwipeConfigTest.kt
@@ -1,0 +1,27 @@
+package com.mydeck.app.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SwipeConfigTest {
+
+    @Test
+    fun `Default enables swipe with delete left and archive right`() {
+        val default = SwipeConfig.Default
+
+        assertTrue(default.enabled)
+        assertEquals(SwipeAction.DELETE, default.leftAction)
+        assertEquals(SwipeAction.ARCHIVE, default.rightAction)
+    }
+
+    @Test
+    fun `copy with enabled false produces disabled pass-through config`() {
+        val disabled = SwipeConfig.Default.copy(enabled = false)
+
+        assertFalse(disabled.enabled)
+        assertEquals(SwipeConfig.Default.leftAction, disabled.leftAction)
+        assertEquals(SwipeConfig.Default.rightAction, disabled.rightAction)
+    }
+}

--- a/app/src/test/java/com/mydeck/app/io/prefs/SettingsDataStoreImplTest.kt
+++ b/app/src/test/java/com/mydeck/app/io/prefs/SettingsDataStoreImplTest.kt
@@ -6,6 +6,8 @@ import androidx.test.core.app.ApplicationProvider
 import com.mydeck.app.domain.model.BookmarkShareFormat
 import com.mydeck.app.domain.model.DarkAppearance
 import com.mydeck.app.domain.model.LightAppearance
+import com.mydeck.app.domain.model.SwipeAction
+import com.mydeck.app.domain.model.SwipeConfig
 import com.mydeck.app.domain.model.TypographySettings
 import com.mydeck.app.domain.model.Theme
 import com.mydeck.app.domain.sync.OfflineContentScope
@@ -233,5 +235,58 @@ class SettingsDataStoreImplTest {
         val dataStore = SettingsDataStoreImpl(context)
 
         assertEquals(250L * 1024 * 1024, dataStore.getOfflinePolicyStorageLimit())
+    }
+
+    @Test
+    fun `swipeConfig defaults match SwipeConfig Default`() = runTest {
+        val dataStore = SettingsDataStoreImpl(context)
+
+        assertEquals(SwipeConfig.Default, dataStore.swipeConfigFlow.value)
+    }
+
+    @Test
+    fun `saveSwipeEnabled round-trips enabled flag`() = runTest {
+        val dataStore = SettingsDataStoreImpl(context)
+
+        dataStore.saveSwipeEnabled(false)
+        assertFalse(dataStore.swipeConfigFlow.value.enabled)
+
+        dataStore.saveSwipeEnabled(true)
+        assertTrue(dataStore.swipeConfigFlow.value.enabled)
+    }
+
+    @Test
+    fun `saveSwipeLeftAction round-trips action`() = runTest {
+        val dataStore = SettingsDataStoreImpl(context)
+
+        dataStore.saveSwipeLeftAction(SwipeAction.ARCHIVE)
+        assertEquals(SwipeAction.ARCHIVE, dataStore.swipeConfigFlow.value.leftAction)
+
+        dataStore.saveSwipeLeftAction(SwipeAction.NONE)
+        assertEquals(SwipeAction.NONE, dataStore.swipeConfigFlow.value.leftAction)
+    }
+
+    @Test
+    fun `saveSwipeRightAction round-trips action`() = runTest {
+        val dataStore = SettingsDataStoreImpl(context)
+
+        dataStore.saveSwipeRightAction(SwipeAction.DELETE)
+        assertEquals(SwipeAction.DELETE, dataStore.swipeConfigFlow.value.rightAction)
+
+        dataStore.saveSwipeRightAction(SwipeAction.FAVORITE)
+        assertEquals(SwipeAction.FAVORITE, dataStore.swipeConfigFlow.value.rightAction)
+    }
+
+    @Test
+    fun `swipeConfig falls back to default when stored action string is corrupted`() = runTest {
+        userPreferences.edit()
+            .putString("swipe_left_action", "INVALID_ACTION")
+            .putString("swipe_right_action", "ALSO_INVALID")
+            .commit()
+
+        val dataStore = SettingsDataStoreImpl(context)
+
+        assertEquals(SwipeConfig.Default.leftAction, dataStore.swipeConfigFlow.value.leftAction)
+        assertEquals(SwipeConfig.Default.rightAction, dataStore.swipeConfigFlow.value.rightAction)
     }
 }

--- a/app/src/test/java/com/mydeck/app/ui/list/BookmarkListViewModelTest.kt
+++ b/app/src/test/java/com/mydeck/app/ui/list/BookmarkListViewModelTest.kt
@@ -17,6 +17,7 @@ import com.mydeck.app.domain.sync.OfflinePolicyEvaluator
 import com.mydeck.app.domain.sync.SyncScheduler
 import com.mydeck.app.domain.usecase.FullSyncUseCase
 import com.mydeck.app.domain.usecase.UpdateBookmarkUseCase
+import com.mydeck.app.domain.model.SwipeConfig
 import com.mydeck.app.io.prefs.SettingsDataStore
 import com.mydeck.app.worker.CreateBookmarkWorker
 import com.mydeck.app.worker.LoadBookmarksWorker
@@ -126,6 +127,7 @@ class BookmarkListViewModelTest {
         every { connectivityMonitor.isBatterySaverOn() } returns false
         coEvery { settingsDataStore.getLayoutMode() } returns null
         coEvery { settingsDataStore.getSortOption() } returns null
+        every { settingsDataStore.swipeConfigFlow } returns kotlinx.coroutines.flow.MutableStateFlow(SwipeConfig.Default)
         coEvery { settingsDataStore.getBookmarkShareFormat() } returns BookmarkShareFormat.URL_ONLY
         every { settingsDataStore.urlFlow } returns kotlinx.coroutines.flow.MutableStateFlow(null)
         every { settingsDataStore.tokenFlow } returns kotlinx.coroutines.flow.MutableStateFlow(null)

--- a/app/src/test/java/com/mydeck/app/ui/list/SwipeableCardContainerTest.kt
+++ b/app/src/test/java/com/mydeck/app/ui/list/SwipeableCardContainerTest.kt
@@ -1,0 +1,305 @@
+package com.mydeck.app.ui.list
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.longClick
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipe
+import androidx.compose.ui.test.swipeDown
+import androidx.compose.ui.test.swipeLeft
+import androidx.compose.ui.test.swipeRight
+import androidx.compose.ui.unit.dp
+import com.mydeck.app.domain.model.SwipeAction
+import com.mydeck.app.domain.model.SwipeConfig
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import dagger.hilt.android.testing.HiltTestApplication
+import dagger.hilt.android.testing.UninstallModules
+import com.mydeck.app.io.rest.NetworkModule
+import java.util.concurrent.atomic.AtomicInteger
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@OptIn(ExperimentalComposeUiApi::class, ExperimentalFoundationApi::class)
+@RunWith(RobolectricTestRunner::class)
+@HiltAndroidTest
+@Config(application = HiltTestApplication::class, sdk = [34])
+@UninstallModules(NetworkModule::class)
+class SwipeableCardContainerTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @get:Rule
+    val hiltRule = HiltAndroidRule(this)
+
+    @Before
+    fun setup() {
+        hiltRule.inject()
+    }
+
+    private val wrapperTag = "swipe-wrapper"
+    private val contentTag = "swipe-content"
+
+    private fun setSwipeable(
+        config: SwipeConfig = SwipeConfig.Default,
+        leftCounter: AtomicInteger = AtomicInteger(0),
+        rightCounter: AtomicInteger = AtomicInteger(0),
+        contentBuilder: @Composable () -> Unit = {
+            Box(
+                Modifier
+                    .testTag(contentTag)
+                    .fillMaxSize()
+                    .background(Color.LightGray),
+            ) { Text("card") }
+        },
+    ) {
+        composeTestRule.setContent {
+            Box(
+                Modifier
+                    .testTag(wrapperTag)
+                    .width(300.dp)
+                    .height(120.dp),
+            ) {
+                SwipeableCardContainer(
+                    config = config,
+                    onCommitLeft = { leftCounter.incrementAndGet() },
+                    onCommitRight = { rightCounter.incrementAndGet() },
+                    a11yLeftLabel = "left",
+                    a11yRightLabel = "right",
+                ) { contentBuilder() }
+            }
+        }
+    }
+
+    @Test
+    fun tap_propagates_to_content_without_committing() {
+        val tapped = AtomicInteger(0)
+        val left = AtomicInteger(0)
+        val right = AtomicInteger(0)
+        setSwipeable(
+            leftCounter = left,
+            rightCounter = right,
+            contentBuilder = {
+                Box(
+                    Modifier
+                        .testTag(contentTag)
+                        .fillMaxSize()
+                        .clickable { tapped.incrementAndGet() }
+                        .background(Color.LightGray),
+                ) { Text("card") }
+            },
+        )
+
+        composeTestRule.onNodeWithTag(contentTag).performClick()
+        composeTestRule.waitForIdle()
+
+        assertEquals(1, tapped.get())
+        assertEquals(0, left.get())
+        assertEquals(0, right.get())
+    }
+
+    @Test
+    fun long_press_propagates_to_content_without_committing() {
+        val longPressed = AtomicInteger(0)
+        val left = AtomicInteger(0)
+        val right = AtomicInteger(0)
+        setSwipeable(
+            leftCounter = left,
+            rightCounter = right,
+            contentBuilder = {
+                val interaction = remember { MutableInteractionSource() }
+                Box(
+                    Modifier
+                        .testTag(contentTag)
+                        .fillMaxSize()
+                        .combinedClickable(
+                            interactionSource = interaction,
+                            indication = null,
+                            onClick = {},
+                            onLongClick = { longPressed.incrementAndGet() },
+                        )
+                        .background(Color.LightGray),
+                ) { Text("card") }
+            },
+        )
+
+        composeTestRule.onNodeWithTag(contentTag).performTouchInput { longClick() }
+        composeTestRule.waitForIdle()
+
+        assertEquals(1, longPressed.get())
+        assertEquals(0, left.get())
+        assertEquals(0, right.get())
+    }
+
+    @Test
+    fun vertical_drag_does_not_commit() {
+        val left = AtomicInteger(0)
+        val right = AtomicInteger(0)
+        setSwipeable(leftCounter = left, rightCounter = right)
+
+        composeTestRule.onNodeWithTag(wrapperTag).performTouchInput { swipeDown() }
+        composeTestRule.waitForIdle()
+
+        assertEquals(0, left.get())
+        assertEquals(0, right.get())
+    }
+
+    @Test
+    fun horizontal_swipe_left_past_threshold_fires_left_commit_once_per_gesture() {
+        val left = AtomicInteger(0)
+        val right = AtomicInteger(0)
+        setSwipeable(leftCounter = left, rightCounter = right)
+
+        composeTestRule.onNodeWithTag(wrapperTag).performTouchInput { swipeLeft() }
+        composeTestRule.waitForIdle()
+        assertEquals("first gesture fires once", 1, left.get())
+        assertEquals(0, right.get())
+
+        composeTestRule.onNodeWithTag(wrapperTag).performTouchInput { swipeLeft() }
+        composeTestRule.waitForIdle()
+        assertEquals("second gesture fires once more, not multiplied", 2, left.get())
+        assertEquals(0, right.get())
+    }
+
+    @Test
+    fun horizontal_swipe_right_past_threshold_fires_right_commit_once_per_gesture() {
+        val left = AtomicInteger(0)
+        val right = AtomicInteger(0)
+        setSwipeable(leftCounter = left, rightCounter = right)
+
+        composeTestRule.onNodeWithTag(wrapperTag).performTouchInput { swipeRight() }
+        composeTestRule.waitForIdle()
+        assertEquals(0, left.get())
+        assertEquals(1, right.get())
+    }
+
+    @Test
+    fun horizontal_drag_below_threshold_does_not_commit() {
+        val left = AtomicInteger(0)
+        val right = AtomicInteger(0)
+        setSwipeable(leftCounter = left, rightCounter = right)
+
+        // Move from the right side of the card leftward by ~35% of the width — well
+        // below the 50% commit threshold; verifies the snap-back path.
+        composeTestRule.onNodeWithTag(wrapperTag).performTouchInput {
+            swipe(
+                start = Offset(width * 0.85f, height / 2f),
+                end = Offset(width * 0.50f, height / 2f),
+                durationMillis = 200,
+            )
+        }
+        composeTestRule.waitForIdle()
+
+        assertEquals(0, left.get())
+        assertEquals(0, right.get())
+    }
+
+    @Test
+    fun disabled_config_passes_through_without_committing() {
+        val left = AtomicInteger(0)
+        val right = AtomicInteger(0)
+        val tapped = AtomicInteger(0)
+        setSwipeable(
+            config = SwipeConfig.Default.copy(enabled = false),
+            leftCounter = left,
+            rightCounter = right,
+            contentBuilder = {
+                Box(
+                    Modifier
+                        .testTag(contentTag)
+                        .fillMaxSize()
+                        .clickable { tapped.incrementAndGet() }
+                        .background(Color.LightGray),
+                ) { Text("card") }
+            },
+        )
+
+        // Tap must still flow to the underlying clickable.
+        composeTestRule.onNodeWithTag(contentTag).performClick()
+        composeTestRule.waitForIdle()
+        val tappedAfterClick = tapped.get()
+        assertEquals("inner clickable still receives taps", 1, tappedAfterClick)
+
+        // Swiping does not fire either commit; the gesture passes through to
+        // whatever the content does with it (possibly nothing, possibly more
+        // taps — that's the content's business, not ours).
+        composeTestRule.onNodeWithTag(wrapperTag).performTouchInput { swipeLeft() }
+        composeTestRule.waitForIdle()
+        assertEquals(0, left.get())
+        assertEquals(0, right.get())
+    }
+
+    @Test
+    fun both_directions_none_passes_through_without_committing() {
+        val left = AtomicInteger(0)
+        val right = AtomicInteger(0)
+        setSwipeable(
+            config = SwipeConfig(
+                enabled = true,
+                leftAction = SwipeAction.NONE,
+                rightAction = SwipeAction.NONE,
+            ),
+            leftCounter = left,
+            rightCounter = right,
+        )
+
+        composeTestRule.onNodeWithTag(wrapperTag).performTouchInput { swipeLeft() }
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(wrapperTag).performTouchInput { swipeRight() }
+        composeTestRule.waitForIdle()
+
+        assertEquals(0, left.get())
+        assertEquals(0, right.get())
+    }
+
+    @Test
+    fun one_direction_none_is_inert_in_that_direction_only() {
+        val left = AtomicInteger(0)
+        val right = AtomicInteger(0)
+        setSwipeable(
+            config = SwipeConfig(
+                enabled = true,
+                leftAction = SwipeAction.NONE,
+                rightAction = SwipeAction.ARCHIVE,
+            ),
+            leftCounter = left,
+            rightCounter = right,
+        )
+
+        // Right (mapped) fires.
+        composeTestRule.onNodeWithTag(wrapperTag).performTouchInput { swipeRight() }
+        composeTestRule.waitForIdle()
+        assertEquals(1, right.get())
+        assertEquals(0, left.get())
+
+        // Left (NONE) does not.
+        composeTestRule.onNodeWithTag(wrapperTag).performTouchInput { swipeLeft() }
+        composeTestRule.waitForIdle()
+        assertEquals(0, left.get())
+        assertEquals(1, right.get())
+    }
+}

--- a/app/src/test/java/com/mydeck/app/ui/settings/UiSettingsViewModelTest.kt
+++ b/app/src/test/java/com/mydeck/app/ui/settings/UiSettingsViewModelTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.mydeck.app.domain.model.BookmarkShareFormat
 import com.mydeck.app.domain.model.DarkAppearance
 import com.mydeck.app.domain.model.LightAppearance
+import com.mydeck.app.domain.model.SwipeConfig
 import com.mydeck.app.domain.model.Theme
 import com.mydeck.app.io.prefs.SettingsDataStore
 import io.mockk.coEvery
@@ -59,6 +60,7 @@ class UiSettingsViewModelTest {
         coEvery { settingsDataStore.saveBookmarkShareFormat(any()) } returns Unit
         coEvery { settingsDataStore.saveKeepScreenOnWhileReading(any()) } returns Unit
         coEvery { settingsDataStore.saveFullscreenWhileReading(any()) } returns Unit
+        every { settingsDataStore.swipeConfigFlow } returns MutableStateFlow(SwipeConfig.Default)
 
         viewModel = UiSettingsViewModel(settingsDataStore, context)
     }

--- a/docs/specs/swipe-actions-for-bookmark-cards-arch-spec.md
+++ b/docs/specs/swipe-actions-for-bookmark-cards-arch-spec.md
@@ -1,0 +1,334 @@
+# **Swipe Gesture Implementation Spec (Architecture-Aligned)**
+
+## **1. Design Principle (Critical)**
+
+Swipe must:
+
+> **Trigger existing action pathways only**
+
+No new ViewModel methods, no alternate mutation logic.
+
+Equivalent mapping:
+
+* Swipe → invokes same handler as action icon click
+* UI reacts via existing observers / flows / adapters
+
+---
+
+## **2. Interaction State Model (UI Layer Only)**
+
+Per card the only durable state is the drag offset; the gesture model is
+commit-only with elastic snap-back, so there is no `Revealed` or
+`Committed` state to persist:
+
+```
+SwipeState:
+  - Idle              (offset == 0)
+  - Dragging(offsetX) (anywhere in between)
+```
+
+Commit fires on `onDragStopped` if `|offset| >= 0.5 * cardWidth` at the
+moment of release. Haptic feedback fires once mid-drag, on the first
+threshold crossing within a gesture, as a commit-ready cue. A boolean
+guard (`hapticConsumed`) prevents repeated haptic on offset jitter near
+the threshold; it resets on settle at Idle. After commit, the drag state
+animates back to Idle. If the user crosses threshold and then drags back
+under it before release, no commit fires — this back-off cancellation is
+an intentional escape hatch.
+
+This state:
+
+* Lives **only in the View layer (Compose)**
+* Must not leak into domain/data layer
+* Is owned by the bookmark card composable, not by the list, scaffold,
+  drawer, rail, or shell
+
+Gesture recognizers must be installed only on bookmark card roots. Do not put
+the recognizer on `LazyColumn`, `LazyVerticalGrid`, the screen scaffold, or any
+navigation container. This prevents tablet navigation areas from participating
+in bookmark-card swipe tracking.
+
+### Layout gating
+
+Swipe is only attached in single-column rendering: phone portrait in any
+layout, or Compact layout on any device. In multi-column grid/mosaic
+layouts (tablet or mobile landscape) the wrap site passes
+`config.copy(enabled = false)` so the container is a pure pass-through.
+
+---
+
+## **3. Gesture Resolution Logic**
+
+### **3.1 Input Arbitration**
+
+On pointer input:
+
+```
+if down started inside system gesture inset:
+    do not track card swipe
+elif abs(dx) > touchSlop AND abs(dx) >= abs(dy) * 1.5:
+    enter SwipeState.Dragging
+    cancel long press
+    consume horizontal deltas
+elif abs(dy) > touchSlop:
+    pass to scroll
+else:
+    continue waiting (long press eligible)
+```
+
+Rules:
+
+* Track passively until the gesture resolves; do not consume pointer movement
+  before swipe intent is locked.
+* Vertical scroll has precedence for ambiguous diagonals.
+* Once scroll wins, card swipe must not start later in the same pointer
+  sequence.
+* Once swipe wins, keep the swipe locked until release/cancel.
+* Use platform touch slop, not a hardcoded pixel value.
+
+Long press:
+
+* Only fires if still in Idle within slop radius
+
+---
+
+### **3.2 System Back and Drawer Policy**
+
+Compact `ModalNavigationDrawer` swipe-open gestures conflict directly with
+rightward card swipes. When swipe actions are enabled, set compact drawer
+gestures to disabled on bookmark-list screens and rely on the existing
+hamburger button to open the drawer.
+
+System back must keep priority at the screen edge:
+
+* Do not start card swipe tracking when the initial pointer is inside the
+  system gesture inset. At minimum, reserve the left inset for the
+  left-to-right back gesture; reserving both horizontal system gesture insets is
+  preferable for Android gesture-navigation consistency.
+* Do not call gesture exclusion APIs for bookmark-card swipe actions.
+* If the pointer starts in the reserved edge area, let the event stream pass to
+  the platform and parent containers.
+
+Compose implementation note: use `WindowInsets.systemGestures` (or the current
+project equivalent) to derive the reserved edge width in pixels for the current
+density/layout direction. Add only a small safety margin if needed; do not
+reserve the whole card padding area.
+
+---
+
+### **3.3 Threshold Model**
+
+Single commit threshold, per card width:
+
+```
+COMMIT_THRESHOLD = 0.5
+```
+
+Behavior:
+
+| Event                                             | Result                                       |
+| ------------------------------------------------- | -------------------------------------------- |
+| First time `|offset| >= 0.5*W` during a gesture   | fire haptic once (commit-ready cue)          |
+| Release with `|offset| < 0.5*W`                   | snap back to 0; no commit                    |
+| Release with `|offset| >= 0.5*W`                  | commit fires; snap back to 0; list updates   |
+
+Implementation note: there is only one `AnchoredDraggableState` anchor
+(`Idle: 0f`). The haptic cue is dispatched from a `snapshotFlow { state.offset }`
+collector with a once-per-gesture `hapticConsumed` guard. Commit dispatch
+lives in the `onDragStopped` callback (or equivalent), which checks the
+final offset against the threshold. The user-facing benefit: dragging
+past the threshold and then back off before release cancels the commit.
+
+---
+
+## **4. Action Dispatch (Key Integration Point)**
+
+When swipe commits:
+
+```
+onSwipeCommit(direction):
+    val action = resolveConfiguredAction(direction)
+    invokeExistingActionHandler(action, itemId)
+```
+
+The "existing action handler" is the **screen-level callback** already
+passed into each card composable, not a direct ViewModel call:
+
+* `Archive`  → `onClickArchive(bookmark.id, !bookmark.isArchived)`
+* `Delete`   → `onClickDelete(bookmark.id)` (this is the lambda in
+  `BookmarkListScreen` that calls `stageDeleteWithSnackbar` — calling
+  the ViewModel's `onDeleteBookmark` directly would bypass the
+  snackbar + undo pipeline)
+* `Favorite` → `onClickFavorite(bookmark.id, !bookmark.isMarked)`
+  (the `BookmarkListItem` field is `isMarked`, not `isFavorite`)
+
+The archive / favorite handlers take the **desired new state** as the
+second argument, not a toggle — read the bookmark's current flag and
+pass the negation.
+
+No branching by list type here.
+
+---
+
+## **5. View-Specific Behavior (Handled Indirectly)**
+
+You correctly identified this already—formalizing it:
+
+### **Important Rule**
+
+> Swipe does not decide list removal. Filtering does.
+
+So:
+
+| View                     | Archive Effect   | Removal Behavior |
+| ------------------------ | ---------------- | ---------------- |
+| Main                     | archived = true  | removed          |
+| Archive                  | archived = false | removed          |
+| Favorites                | toggle archived  | stays            |
+| Articles/Videos/Pictures | toggle archived  | stays            |
+
+Implementation:
+
+* Swipe calls `toggleArchive()` (same as icon)
+* List updates automatically via existing filtering logic
+
+---
+
+## **6. Visual Layer Spec**
+
+### **6.1 Background Layer (Gmail-style growing surface)**
+
+* A `Box` matching the card's bounds (use `Modifier.matchParentSize()` on
+  the background layer inside the same parent that holds the draggable
+  card).
+* Inside it, a rounded colored surface aligned to the side the card is
+  being pulled **away from** (i.e. swipe-left exposes a surface aligned
+  to the right edge), with `width = abs(offset)` and the same corner
+  radius and height as the card.
+* Surface color reflects the resolved action for that direction:
+
+  * Archive  → `secondaryContainer`
+  * Delete   → `errorContainer`
+  * Favorite → `tertiaryContainer`
+
+### **6.2 Icon Behavior**
+
+* The action icon is centered inside the growing colored surface.
+* Alpha and scale ramp against the **commit threshold** (not a reveal
+  threshold, which no longer exists):
+
+  * `progress = (abs(offset) / commitPx).coerceIn(0f, 1f)`
+  * `alpha = progress`
+  * `scale = lerp(0.8f, 1.0f, progress)`
+* Icon is fully formed at the commit point.
+
+---
+
+### **6.3 Motion**
+
+#### Dragging
+
+* Card follows finger (1:1 horizontal translation).
+
+#### Release
+
+* If the threshold was crossed during the drag, commit has already fired;
+  the snap-to-Idle is just visual cleanup.
+* Otherwise: animate to `Idle` (single anchor). Default fling behavior
+  on `AnchoredDraggableState` handles this.
+* Velocity-aware commit is optional polish — not required for v1.
+
+---
+
+## **7. Undo Handling**
+
+* Delete → routes through the screen-level `onClickDelete` lambda which
+  calls `stageDeleteWithSnackbar` → ViewModel `onDeleteBookmark` stages
+  the pending deletion; the screen owns the snackbar; on Undo the
+  screen calls `onCancelDeleteBookmark`, on timeout / dismissal it
+  must call `onConfirmDeleteBookmark`.
+* Archive → no undo in this feature.
+* Favorite → toggle, no undo.
+
+Important:
+
+* Do not delay the commit handler for animation — trigger immediately
+  on threshold crossing.
+* Successive deletes must dismiss the prior snackbar in a way that
+  confirms (not cancels) the prior pending deletion. The current
+  screen-level dismiss-then-stage pattern handles this for icon
+  presses; the same pattern must apply to swipe.
+
+---
+
+## **9. Settings Integration**
+
+Persist in `SettingsDataStore` with `swipe_`-prefixed keys; expose:
+
+```
+SwipeConfig:
+  enabled: Boolean
+  leftAction: SwipeAction   // ARCHIVE | DELETE | FAVORITE | NONE
+  rightAction: SwipeAction
+
+Default = SwipeConfig(enabled = true,
+                      leftAction = SwipeAction.DELETE,
+                      rightAction = SwipeAction.ARCHIVE)
+```
+
+Resolution:
+
+```
+resolveConfiguredAction(direction):
+    return config.leftAction or config.rightAction
+```
+
+If a direction resolves to `NONE`, that side of the gesture is inactive
+(no commit, no background reveal, no semantics action).
+
+---
+
+## **10. Compose Implementation Notes**
+
+Project is 100% Compose; the implementation uses:
+
+* `Modifier.anchoredDraggable(Orientation.Horizontal)` with a single
+  anchor at `Idle: 0f`. Free drag in both directions; fling settles
+  back to `Idle`.
+* `snapshotFlow { state.offset }.collect { ... }` for mid-drag commit
+  detection.
+* `commitConsumed` guard reset by the collector when `|offset| < 1f`
+  (not by `state.settledValue`, since pre- and post-commit settled
+  values are both `Idle` and the key would never change).
+* `BoxWithConstraints` to compute `commitPx = 0.5f * maxWidth.toPx()`.
+* The composable wraps the existing card content as the outermost
+  modifier on the wrap site; the inner `combinedClickable` on the
+  card body and thumbnail remains untouched.
+
+---
+
+## **11. Edge Cases (Don’t Skip These)**
+
+### **A. Rapid successive swipes**
+
+* Ensure adapter updates don’t break animation state
+* Use stable IDs
+
+---
+
+### **B. Partial swipe + scroll interruption**
+
+* Cancel swipe cleanly
+* Snap to `Idle` (the only anchor)
+
+---
+
+### **C. Multi-touch**
+
+* Ignore secondary pointers
+
+---
+
+### **D. Dataset mutation mid-gesture**
+
+* If item disappears → cancel animation gracefully

--- a/docs/specs/swipe-actions-for-bookmark-cards-impl-plan.md
+++ b/docs/specs/swipe-actions-for-bookmark-cards-impl-plan.md
@@ -1,0 +1,292 @@
+# Swipe Actions for Bookmark Cards — Implementation Plan
+
+Companion to:
+- [Functional spec](swipe-actions-for-bookmark-cards-spec.md)
+- [Architecture spec](swipe-actions-for-bookmark-cards-arch-spec.md)
+
+## Resolved design questions
+
+| # | Question | Decision |
+|---|----------|----------|
+| 1 | Global enable toggle vs per-direction "None" | **Keep both.** Global enable is the master kill switch. Per-direction "None" disables only one direction. |
+| 2 | Add archive undo as part of this feature? | **No.** Out of scope. Only delete keeps its existing snackbar+undo flow. |
+| 3 | Reveal-and-tap vs commit-only? | **Commit-only.** Reveal-and-tap duplicates the existing icon-tap UX and introduces an ambiguity window where tapping the card body opens the reader instead of confirming. Single elastic snap-back with commit threshold at 0.5 × card width. |
+| 4 | Ship `requireFullSwipe` setting? | **Obsolete.** Commit-only makes this the only mode; no setting needed. |
+| 5 | Active in multi-column layouts? | **No.** Disabled in multi-column grid/mosaic (tablet, mobile landscape). No major app applies row-swipe to a card grid; cards are narrower, neighbouring cells own the horizontal space, and multi-select is the right batch UX for tablet. Compact layout always swipes (it's single-column even on tablet). |
+
+## Visual treatment (Gmail-style)
+
+The action surface is a rounded colored card that grows from the trailing
+edge of the swiped bookmark card, matching the card's height and corner
+radius. The action icon is centered inside the growing surface. Width
+tracks `abs(offset)`; alpha and scale ramp against the commit threshold,
+so the icon is fully formed at the commit point. This avoids the
+"thin band along the top" appearance of a naive full-width background.
+
+## Reference: existing entry points
+
+- Card action callbacks already plumbed through `BookmarkListView` → each card composable:
+  - `onClickDelete(id: String)` — stages pending deletion (snackbar + undo handled in screen).
+  - `onClickArchive(id: String, isArchived: Boolean)` — takes desired new state.
+  - `onClickFavorite(id: String, isFavorite: Boolean)` — takes desired new state.
+- ViewModel layer: `BookmarkListViewModel.onDeleteBookmark`, `onToggleArchiveBookmark`, `onToggleFavoriteBookmark`.
+- Screen-level snackbar plumbing: `BookmarkListScreen.stageDeleteWithSnackbar` and `pendingDeletionBookmarkIds` flow.
+- Drawer gesture flag: `AppShell.kt` line ~218, `gesturesEnabled = isOnBookmarkList`.
+- Settings persistence interface: `SettingsDataStore` (Flow + suspend setter pattern).
+- Settings UI: `UiSettingsScreen` + `UiSettingsViewModel`.
+
+Swipe must reuse `onClickDelete`/`onClickArchive`/`onClickFavorite` exactly — do not call the ViewModel directly, or the existing pending-delete snackbar pipeline is bypassed.
+
+## Slices
+
+Slices are sequential; each is independently testable. Model recommendations reflect risk and novelty.
+
+### Status
+
+- Slice 1 — **DONE**
+- Slice 2 — **DONE** (original two-anchor reveal+commit; superseded behaviorally by Slice 3.5a)
+- Slice 3 — **DONE**
+- Slice 3.5a — **DONE** (visual + behavior overhaul + multi-column gating)
+- Slice 3.5b — **DONE** (pending-delete snackbar auto-confirm bug)
+- Slice 4 — **DONE** (drawer gesture flip + settings UI; one regression patch landed mid-Slice-7 — see note below)
+- Slice 5 — **DONE** (user guide documentation)
+- Slice 6 — **DONE** (tests; surfaced a spec/code discrepancy on commit timing — specs updated to match implementation)
+- Slice 7 — **DONE** (final verification; cross-theme reveal-color tuning landed during Slice 7 — see note below)
+
+**Feature complete.** Branch ready to PR.
+
+### Slice 7 reveal-color tuning (post-verification polish)
+
+During the Phase C manual matrix, the reveal colors looked inconsistent
+across themes:
+
+- Sepia Delete used Sepia's `errorContainer`, which read darker than
+  Paper's softened red.
+- Dark/Black Archive used each theme's `secondaryContainer` (a slate),
+  not the wallpaper-derived primary that Light themes used.
+- Initial fix attempt hardcoded a static teal, which broke on Pixel 9
+  where the live primary is dynamic (wallpaper-sourced blue, not the
+  `PaperColorScheme` fallback teal). It also incorrectly overrode
+  Sepia Archive (which should stay on its curated palette).
+
+Final resolution in `SwipeableCardContainer.kt`:
+
+- Resolve `lightDynamic = dynamicLightColorScheme(LocalContext.current)`
+  once at composable scope (with `PaperColorScheme` fallback for API <31).
+- `backgroundColorFor` / `iconTintFor` rewritten as explicit
+  `when (appearance)` blocks so every theme/action cell is auditable.
+- Archive uses `lightDynamic.primary` / `.onPrimary` for **Paper, Dark,
+  Black** — identical wallpaper-derived shade across all three.
+- Archive uses `cs.secondaryContainer` / `.onSecondaryContainer` for
+  **Sepia** — preserves the curated sepia palette.
+- Delete uses `lerp(cs.error, cs.errorContainer, 0.2f)` for both
+  **Paper and Sepia** (light themes get the softened red, each tinted
+  by its own palette); `cs.errorContainer` for Dark/Black.
+- Favorite mappings unchanged from pre-Slice-7 (Paper → `tertiary`,
+  others → `tertiaryContainer`).
+
+### Slice 4 regression patch (post-landing fix)
+
+Device testing during Slice 7 surfaced a regression in the drawer-gesture
+flip. `gesturesEnabled = false` on `ModalNavigationDrawer` disables not
+only swipe-to-open but also scrim-tap-to-close and swipe-to-close, so
+with swipe actions enabled the drawer could only be closed by selecting
+a drawer item. Fixed in `AppShell.kt` by gating the suppression on
+`drawerState.isOpen`:
+
+```kotlin
+gesturesEnabled = drawerState.isOpen
+    || !isOnBookmarkList
+    || !swipeConfig.value.enabled,
+```
+
+Drawer-swipe-to-open is still suppressed when the drawer is closed on
+the bookmark list with swipe enabled; once the drawer is open, gestures
+go live again so scrim-tap and swipe-close work. Slice 7 matrix C3
+gained two new rows to cover this.
+
+### Slice 1 — Settings model + persistence (no UI)
+
+**Model: Sonnet**
+
+- New file `SwipeAction.kt` (enum: `ARCHIVE`, `DELETE`, `FAVORITE`, `NONE`).
+- New file `SwipeConfig.kt` (data class: `enabled: Boolean`, `leftAction: SwipeAction`, `rightAction: SwipeAction`).
+- Defaults: `enabled = true`, `leftAction = DELETE`, `rightAction = ARCHIVE`.
+- Extend `SettingsDataStore`:
+  - `val swipeConfigFlow: StateFlow<SwipeConfig>`
+  - `suspend fun saveSwipeEnabled(enabled: Boolean)`
+  - `suspend fun saveSwipeLeftAction(action: SwipeAction)`
+  - `suspend fun saveSwipeRightAction(action: SwipeAction)`
+- Implement in `SettingsDataStoreImpl` following the existing key/flow pattern (see e.g. `keepScreenOnWhileReadingFlow`).
+- Unit-test serialization / round-trip / defaults.
+
+**Out of scope this slice:** any UI, any wiring into cards or the drawer.
+
+### Slice 2 — `SwipeableCardContainer` composable
+
+**Model: Opus**
+
+This is the highest-risk slice (gesture arbitration with `combinedClickable`, system-gesture insets, commit dispatch).
+
+- New file `app/src/main/java/com/mydeck/app/ui/list/SwipeableCardContainer.kt`.
+- API:
+  ```kotlin
+  @Composable
+  fun SwipeableCardContainer(
+      config: SwipeConfig,
+      onCommitLeft: () -> Unit,
+      onCommitRight: () -> Unit,
+      a11yLeftLabel: String,
+      a11yRightLabel: String,
+      modifier: Modifier = Modifier,
+      content: @Composable () -> Unit,
+  )
+  ```
+- Architecture:
+  - Outer `Box` owns `Modifier.anchoredDraggable(Orientation.Horizontal)` so it wraps the existing card. Inner cards' `combinedClickable` modifiers are untouched — horizontal slop crossing cancels the parent long-press automatically.
+  - Anchors: `Idle: 0f`, `RevealedLeft: -revealPx`, `RevealedRight: +revealPx`. Use `cardWidthPx` from `BoxWithConstraints` to compute `revealPx = 0.25 * width`, `commitPx = 0.65 * width`.
+  - Commit dispatch as a one-shot effect, not state. Use a `var commitConsumed: Boolean by remember(state.settledValue)` flag, reset when `settledValue == Idle`. When `abs(state.offset) >= commitPx` and not consumed, set consumed and call the handler — addresses arch spec issue #4 (no `Committed(direction)` state).
+  - Edge gating: in `pointerInput`, read pointer-down position and the start-side `WindowInsets.systemGestures` in px; abort tracking if down is inside that inset.
+  - Background layer behind the card: a `Row` filling the box, aligned by drag direction, with action color (`secondaryContainer` / `errorContainer` / `tertiaryContainer`) and icon. Icon `alpha` follows `(abs(offset) / revealPx).coerceIn(0f, 1f)`, scale `lerp(0.8f, 1.0f, fraction)`.
+  - On revealed state, the visible action icon is part of the background layer; it's tappable and calls the same commit handler then animates closed.
+  - Haptic feedback (`HapticFeedbackType.LongPress`) fires on commit.
+  - `Modifier.semantics { customActions = listOf(...) }` for TalkBack — only emit actions whose direction has a non-`NONE` mapping.
+  - Pass-through behavior when `config.enabled == false` (just emit `content()` with the supplied modifier).
+- Resolution helper: `resolveAction(SwipeAction, onCommitLeft, onCommitRight, ...)` mapping action enum to one of the existing on-click handlers.
+
+**Out of scope this slice:** wiring into the list — keep this composable standalone + previewable.
+
+### Slice 3 — Wire `SwipeableCardContainer` into the list
+
+**Model: Sonnet**
+
+- `BookmarkListScreen.kt` `BookmarkListView`: collect the `swipeConfig` from the ViewModel (add a state-collecting `viewModel.swipeConfig.collectAsStateWithLifecycle()` upstream and plumb it through to `BookmarkListView`).
+- In both the `LazyVerticalGrid.itemsIndexed` and `LazyColumn.itemsIndexed` blocks, wrap the existing `Box(modifier = Modifier.alpha(...))` in `SwipeableCardContainer`. Card composables stay unchanged.
+- Resolve handlers per direction:
+  - `SwipeAction.ARCHIVE` → `{ onClickArchive(bookmark.id, !bookmark.isArchived) }`
+  - `SwipeAction.DELETE` → `{ onClickDelete(bookmark.id) }`
+  - `SwipeAction.FAVORITE` → `{ onClickFavorite(bookmark.id, !bookmark.isFavorite) }`
+  - `SwipeAction.NONE` → no-op (and direction should be elided from accessibility actions and from anchor set)
+- ViewModel: add `val swipeConfig: StateFlow<SwipeConfig>` sourced from `settingsDataStore.swipeConfigFlow`.
+
+### Slice 3.5a — Visual overhaul + commit-only behavior + multi-column gating
+
+**Model: Opus**
+
+Triggered by device testing after Slice 3 landed. Combines three changes
+in one pass because they all touch the same files.
+
+**Scope:**
+- `SwipeableCardContainer`:
+  - Drop `RevealedLeft` / `RevealedRight` anchors — single `Idle: 0f` anchor only.
+  - Drop the revealed-icon `clickable` from the background layer (no tap-to-confirm).
+  - Lower commit threshold from `0.65 * width` to `0.5 * width`.
+  - Rework the background layer to Gmail-style growing colored surface:
+    `Modifier.matchParentSize()` box behind the draggable; inside it, a
+    rounded surface (matching card corner radius) aligned to the
+    away-from-finger edge, with `width = abs(offset)`. Icon centered
+    inside. Icon alpha/scale ramps against the new commit threshold.
+  - Update the `@Preview` to reflect the new visual.
+- `BookmarkListScreen.kt`:
+  - In the `LazyVerticalGrid` branch (multi-column path), pass
+    `swipeConfig.copy(enabled = false)` into `SwipeWrappedBookmark`.
+    The `LazyColumn` branch (single-column path, includes Compact on
+    tablet) continues to pass the user's actual config.
+
+**Verification:** install on Pixel 9 and verify on each layout (Mosaic/
+Grid/Compact in portrait, landscape, and on a tablet emulator if
+available) that swipe is active or absent per the gating rule, and that
+the visual matches the Gmail mental model.
+
+### Slice 3.5b — Pending-delete snackbar auto-confirm bug
+
+**Model: Sonnet**
+
+Separate from swipe per se but surfaced by device testing. Investigate
+`BookmarkListScreen.stageDeleteWithSnackbar` and the
+`SnackbarHostState.showSnackbar` result handling:
+
+- Confirm whether the `SnackbarResult.Dismissed` branch calls
+  `viewModel.onConfirmDeleteBookmark(id)` or whether dismissal silently
+  strands the pending item.
+- Confirm whether the swipe-delete path goes through the same
+  `dismissPendingDeleteSnackbar(); stageDeleteWithSnackbar(id)`
+  sequence that the icon path uses.
+- Reproduce both paths (icon-then-icon, swipe-then-swipe, mixed) to
+  determine whether the bug is swipe-specific or pre-existing.
+- Fix so that any new delete (swipe or icon) confirms the prior
+  pending deletion.
+
+### Slice 4 — Drawer gesture flip + Settings UI
+
+**Model: Sonnet**
+
+- `AppShell.kt`: change `gesturesEnabled = isOnBookmarkList` to read from `swipeConfig.enabled` — when swipe is enabled, drawer-swipe is disabled; when swipe is disabled, drawer-swipe stays enabled (preserves current behavior for users who turn the feature off).
+  - Cleanest: inject the config flow into `CompactAppShell` (medium/expanded shells don't use a swipe-out drawer anyway).
+- `UiSettingsScreen` + `UiSettingsViewModel`: add "Swipe actions" section.
+  - Master Switch (enable / disable).
+  - Two pickers (dropdown menus or M3 segmented buttons): "Swipe left action" and "Swipe right action", options Archive / Delete / Favorite / None.
+- Add 10 new strings to all 10 locale files per CLAUDE.md (English placeholders in non-English locales):
+  - `swipe_settings_section_title` ("Swipe actions")
+  - `swipe_settings_enable` ("Enable swipe actions")
+  - `swipe_settings_left_action` ("Swipe left action")
+  - `swipe_settings_right_action` ("Swipe right action")
+  - `swipe_action_archive`, `swipe_action_delete`, `swipe_action_favorite`, `swipe_action_none`
+  - `swipe_a11y_archive` ("Archive"), `swipe_a11y_delete` ("Delete") — for semantics custom actions
+  - (`swipe_a11y_favorite` if needed)
+
+### Slice 5 — Documentation
+
+**Model: Sonnet**
+
+- `app/src/main/assets/guide/en/your-bookmarks.md`: add a "Swipe actions" subsection — defaults, reveal vs commit, customizing in settings, note that the drawer is opened by the hamburger button only (assuming swipe is enabled).
+- `app/src/main/assets/guide/en/settings.md`: document the new section under UI Settings.
+- English only — translations handled separately.
+
+### Slice 6 — Tests
+
+**Model: Opus** (gesture tests are tricky; basic unit tests could be Sonnet — split if needed)
+
+- Unit tests:
+  - `SwipeConfig` defaults.
+  - `SettingsDataStoreImpl` swipe pref persistence round-trip.
+  - `resolveAction` mapping.
+- Compose UI tests (one suite for `SwipeableCardContainer`):
+  - Tap on content still propagates to inner `clickable`.
+  - Long-press on content still propagates (no swipe interference under slop).
+  - Horizontal drag past commit fires the corresponding handler exactly once.
+  - Drag-down inside system-gestures start-inset does not start tracking.
+  - `config.enabled == false` → no draggable behavior; pure pass-through.
+  - Revealed-state tap on action icon fires handler and snaps closed.
+- Integration smoke (BookmarkListScreen): swipe-delete shows the existing pending-delete snackbar with Undo.
+
+### Slice 7 — Verify
+
+**Model: Haiku**
+
+Run before any commit per CLAUDE.md:
+- `./gradlew :app:assembleDebugAll`
+- `./gradlew :app:testDebugUnitTestAll`
+- `./gradlew :app:lintDebugAll`
+
+Then `./scripts/install-phone.sh` and manually verify:
+- Tap, long-press, vertical scroll unaffected.
+- Swipe-archive / swipe-delete (with undo) fire.
+- Partial-reveal + tap revealed icon fires.
+- Edge-back gesture from screen edge still works.
+- Hamburger drawer open still works (drawer swipe-open suppressed when swipe is enabled).
+- Settings toggle disables swipe and re-enables drawer swipe.
+
+## Model selection summary
+
+| Slice | Model | Why |
+|-------|-------|-----|
+| 1. Settings model + persistence | Sonnet | Pattern-heavy, low novelty. |
+| 2. SwipeableCardContainer | Opus | Novel gesture work; arbitration with existing modifiers; edge-inset handling; highest defect cost. |
+| 3. Wire into list | Sonnet | Mechanical; reuses existing handlers. |
+| 3.5a. Visual + commit-only + multi-column gate | Opus | Visual refactor (Gmail-style growing surface) plus single-anchor refactor; touches the highest-risk file again. |
+| 3.5b. Snackbar auto-confirm bug | Sonnet | Investigation in screen-level snackbar handling; well-defined surface area. |
+| 4. Drawer flip + Settings UI | Sonnet | Multi-locale string work plus straightforward UI. |
+| 5. Docs | Sonnet | Tone/style alignment with existing guide. |
+| 6. Tests | Opus | Compose gesture tests, slop/anchor verification. |
+| 7. Verify | Haiku | Shell commands + manual checks. |

--- a/docs/specs/swipe-actions-for-bookmark-cards-spec.md
+++ b/docs/specs/swipe-actions-for-bookmark-cards-spec.md
@@ -1,0 +1,316 @@
+# **Swipe Actions for Bookmark Cards — Functional Spec**
+
+## **1. Purpose**
+
+Add horizontal swipe gestures to bookmark cards to enable fast access to common actions (archive / delete), while preserving all existing interactions (tap, long press, action icons).
+
+Swipe is an **optional accelerator**, not a replacement for existing UI controls.
+
+---
+
+## **2. Scope**
+
+Applies to card-based lists in these views:
+
+* Main list (“My List”)
+* Archive
+* Favorites
+* Articles
+* Videos
+* Pictures
+
+Swipe tracking is scoped to the bookmark card surface only. It must not be
+attached to the list container, scaffold, navigation drawer, navigation rail,
+or permanent drawer area. On tablet layouts, gestures that begin over the rail
+or permanent drawer are navigation interactions, not bookmark-card swipe
+interactions.
+
+### Layout gating
+
+Swipe applies only when the layout renders as a single column:
+
+* Phone portrait, in any layout
+* Compact layout on any device (Compact uses a single-column list even on
+  tablets)
+
+Multi-column grid and mosaic layouts (tablet, mobile landscape) do **not**
+enable swipe. In those layouts, neighbouring cards occupy the horizontal
+space that swipe would otherwise reveal, and no major app applies row-swipe
+gestures to a card grid. Users in multi-column layouts use icon buttons or
+multi-select for batch actions.
+
+---
+
+## **3. Core Interaction Model**
+
+### **3.1 Gesture Detection**
+
+* On pointer down over a bookmark card, begin passive tracking only.
+* Do not consume pointer changes until swipe intent is locked.
+* Determine gesture intent after touch slop is crossed:
+
+  * If horizontal movement clearly dominates → **swipe**
+  * If vertical movement reaches slop first or dominates → **scroll**
+  * If movement remains ambiguous → keep waiting
+* Long press triggers only if:
+
+  * Movement remains within touch slop
+  * Time threshold is reached
+* Any horizontal movement beyond touch slop **cancels long press**
+* Once a swipe is locked, keep it locked until release/cancel.
+* Once scroll is locked, do not start a card swipe for that pointer sequence.
+
+Suggested arbitration:
+
+* Lock swipe only when `abs(dx) > touchSlop` and `abs(dx) >= 1.5 * abs(dy)`.
+* Lock scroll when `abs(dy) > touchSlop` before swipe locks, or when vertical
+  movement is not clearly subordinate to horizontal movement.
+* Consume horizontal drag deltas only after swipe lock.
+
+### **3.2 System and Navigation Gestures**
+
+Compact layout currently opens the navigation drawer with a left-to-right
+swipe on bookmark-list screens. This must be disabled when card swipe actions
+are introduced. Users will open the drawer with the hamburger button only.
+
+Android system back gestures must remain available. A left-to-right swipe that
+starts from the screen edge/system gesture inset must not be captured by a
+bookmark card. Do not apply gesture exclusion to the system back edge for this
+feature.
+
+---
+
+### **3.3 Swipe Behavior**
+
+Each card supports:
+
+* **Swipe right** → configurable action (default: Archive)
+* **Swipe left** → configurable action (default: Delete)
+
+#### Commit-only (elastic snap-back)
+
+Swipe is a single-stage commit gesture. There is no reveal-and-tap mode.
+
+* Card translates with the finger (1:1).
+* Visual feedback (colored action surface + icon) grows from the trailing
+  edge as the card moves.
+* **Threshold cue:** when the dragged edge of the card first reaches the
+  mid-point of the card's width (i.e. `|offset| >= 0.5 * cardWidth`),
+  haptic feedback fires once to confirm commit-ready state. The icon is
+  fully formed at this point.
+* **Commit on release past threshold:** if the finger is released while
+  `|offset| >= 0.5 * cardWidth`, the action fires. The card then snaps
+  back to its origin while the list state handles any consequent removal
+  or re-render.
+* **Back-off cancellation:** if the user crosses threshold, then drags
+  back to under threshold and releases, the action does **not** fire.
+  Gives the user an escape hatch from a near-miss commit.
+* **Released below threshold:** card snaps back; nothing happens.
+
+Rationale: a reveal-then-tap mode duplicates what the existing action icons
+already do (tap to act) and creates a window in which tapping the card body
+opens the reader instead of confirming the action. Commit-only removes that
+ambiguity.
+
+---
+
+## **4. Actions**
+
+### **4.1 Action Mapping**
+
+User-configurable per direction:
+
+* Archive (toggle)
+* Delete
+* Favorite (optional future)
+* None (disable direction)
+
+Default:
+
+* Swipe right → Archive
+* Swipe left → Delete
+
+---
+
+### **4.2 Action Execution**
+
+Swipe actions must invoke the **same logic paths** as existing action icons:
+
+* Archive → identical to archive icon
+* Delete → identical to delete icon (including snackbar + undo)
+
+No separate business logic for swipe.
+
+---
+
+## **5. View-Specific Behavior**
+
+Swipe always performs a **state change**, not a direct list mutation.
+
+### **5.1 Main List**
+
+* Archive:
+
+  * Sets archived = true
+  * Item removed from list (due to filter)
+* Delete:
+
+  * Deletes item
+  * Snackbar with Undo
+
+---
+
+### **5.2 Archive View**
+
+* Archive swipe:
+
+  * Toggles archived → false (unarchive)
+  * Item removed from list
+
+---
+
+### **5.3 Favorites / Articles / Videos / Pictures**
+
+* Archive swipe:
+
+  * Toggles archived state (set or unset)
+  * **Item remains in list**
+* Delete:
+
+  * Deletes item
+  * Snackbar with Undo
+
+Note:
+
+* No special-case removal logic required; rely on existing filtering behavior.
+
+---
+
+## **6. Visual & Motion Design**
+
+### **6.1 Swipe Feedback**
+
+The action surface is drawn behind the card and mimics the Gmail-style
+interaction:
+
+* A rounded colored surface grows from the trailing edge of the card,
+  matching the card's height and corner radius.
+* Width of the colored surface tracks the absolute drag offset (so it
+  appears to fill the gap the card vacates).
+* Surface color reflects the action mapped to the swipe direction:
+
+  * Archive → secondary container
+  * Delete → error container
+  * Favorite → tertiary container
+* Action icon is centered horizontally within the growing surface and
+  vertically centered against the card. It fades in and scales from
+  ~0.8 → 1.0 as the offset approaches the commit threshold.
+* Haptic feedback (`HapticFeedbackType.LongPress`) fires at the commit
+  threshold. This is required, not optional, to match existing destructive
+  action affordances.
+
+---
+
+### **6.2 Motion**
+
+* Smooth horizontal drag tied to finger (1:1 translation).
+* Haptic fires once on the first threshold crossing within a gesture (mid-drag).
+* Release behavior:
+
+  * `|offset| < 0.5 * cardWidth` on release → snap back to 0; no commit.
+  * `|offset| >= 0.5 * cardWidth` on release → commit fires; card snaps
+    back to 0 and the list state handles any consequent removal.
+* Velocity-aware commit may be added as polish if the elastic snap-back
+  feels sluggish on fast flicks.
+
+---
+
+## **7. Undo Behavior**
+
+* Delete must trigger the existing pending-deletion snackbar with Undo
+  (this is already implemented for icon-button deletes; swipe must invoke
+  the same screen-level handler, not the ViewModel directly, so the
+  snackbar pipeline is preserved).
+* Archive has no undo in this feature. Adding archive undo is a separate
+  workstream.
+* Favorite is a toggle and does not require undo.
+* Multiple rapid deletes must not strand prior pending deletions. Each new
+  delete dismisses the prior snackbar, which must confirm (not cancel)
+  the prior pending deletion.
+
+---
+
+## **8. Coexistence with Existing Interactions**
+
+Must not interfere with:
+
+* Tap → open reader
+* Long press (card body) → open card context menu
+* Long press (thumbnail) → open thumbnail context menu
+* Action icons → unchanged
+* Hamburger button → open navigation drawer
+* Left-edge system gesture → system back
+* Multi-select mode → swipe is disabled while multi-select is active.
+  Entering multi-select must close any in-flight swipe state.
+
+Gesture priority:
+
+1. System back edge gesture
+2. Vertical scroll
+3. Horizontal card swipe
+4. Long press (only if no movement)
+
+Navigation drawer policy:
+
+* Disable `ModalNavigationDrawer` swipe gestures on bookmark-list screens.
+* Keep explicit drawer open/close actions through existing buttons and drawer
+  item taps.
+* Do not add a replacement drawer-edge gesture.
+
+---
+
+## **9. Settings**
+
+Add user-configurable options:
+
+* Enable/disable swipe gestures (master kill switch)
+* Swipe left action (Archive / Delete / Favorite / None)
+* Swipe right action (Archive / Delete / Favorite / None)
+
+Per-direction "None" disables a single direction independently of the
+master toggle.
+
+---
+
+## **10. Non-Goals**
+
+* No removal of existing action icons
+* No change to underlying data model
+* No new actions beyond existing ones
+
+---
+
+## **11. Success Criteria**
+
+* Swipe feels responsive and predictable
+* No accidental triggering of long press during swipe
+* No accidental triggering of swipe during vertical scroll
+* No accidental triggering of vertical scroll during a locked card swipe
+* Navigation drawer does not open from a left-to-right card swipe
+* Left-edge Android system back gesture still works
+* Swipe tracking occurs only over bookmark cards, including on tablet layouts
+* Swipe is not active in multi-column grid/mosaic layouts
+* Actions behave identically to icon-triggered actions
+* Successive deletes confirm prior pending deletions; no orphaned snackbars
+* Users can ignore swipe entirely and still use the app normally
+
+---
+
+## **12. Documentation & Localization**
+
+If implementation adds settings labels, action labels, accessibility labels, or
+snackbar text, add English placeholder values to every language `strings.xml`
+file, following the project localization rule.
+
+Because this is user-visible behavior, update the English user guide under
+`app/src/main/assets/guide/en/` when the feature is implemented.


### PR DESCRIPTION
## Summary
- Horizontal swipe on bookmark cards now archives, deletes, or favorites — Gmail-style growing colored surface with commit-only behavior at 0.5× card-width threshold, haptic feedback on threshold crossing, and elastic snap-back with back-off cancellation.
- Layout-gated to single-column lists: Compact swipes on every device/orientation; Mosaic and Grid swipe only in phone portrait. Multi-column grids stay tap-only.
- New "Swipe actions" section under UI Settings: master toggle plus per-direction picker (Archive / Delete / Favorite / None). Defaults are right→Archive, left→Delete.
- When swipe is enabled the drawer's edge-swipe-to-open is suppressed (scrim tap and swipe-to-close still work); turning swipe off restores the original drawer gesture.
- Archive reveal color sourced from `dynamicLightColorScheme(...).primary` so the shade is consistent across Paper / Dark / Black; Sepia keeps its curated palette.
- All 10 locales updated with English-placeholder strings per project rule.

## Test plan
- [x] `./gradlew :app:assembleDebugAll` — green
- [x] `./gradlew :app:testDebugUnitTestAll` — green (includes Robolectric Compose UI tests for `SwipeableCardContainer`)
- [x] `./gradlew :app:lintDebugAll` — green, no new warnings
- [x] Installed on Pixel 9; full Slice 7 manual matrix passed: default behavior across Mosaic / Grid / Compact, layout gating in landscape, settings toggle and per-direction pickers, drawer interaction (tap-outside + swipe-to-close), tap / long-press / scroll coexistence, system-back edge gesture preserved, sequential swipe-delete snackbar auto-confirm, visual polish across all four themes.

## Notes
- Two mid-verification fixes landed on this branch: `AppShell` drawer-gesture gating now keys off `drawerState.isOpen` so the drawer can still be dismissed by scrim-tap and swipe-to-close; reveal colors retuned so the Archive shade is wallpaper-derived and consistent across themes.
- Specs and impl plan are checked in under `docs/specs/swipe-actions-for-bookmark-cards-*.md` and reflect the final landed behavior (commit-only, single-anchor, layout gating).
