### PR TITLE
Fix critical metadata wipe on label edit + related UX issues

### DIFF
--- a/app/src/main/java/com/mydeck/app/AppModule.kt
+++ b/app/src/main/java/com/mydeck/app/AppModule.kt
@@ -64,7 +64,16 @@ abstract class AppModule {
             return Json {
                 ignoreUnknownKeys = true // Handle unknown keys gracefully
                 isLenient = true // Allow lenient parsing
-                encodeDefaults = true // Always emit fields even when value == default
+                // Do NOT enable encodeDefaults: it turns every sparse DTO into a
+                // dense JSON object full of explicit nulls / zero values, which
+                // older callers expected the server to ignore. Readeck 0.22.3
+                // started treating bound-but-null fields as "set to empty",
+                // which silently wiped title/site_name/description on every
+                // PATCH /bookmarks/{id} that used EditBookmarkDto with only one
+                // field set (e.g. labels add). explicitNulls=false additionally
+                // drops fields that are explicitly assigned null, so the wire
+                // body contains only the keys the caller actually populated.
+                explicitNulls = false
             }
         }
     }

--- a/app/src/main/java/com/mydeck/app/domain/usecase/OAuthDeviceAuthorizationUseCase.kt
+++ b/app/src/main/java/com/mydeck/app/domain/usecase/OAuthDeviceAuthorizationUseCase.kt
@@ -1,10 +1,12 @@
 package com.mydeck.app.domain.usecase
 
+import android.content.Context
 import android.os.Build
-import com.mydeck.app.BuildConfig
 import com.mydeck.app.domain.model.OAuthDeviceAuthorizationState
 import com.mydeck.app.io.rest.ReadeckApi
 import com.mydeck.app.io.rest.model.*
+import com.mydeck.app.util.AppVersion
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import timber.log.Timber
@@ -19,7 +21,8 @@ import javax.inject.Inject
  */
 class OAuthDeviceAuthorizationUseCase @Inject constructor(
     private val readeckApi: ReadeckApi,
-    private val json: Json
+    private val json: Json,
+    @ApplicationContext private val context: Context
 ) {
     companion object {
         private const val GRANT_TYPE_DEVICE_CODE = "urn:ietf:params:oauth:grant-type:device_code"
@@ -59,7 +62,7 @@ class OAuthDeviceAuthorizationUseCase @Inject constructor(
                 clientName = CLIENT_NAME,
                 clientUri = CLIENT_URI,
                 softwareId = SOFTWARE_ID,
-                softwareVersion = BuildConfig.VERSION_NAME,
+                softwareVersion = AppVersion.versionName(context),
                 grantTypes = listOf(GRANT_TYPE_DEVICE_CODE)
             )
 

--- a/app/src/main/java/com/mydeck/app/io/rest/NetworkModule.kt
+++ b/app/src/main/java/com/mydeck/app/io/rest/NetworkModule.kt
@@ -22,6 +22,7 @@ import retrofit2.Retrofit
 import retrofit2.converter.kotlinx.serialization.asConverterFactory
 import retrofit2.converter.scalars.ScalarsConverterFactory
 import retrofit2.create
+import timber.log.Timber
 import java.io.File
 import javax.inject.Singleton
 
@@ -41,8 +42,19 @@ object NetworkModule {
             .addInterceptor(baseUrlInterceptor)
 
         if (BuildConfig.DEBUG) {
-            val loggingInterceptor = HttpLoggingInterceptor().apply {
-                level = HttpLoggingInterceptor.Level.BASIC
+            // Route OkHttp wire logs through Timber so they land in the on-device
+            // log file alongside everything else. Default logger writes to logcat
+            // only, which is invisible to the in-app log viewer / share flow.
+            // Use DEBUG (priority 3), not VERBOSE — the FileLoggerTree is
+            // configured at level=3 and would silently drop VERBOSE messages.
+            val timberLogger = HttpLoggingInterceptor.Logger { message ->
+                Timber.tag("OkHttp").d(message)
+            }
+            val loggingInterceptor = HttpLoggingInterceptor(timberLogger).apply {
+                level = HttpLoggingInterceptor.Level.BODY
+                redactHeader("Authorization")
+                redactHeader("Cookie")
+                redactHeader("Set-Cookie")
             }
             builder.addInterceptor(loggingInterceptor)
         }

--- a/app/src/main/java/com/mydeck/app/io/rest/model/SyncRequest.kt
+++ b/app/src/main/java/com/mydeck/app/io/rest/model/SyncRequest.kt
@@ -7,8 +7,9 @@ import kotlinx.serialization.Serializable
 data class SyncRequest(
     val id: List<String>,
     // Boolean fields default to false (= don't include that content type).
-    // The shared Json instance uses encodeDefaults=true so all fields are always serialized;
-    // false values are benign — the server ignores them.
+    // The shared Json instance uses encodeDefaults=false, so a caller passing
+    // an explicit `true` differs from the default and serializes; an unset
+    // field is omitted from the body, which the server treats as false.
     @SerialName("with_json")
     val withJson: Boolean = false,
     @SerialName("with_html")

--- a/app/src/main/java/com/mydeck/app/ui/about/AboutScreen.kt
+++ b/app/src/main/java/com/mydeck/app/ui/about/AboutScreen.kt
@@ -46,8 +46,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
-import com.mydeck.app.BuildConfig
 import com.mydeck.app.R
+import com.mydeck.app.util.AppVersion
 import com.mydeck.app.domain.model.CachedServerInfo
 import com.mydeck.app.ui.components.MyDeckBrandHeader
 import com.mydeck.app.ui.navigation.OpenSourceLibrariesRoute
@@ -124,13 +124,17 @@ fun AboutScreenContent(
                 .padding(16.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
+            val context = LocalContext.current
+            val versionName = remember(context) { AppVersion.versionName(context) }
+            val versionCode = remember(context) { AppVersion.versionCode(context) }
+
             // App Header
             MyDeckBrandHeader(iconSize = 96.dp)
 
             Spacer(modifier = Modifier.height(24.dp))
 
             Text(
-                text = stringResource(R.string.about_version, BuildConfig.VERSION_NAME),
+                text = stringResource(R.string.about_version, versionName),
                 style = MaterialTheme.typography.bodyLarge,
                 textAlign = TextAlign.Center
             )
@@ -205,17 +209,18 @@ fun AboutScreenContent(
             Spacer(modifier = Modifier.height(12.dp))
 
             // App Info Card
+            //
+            // Read versionName / versionCode / install time from PackageManager rather
+            // than BuildConfig. The Kotlin compiler inlines `static final` constants
+            // from BuildConfig at every call site, and incremental compilation does
+            // not invalidate those sites when BuildConfig.java regenerates with new
+            // values (the ABI is unchanged), so the inlined constants silently go
+            // stale across version bumps until a clean build.
             val appInfoSummary = stringResource(
                 R.string.about_system_info_version,
-                BuildConfig.VERSION_NAME,
-                BuildConfig.VERSION_CODE
+                versionName,
+                versionCode
             )
-            // Use the OS-recorded install time rather than BuildConfig.BUILD_TIME.
-            // The Kotlin compiler inlines `static final long BUILD_TIME` at every
-            // call site, and incremental compilation does not invalidate this file
-            // when BuildConfig.java is regenerated (the ABI is unchanged), so
-            // BuildConfig.BUILD_TIME silently goes stale across rebuilds.
-            val context = LocalContext.current
             val appBuildTime = remember(context) {
                 val installedAt = context.packageManager
                     .getPackageInfo(context.packageName, 0)

--- a/app/src/main/java/com/mydeck/app/ui/detail/BookmarkMetadataEditorDialog.kt
+++ b/app/src/main/java/com/mydeck/app/ui/detail/BookmarkMetadataEditorDialog.kt
@@ -137,7 +137,12 @@ fun BookmarkMetadataEditorDialog(
                         .padding(horizontal = 16.dp, vertical = 12.dp),
                     horizontalArrangement = Arrangement.End
                 ) {
+                    // Server rejects empty title or site_name with 400 "field is required".
+                    // Block the save here so the user gets immediate feedback instead of a
+                    // silent failure followed by an apparent rollback after resync.
+                    val canSave = title.isNotBlank() && siteName.isNotBlank()
                     Button(
+                        enabled = canSave,
                         onClick = {
                             onSave(
                                 BookmarkMetadataUpdate(
@@ -173,8 +178,12 @@ fun BookmarkMetadataEditorDialog(
                     value = title,
                     onValueChange = { title = it },
                     modifier = Modifier.fillMaxWidth(),
-                    label = { Text(stringResource(R.string.title)) },
+                    label = { Text(stringResource(R.string.metadata_title_label)) },
                     singleLine = true,
+                    isError = title.isBlank(),
+                    supportingText = if (title.isBlank()) {
+                        { Text(stringResource(R.string.metadata_field_required)) }
+                    } else null,
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
                     keyboardActions = KeyboardActions(
                         onNext = { descriptionFocusRequester.requestFocus() }
@@ -203,6 +212,10 @@ fun BookmarkMetadataEditorDialog(
                         .focusRequester(siteNameFocusRequester),
                     label = { Text(stringResource(R.string.detail_site_name)) },
                     singleLine = true,
+                    isError = siteName.isBlank(),
+                    supportingText = if (siteName.isBlank()) {
+                        { Text(stringResource(R.string.metadata_field_required)) }
+                    } else null,
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
                     keyboardActions = KeyboardActions(
                         onNext = { authorsFocusRequester.requestFocus() }

--- a/app/src/main/java/com/mydeck/app/ui/detail/components/BookmarkDetailWebViews.kt
+++ b/app/src/main/java/com/mydeck/app/ui/detail/components/BookmarkDetailWebViews.kt
@@ -150,10 +150,14 @@ fun BookmarkDetailArticle(
     val latestToggleArchive by rememberUpdatedState(onToggleArchive)
     // Key on articleContent presence (not the full string) so annotation-refresh HTML changes
     // don't trigger a full WebView reload — those are handled via JS innerHTML replacement.
+    // Title and description are reader-header inputs, so include them so that an in-app
+    // metadata edit re-renders the reader without requiring a navigate-out / navigate-in.
     val content = remember(
         uiState.bookmark.bookmarkId,
         uiState.bookmark.articleContent != null,
         uiState.bookmark.embed,
+        uiState.bookmark.title,
+        uiState.bookmark.description,
         contentReloadKey,
         readerTopClearanceCssPx
     ) {
@@ -238,6 +242,8 @@ fun BookmarkDetailArticle(
         uiState.bookmark.bookmarkId,
         uiState.bookmark.articleContent != null,
         uiState.bookmark.embed,
+        uiState.bookmark.title,
+        uiState.bookmark.description,
         contentReloadKey,
         readerTopClearanceCssPx
     ) {

--- a/app/src/main/java/com/mydeck/app/ui/list/BookmarkListScreen.kt
+++ b/app/src/main/java/com/mydeck/app/ui/list/BookmarkListScreen.kt
@@ -6,6 +6,7 @@ package com.mydeck.app.ui.list
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -1065,6 +1066,7 @@ fun BookmarkListView(
                         onClickArchive = onClickArchive,
                         onClickDelete = onClickDelete,
                         onClickFavorite = onClickFavorite,
+                        onPendingDeletionTap = onUserInteraction,
                         modifier = Modifier.animateItem(),
                     ) {
                         when (layoutMode) {
@@ -1163,6 +1165,7 @@ fun BookmarkListView(
                         onClickArchive = onClickArchive,
                         onClickDelete = onClickDelete,
                         onClickFavorite = onClickFavorite,
+                        onPendingDeletionTap = onUserInteraction,
                         modifier = Modifier.animateItem(),
                     ) {
                         when (layoutMode) {
@@ -1269,6 +1272,7 @@ private fun SwipeWrappedBookmark(
     onClickArchive: (String, Boolean) -> Unit,
     onClickDelete: (String) -> Unit,
     onClickFavorite: (String, Boolean) -> Unit,
+    onPendingDeletionTap: () -> Unit,
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {
@@ -1299,8 +1303,27 @@ private fun SwipeWrappedBookmark(
         },
         modifier = modifier,
     ) {
-        Box(modifier = Modifier.alpha(if (isPendingDeletion) 0.38f else 1f)) {
-            content()
+        Box {
+            Box(modifier = Modifier.alpha(if (isPendingDeletion) 0.38f else 1f)) {
+                content()
+            }
+            // While pending deletion, an opaque click-interceptor overlay catches
+            // every tap and long-press on the card before they can reach any of
+            // the inner click surfaces (image, title overlay, body, action icons).
+            // Routes to onPendingDeletionTap, which dismisses the snackbar without
+            // Undo — committing the delete — and ensures the reading view does
+            // NOT also open from a stray click leak.
+            if (isPendingDeletion) {
+                Box(
+                    modifier = Modifier
+                        .matchParentSize()
+                        .clickable(
+                            interactionSource = remember { MutableInteractionSource() },
+                            indication = null,
+                            onClick = onPendingDeletionTap
+                        )
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/mydeck/app/ui/settings/LogViewViewModel.kt
+++ b/app/src/main/java/com/mydeck/app/ui/settings/LogViewViewModel.kt
@@ -73,7 +73,7 @@ class LogViewViewModel @Inject constructor(
     }
 
     fun onShareLogs() {
-        logAppInfo()
+        logAppInfo(context)
         viewModelScope.launch {
             val zipFile = createLogFilesZip(context)
             if (zipFile != null) {
@@ -90,7 +90,7 @@ class LogViewViewModel @Inject constructor(
     }
 
     fun onSaveToDownloads() {
-        logAppInfo()
+        logAppInfo(context)
         viewModelScope.launch {
             val zipFile = createLogFilesZip(context)
             if (zipFile == null) {

--- a/app/src/main/java/com/mydeck/app/util/AppVersion.kt
+++ b/app/src/main/java/com/mydeck/app/util/AppVersion.kt
@@ -1,0 +1,32 @@
+package com.mydeck.app.util
+
+import android.content.Context
+import android.content.pm.PackageInfo
+import android.os.Build
+
+/**
+ * Reads versionName / versionCode from the installed PackageInfo at runtime.
+ *
+ * Avoids `BuildConfig.VERSION_NAME` / `BuildConfig.VERSION_CODE`, which the
+ * Kotlin compiler inlines at every call site as `static final` constants.
+ * Incremental compilation does not invalidate inlined call sites when only
+ * the generated `BuildConfig.java` value changes (the ABI is unchanged), so
+ * those constants silently go stale across version bumps until a clean build.
+ */
+object AppVersion {
+    fun versionName(context: Context): String =
+        packageInfo(context).versionName.orEmpty()
+
+    fun versionCode(context: Context): Long {
+        val info = packageInfo(context)
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            info.longVersionCode
+        } else {
+            @Suppress("DEPRECATION")
+            info.versionCode.toLong()
+        }
+    }
+
+    private fun packageInfo(context: Context): PackageInfo =
+        context.packageManager.getPackageInfo(context.packageName, 0)
+}

--- a/app/src/main/java/com/mydeck/app/util/BookmarkDebugExporter.kt
+++ b/app/src/main/java/com/mydeck/app/util/BookmarkDebugExporter.kt
@@ -78,8 +78,8 @@ class BookmarkDebugExporter(
         val root = buildJsonObject {
             putJsonObject("exportInfo") {
                 put("exportTimestamp", SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.US).format(Date()))
-                put("appVersion", BuildConfig.VERSION_NAME)
-                put("appVersionCode", BuildConfig.VERSION_CODE)
+                put("appVersion", AppVersion.versionName(context))
+                put("appVersionCode", AppVersion.versionCode(context))
                 put("buildType", BuildConfig.BUILD_TYPE)
                 put("apiDataAvailable", rawApiJson != null)
                 put("articleHtmlAvailable", rawArticleHtml != null)

--- a/app/src/main/java/com/mydeck/app/util/LoggerUtil.kt
+++ b/app/src/main/java/com/mydeck/app/util/LoggerUtil.kt
@@ -1,6 +1,7 @@
 package com.mydeck.app.util
 
 
+import android.content.Context
 import com.mydeck.app.BuildConfig
 import com.mydeck.app.LOGDIR
 import fr.bipi.treessence.file.FileLoggerTree
@@ -61,11 +62,11 @@ fun createLogDir(parentDir: File): File? {
     }
 }
 
-fun logAppInfo() {
+fun logAppInfo(context: Context) {
     Timber.tag("APP-INFO")
-    Timber.i("versionName=${BuildConfig.VERSION_NAME}")
+    Timber.i("versionName=${AppVersion.versionName(context)}")
     Timber.tag("APP-INFO")
-    Timber.i("versionCode=${BuildConfig.VERSION_CODE}")
+    Timber.i("versionCode=${AppVersion.versionCode(context)}")
     Timber.tag("APP-INFO")
     Timber.i("flavor=${BuildConfig.FLAVOR}")
 }

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -327,6 +327,8 @@ other{}
     <string name="detail_images_downloaded">Images downloaded</string>
     <string name="detail_images_from_network">Images load from network</string>
     <string name="metadata_one_value_per_line">One value per line</string>
+    <string name="metadata_field_required">Required</string>
+    <string name="metadata_title_label">Title</string>
     <string name="metadata_text_direction_auto">Automatic</string>
     <string name="metadata_text_direction_ltr">Left to right</string>
     <string name="metadata_text_direction_rtl">Right to left</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -310,6 +310,8 @@ other{}
     <string name="detail_images_downloaded">Images downloaded</string>
     <string name="detail_images_from_network">Images load from network</string>
     <string name="metadata_one_value_per_line">One value per line</string>
+    <string name="metadata_field_required">Required</string>
+    <string name="metadata_title_label">Title</string>
     <string name="metadata_text_direction_auto">Automatic</string>
     <string name="metadata_text_direction_ltr">Left to right</string>
     <string name="metadata_text_direction_rtl">Right to left</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -169,6 +169,8 @@
     <string name="detail_images_downloaded">Images downloaded</string>
     <string name="detail_images_from_network">Images load from network</string>
     <string name="metadata_one_value_per_line">One value per line</string>
+    <string name="metadata_field_required">Required</string>
+    <string name="metadata_title_label">Title</string>
     <string name="metadata_text_direction_auto">Automatic</string>
     <string name="metadata_text_direction_ltr">Left to right</string>
     <string name="metadata_text_direction_rtl">Right to left</string>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -249,6 +249,8 @@ other{}
     <string name="detail_images_downloaded">Images downloaded</string>
     <string name="detail_images_from_network">Images load from network</string>
     <string name="metadata_one_value_per_line">One value per line</string>
+    <string name="metadata_field_required">Required</string>
+    <string name="metadata_title_label">Title</string>
     <string name="metadata_text_direction_auto">Automatic</string>
     <string name="metadata_text_direction_ltr">Left to right</string>
     <string name="metadata_text_direction_rtl">Right to left</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -169,6 +169,8 @@
     <string name="detail_images_downloaded">Images downloaded</string>
     <string name="detail_images_from_network">Images load from network</string>
     <string name="metadata_one_value_per_line">One value per line</string>
+    <string name="metadata_field_required">Required</string>
+    <string name="metadata_title_label">Title</string>
     <string name="metadata_text_direction_auto">Automatic</string>
     <string name="metadata_text_direction_ltr">Left to right</string>
     <string name="metadata_text_direction_rtl">Right to left</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -169,6 +169,8 @@
     <string name="detail_images_downloaded">Images downloaded</string>
     <string name="detail_images_from_network">Images load from network</string>
     <string name="metadata_one_value_per_line">One value per line</string>
+    <string name="metadata_field_required">Required</string>
+    <string name="metadata_title_label">Title</string>
     <string name="metadata_text_direction_auto">Automatic</string>
     <string name="metadata_text_direction_ltr">Left to right</string>
     <string name="metadata_text_direction_rtl">Right to left</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -169,6 +169,8 @@
     <string name="detail_images_downloaded">Images downloaded</string>
     <string name="detail_images_from_network">Images load from network</string>
     <string name="metadata_one_value_per_line">One value per line</string>
+    <string name="metadata_field_required">Required</string>
+    <string name="metadata_title_label">Title</string>
     <string name="metadata_text_direction_auto">Automatic</string>
     <string name="metadata_text_direction_ltr">Left to right</string>
     <string name="metadata_text_direction_rtl">Right to left</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -169,6 +169,8 @@
     <string name="detail_images_downloaded">Images downloaded</string>
     <string name="detail_images_from_network">Images load from network</string>
     <string name="metadata_one_value_per_line">One value per line</string>
+    <string name="metadata_field_required">Required</string>
+    <string name="metadata_title_label">Title</string>
     <string name="metadata_text_direction_auto">Automatic</string>
     <string name="metadata_text_direction_ltr">Left to right</string>
     <string name="metadata_text_direction_rtl">Right to left</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -303,6 +303,8 @@
     <string name="detail_images_downloaded">Images downloaded</string>
     <string name="detail_images_from_network">Images load from network</string>
     <string name="metadata_one_value_per_line">One value per line</string>
+    <string name="metadata_field_required">Required</string>
+    <string name="metadata_title_label">Title</string>
     <string name="metadata_text_direction_auto">Automatic</string>
     <string name="metadata_text_direction_ltr">Left to right</string>
     <string name="metadata_text_direction_rtl">Right to left</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -335,6 +335,8 @@ other{}
     <string name="extraction_log_copy">copy to clipboard</string>
     <string name="extraction_log_retry">Retry</string>
     <string name="metadata_one_value_per_line">One value per line</string>
+    <string name="metadata_field_required">Required</string>
+    <string name="metadata_title_label">Title</string>
     <string name="metadata_text_direction_auto">Automatic</string>
     <string name="metadata_text_direction_ltr">Left to right</string>
     <string name="metadata_text_direction_rtl">Right to left</string>

--- a/app/src/test/java/com/mydeck/app/domain/usecase/OAuthDeviceAuthorizationUseCaseTest.kt
+++ b/app/src/test/java/com/mydeck/app/domain/usecase/OAuthDeviceAuthorizationUseCaseTest.kt
@@ -1,5 +1,8 @@
 package com.mydeck.app.domain.usecase
 
+import android.content.Context
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
 import com.mydeck.app.domain.model.OAuthDeviceAuthorizationState
 import com.mydeck.app.io.rest.ReadeckApi
 import com.mydeck.app.io.rest.model.*
@@ -26,7 +29,15 @@ class OAuthDeviceAuthorizationUseCaseTest {
     fun setup() {
         readeckApi = mockk()
         json = Json { ignoreUnknownKeys = true }
-        useCase = OAuthDeviceAuthorizationUseCase(readeckApi, json)
+        val packageInfo = PackageInfo().apply { versionName = "test-version" }
+        val packageManager = mockk<PackageManager> {
+            every { getPackageInfo(any<String>(), 0) } returns packageInfo
+        }
+        val context = mockk<Context> {
+            every { this@mockk.packageManager } returns packageManager
+            every { packageName } returns "com.mydeck.app.test"
+        }
+        useCase = OAuthDeviceAuthorizationUseCase(readeckApi, json, context)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes a critical server-side metadata wipe triggered by ordinary label edits, plus four related UX/diagnostic issues surfaced while investigating it. Verified at the wire with OkHttp body-level logging against Readeck 0.22.3.

---

### 1. Bookmark title / site_name / description wiped on label add (critical)

**Diagnosis.** The shared `Json` instance had `encodeDefaults = true` (added defensively in #127). For sparse outgoing DTOs like `EditBookmarkDto`, every nullable default serialized as an explicit JSON `null`. When the app PATCHed `{"labels":["foo"]}` it actually sent 14 extra `null` fields. Readeck 0.22.3 treats bound-but-null fields as "set to empty" and silently zeroed `title`, `site_name`, `description`, `lang`, `authors`. The next delta sync pulled the corrupted bookmark back into the local DB. Readeck 0.22.1 tolerated the nulls as no-ops, which is why the bug only reproduces against 0.22.3.

**Solution.** Remove `encodeDefaults = true` and add `explicitNulls = false` in `AppModule.provideJson()`. Sparse DTOs now serialize only the fields the caller populated. Confirmed safe for `SyncRequest` (booleans default to `false` and callers pass explicit `true` when needed) and all other outgoing request DTOs.

### 2. `BuildConfig.VERSION_NAME` silently stale across version bumps

**Diagnosis.** The Kotlin compiler inlines `static final` constants from generated `BuildConfig.java` at every call site. Incremental compilation does not invalidate inlined sites when only the constant's value changes (the ABI is unchanged), so version bumps leave stale values baked into compiled classes until a clean build. About screen showed `0.12.6-snapshot` after upgrading to 0.13.0; the OAuth client registration was reporting the wrong version to the server.

**Solution.** New `AppVersion` helper reads `versionName` / `versionCode` from `PackageManager` at runtime. Applied to `AboutScreen`, `LoggerUtil.logAppInfo`, `BookmarkDebugExporter`, and `OAuthDeviceAuthorizationUseCase`. Matches the existing PackageManager-based workaround already used for `BUILD_TIME`.

### 3. Metadata editor allowed unsavable empty title / site_name

**Diagnosis.** Readeck 0.22.3 rejects PATCHes with empty `title` or `site_name` (400, "field is required"). The dialog let the user save anyway: the local DB optimistically showed the blanks, the PATCH 400ed, the pending action errored out silently, and the next resync replaced the local blanks with the server's existing values — making the edit appear to roll back for no reason.

**Solution.** Disable the Save button while `title` or `siteName` is blank, and mark each field with `isError = true` + inline "Required" supporting text. Also use a dedicated `metadata_title_label` ("Title") instead of borrowing the Add Bookmark sheet's "Title (Optional)".

### 4. Tap on greyed pending-delete card opened the reading view

**Diagnosis.** The card has multiple click surfaces (image, title overlay, body, action icons), each with its own `clickable` modifier. Per-call-site gating (`if (isPendingDeletion) confirmDelete else onClickBookmark`) was incomplete and racy — long-press handlers and rapid taps during state propagation could still navigate to the reader, which then errored out trying to load the locally-deleted bookmark.

**Solution.** When `isPendingDeletion = true`, `SwipeWrappedBookmark` overlays a transparent, full-card click interceptor on top of the content. All taps land on the overlay, dismiss the snackbar without Undo (committing the delete), and never reach the underlying click surfaces.

### 5. Reading view did not reflect title / description edits without re-navigating

**Diagnosis.** The reader's `<header>` (rendered into the WebView HTML by `Bookmark.getContent`) includes the title and description. The `remember` and `LaunchedEffect` keys that regenerate the HTML were intentionally keyed on `articleContent != null` (a boolean, to avoid full reloads on annotation-driven HTML edits) but did not include `title` or `description`. Metadata edits therefore didn't trigger HTML re-emission until the bookmark was closed and reopened.

**Solution.** Add `bookmark.title` and `bookmark.description` to the regeneration keys. Annotation refreshes still don't reload, since they only modify `articleContent` (still keyed as a boolean).

### 6. (Diagnostic infrastructure) OkHttp body logging routed through Timber

To capture the wire-level evidence above, `HttpLoggingInterceptor` is now at `BODY` level in debug builds, with `Authorization` / `Cookie` / `Set-Cookie` redacted. Output is routed through `Timber.d` (not `.v`, which the FileLoggerTree filters) so wire bodies land in the on-device log file alongside everything else.

---

## Test plan

- [ ] Add a label on a Readeck 0.22.3 bookmark; confirm wire body is `{"labels":["..."]}` only and that `title` / `site_name` / `description` survive the next resync.
- [ ] Edit metadata, try to save with blank title or site_name; confirm Save is disabled and inline "Required" appears.
- [ ] Edit title or description from the bookmark details dialog; confirm reader header updates in place without re-navigating.
- [ ] Swipe a card to delete; tap on the greyed-out card during the snackbar; confirm the delete commits and the reading view does not open.
- [ ] Verify About screen shows the installed `versionName` / `versionCode` (no stale-build display).
- [ ] Regression: confirm sync still works (`SyncRequest.withJson=true` still serializes).
- [ ] `./gradlew :app:testDebugUnitTestAll` and `:app:lintDebugAll` clean.
