### PR TITLE
docs: add specs for HTTPS-only release default and native reader action footer

### DIFF
--- a/docs/specs/reader-native-action-footer-spec.md
+++ b/docs/specs/reader-native-action-footer-spec.md
@@ -1,0 +1,289 @@
+# Spec: Native Compose Reader Action Footer
+
+## Status
+
+Proposal — not yet scheduled for implementation.
+
+## Context
+
+### Current state (v0.13.1)
+
+The reader WebView renders favorite and archive buttons at the bottom of the
+article HTML template. These are HTML elements, styled in the template's CSS,
+and wired to native code through `WebViewActionsBridge`:
+
+- `WebViewActionsBridge.toggleFavorite()` — calls into `BookmarkDetailViewModel`
+  to flip the bookmark's favorite state.
+- `WebViewActionsBridge.toggleArchive()` — same for archive state.
+
+Bridge registration happens in
+`app/src/main/java/com/mydeck/app/ui/detail/components/BookmarkDetailWebViews.kt`.
+The bridge is installed only on the reader WebView (the `WebViewAssetLoader`-backed
+instance loading from `https://offline.mydeck.local/...`), not on the
+original-page WebView.
+
+The footer buttons live inside the scrolling article content, so they scroll out
+of view with the rest of the page. Button state (favorited / unfavorited,
+archived / unarchived) is kept in sync via `setFavoriteStateScript` /
+`setArchiveStateScript` in `WebViewActionsInjector`, which are evaluated against
+the WebView whenever the underlying state changes outside the page.
+
+### Why this needs to change
+
+**Defense-in-depth weakness.** The reader WebView loads server-extracted HTML.
+Readeck sanitizes that HTML server-side, but the bridge exposes mutating account
+operations to any JavaScript that runs in the reader context. If the sanitizer
+ever misses a script tag, regresses in a future Readeck release, or behaves
+differently for a new extraction path, the consequence is that page JS can flip
+favorite/archive state on the current bookmark. The blast radius is small (no
+token access, no arbitrary code, two bounded toggles) but the dependency is
+"Readeck's sanitizer never has a bug." That is an unnecessary single point of
+failure when the actions do not need to be JS-callable at all.
+
+The asymmetry matters: MyDeck releases on a 2–3 week cadence; Readeck releases
+on a slower cadence. A sanitizer regression in a Readeck point release would
+expose MyDeck users until the next Readeck release fixes it, and the MyDeck
+side has no recourse beyond removing the bridge — which is what this spec
+proposes doing pre-emptively.
+
+**UX limitations.** The buttons scroll with content rather than remaining
+visible, so they are not always discoverable when the user has read past them.
+They do not get Material ripple, cannot easily honor the reader theme palette
+across sepia/dark/light reliably, and require parallel JS state updates whenever
+favorite/archive state changes elsewhere in the app.
+
+**Architectural cost.** The bridge, the injectors, the JS state-sync calls, and
+the HTML/CSS for the footer all exist solely to make this one piece of UI work
+inside the WebView. A native Compose footer eliminates that entire stack.
+
+### Why a previous attempt failed
+
+An earlier attempt to render the footer as a Compose overlay did not work,
+primarily because the WebView and Compose were competing for scroll ownership
+and the footer-show signal was being computed outside the WebView's scroll
+context. Since then, the top-app-bar scroll behavior has been solved using the
+same overlay shape with the WebView remaining the scroller. The same
+architectural pattern applies to a footer.
+
+## Goals
+
+- Remove `WebViewActionsBridge` entirely.
+- Render favorite and archive as native Compose buttons.
+- The footer is hidden by default and animates in only when the user has
+  scrolled to the end of the article content.
+- The article content never sits underneath the footer when it is visible.
+- Reader theme (light / sepia / dark) is honored without JS state injection.
+
+## Non-goals
+
+- Changing how favorite/archive state is persisted, synced, or queued offline.
+- Changing the top-app-bar pattern. This spec mirrors it; it does not modify it.
+- Adding new actions to the footer beyond favorite and archive. Other actions,
+  if any, are a follow-up.
+- Touching the original-page WebView, which has no bridge today.
+
+## Design
+
+### Signal: IntersectionObserver sentinel, not scroll percentage
+
+Add a zero-height sentinel element at the end of the article body in the reader
+HTML template:
+
+```html
+<div id="mydeck-end-sentinel" aria-hidden="true"></div>
+```
+
+Attach an `IntersectionObserver` in the reader JS that watches this sentinel and
+reports state changes through a new read-only bridge:
+
+```kotlin
+class WebViewEndSentinelBridge(
+    private val onEndVisibleChanged: (Boolean) -> Unit
+) {
+    @JavascriptInterface
+    fun onEndVisible(visible: Boolean) {
+        onEndVisibleChanged(visible)
+    }
+    companion object { const val BRIDGE_NAME = "MyDeckEndSentinel" }
+}
+```
+
+Rationale for sentinel over scroll percentage:
+
+- **Reliable across content types.** Picture and video reader views have CSS
+  padding/margins and iframe-based embeds that distort percentage math. A
+  sentinel reports when the end of content is in viewport, regardless of layout.
+- **Naturally bidirectional.** Hides when the user scrolls back up.
+- **Cheap.** One observer per page, no `requestAnimationFrame` polling.
+- **Read-only callback.** No state mutation; same shape as `WebViewScrollBridge`
+  today. The bridge-removal goal applies to mutating bridges; event-report
+  bridges are kept.
+
+### Shared signal with auto-mark-as-read
+
+Auto-mark-as-read at end-of-content already exists. The end-sentinel-visible
+signal should also feed that logic, so footer-visibility and read-completion
+are derived from the same source of truth and cannot drift. Practical
+implication: the existing scroll-bridge logic that decides "the user has
+finished the article" should either be replaced by, or call into, the same
+end-visible signal.
+
+### Bottom clearance
+
+Mirror the existing top-clearance pattern (`readerTopClearanceCssPx`). Inject a
+CSS custom property from Kotlin and apply it as `padding-bottom` on the body:
+
+```css
+body {
+  padding-top: var(--mydeck-top-clearance-px, 0px);
+  padding-bottom: var(--mydeck-bottom-clearance-px, 0px);
+}
+```
+
+`--mydeck-bottom-clearance-px` is computed from the Compose footer's target
+height plus the bottom safe-area inset, set once when the footer's target
+height is known (not animated). Setting it to the target value up front —
+rather than recomputing during the show/hide animation — prevents content
+reflow during the animation.
+
+When the footer is suppressed for a given layout or bookmark type (see edge
+cases), the clearance variable stays at 0 so the article uses the full
+viewport.
+
+### Compose layer
+
+```
+Box(modifier = Modifier.fillMaxSize()) {
+    ReaderWebView(...)  // unchanged
+    AnimatedVisibility(
+        visible = uiState.endVisible && uiState.showFooter,
+        enter = slideInVertically { it } + fadeIn(),
+        exit = slideOutVertically { it } + fadeOut(),
+        modifier = Modifier.align(Alignment.BottomCenter)
+    ) {
+        ReaderActionFooter(
+            isFavorite = uiState.bookmark.isFavorite,
+            isArchived = uiState.bookmark.isArchived,
+            onToggleFavorite = viewModel::toggleFavorite,
+            onToggleArchive = viewModel::toggleArchive,
+            palette = readerThemePalette
+        )
+    }
+}
+```
+
+`ReaderActionFooter` is a `Row` with two `IconButton`s side-by-side, centered,
+surface coloured from the reader palette (not the global Material scheme) so
+it harmonises with sepia and reader-dark themes. Material ripple is automatic.
+
+`uiState.endVisible` is fed from the new bridge. `uiState.showFooter` gates on
+the layout/type conditions in the edge-cases section below.
+
+## Edge cases
+
+1. **Bookmark type variance.** Picture and video reader templates differ from
+   article. The sentinel must render at the visual end of each template's
+   content (not the end of the DOM, which for video may be the embed iframe).
+   For picture bookmarks the sentinel goes after the image caption; for video,
+   after the embed. Alternatively, scope the footer to article-type bookmarks
+   for v1 and let picture/video continue surfacing favorite/archive via the
+   existing metadata view. **Recommendation: scope to article in v1; revisit
+   picture/video in a follow-up.**
+2. **Wide layouts (tablet landscape).** Bookmark details may already be
+   persistent on the side with favorite/archive controls available there.
+   Verify against the current AppShell layout. If duplicate controls would
+   result, suppress the floating footer in those layouts
+   (`showFooter = false`).
+3. **Original-page WebView.** Do not render the footer there. The
+   favorite/archive actions still apply to the underlying bookmark, but mixing
+   them with non-extracted content is confusing UX, and the original-page
+   WebView has no sentinel injected anyway.
+4. **Annotation / selection toolbars.** If text-selection or
+   annotation-creation surfaces appear at the bottom of the reader, the footer
+   must yield. Gate `showFooter` on "no active selection toolbar" and "no
+   active annotation editor."
+5. **In-article search bar.** Currently at the top, so no collision. Document
+   the assumption and revisit if search ever moves to the bottom.
+6. **Embed-heavy pages with delayed layout.** Some video/embed pages finish
+   layout slowly. The sentinel's first `IntersectionObserver` callback may
+   fire late. Acceptable — the footer simply does not appear until the page
+   is genuinely scrolled to end. Better than a percentage-based heuristic
+   firing too early on slow-loading pages.
+7. **Very short articles where the sentinel is visible immediately on load.**
+   The footer appears right away, which is fine — the user has effectively
+   read the whole article. Optionally debounce by ~150 ms so the footer does
+   not flash during initial page paint.
+8. **Theme changes mid-read.** The CSS clearance variable does not need to
+   change with theme. The footer rerenders on palette change automatically.
+   No special handling needed.
+
+## Implementation outline
+
+1. Add sentinel element to article (and picture/video, if scoping wider)
+   reader HTML templates.
+2. Add reader JS: `IntersectionObserver` wiring, calls
+   `MyDeckEndSentinel.onEndVisible(visible)`.
+3. Add `WebViewEndSentinelBridge` Kotlin class. Register on the reader WebView
+   in `BookmarkDetailWebViews.kt`.
+4. Hoist `endVisible: Boolean` into `BookmarkDetailViewModel.UiState`.
+5. Add `--mydeck-bottom-clearance-px` to the article CSS and its injection
+   point in Kotlin (mirror `readerTopClearanceCssPx`).
+6. Build `ReaderActionFooter` composable.
+7. Wrap the existing WebView in the Compose `Box` + `AnimatedVisibility`
+   overlay.
+8. Wire auto-mark-as-read to consume `endVisible` (or share the signal).
+   Remove the old percentage-based trigger if no longer needed.
+9. Remove the in-template footer HTML, CSS, and the bridge wiring.
+10. Delete `WebViewActionsBridge.kt`, `WebViewActionsInjector.kt` (or trim if
+    other code uses parts of it).
+11. Update `SECURITY.md` reader-bridge enumeration to reflect the new set.
+
+## Code to remove
+
+- `app/src/main/java/com/mydeck/app/ui/detail/WebViewActionsBridge.kt`
+- The action-button HTML/CSS sections of the article/picture/video reader
+  templates under `app/src/main/assets/`.
+- `WebViewActionsInjector.setFavoriteStateScript` and `setArchiveStateScript`
+  (or the entire file, if these are its only uses).
+- The bridge registration block for `WebViewActionsBridge` in
+  `BookmarkDetailWebViews.kt`.
+- The JS state-sync calls that fire when favorite/archive state changes
+  outside the WebView.
+
+## Test plan
+
+- Unit tests for `endVisible` state transitions in
+  `BookmarkDetailViewModel`.
+- Robolectric test for `ReaderActionFooter` rendering with each palette
+  variant.
+- Manual test matrix:
+  - Article / picture / video bookmark types
+  - Phone portrait / phone landscape / tablet portrait / tablet landscape
+  - Light / dark / sepia themes
+  - Short article (sentinel visible at load) vs. long article
+  - Scroll to end, then scroll back up — footer hides
+  - Toggle favorite/archive — state persists, no JS reload of WebView
+  - Offline state — toggle queues to pending actions, footer reflects pending
+    state via the existing UiState path
+  - Original-page WebView — footer never shown
+  - Wide layout — footer suppressed if duplicate controls present in side
+    panel
+
+## Out of scope
+
+- Adding more actions to the footer (share, delete, add label). v1 is
+  favorite + archive only.
+- Changing the top app bar.
+- Picture/video footer support if v1 is scoped to article only.
+- Auto-mark-as-read behavior changes beyond sharing the signal source.
+
+## Open questions
+
+1. **Article-only vs. all reader types in v1?** Scoping to article is simpler
+   and lower risk. Picture/video can adopt the pattern later. Recommendation:
+   article only in v1.
+2. **Animation duration and easing.** Match the top-bar animation, or pick
+   independently? Recommendation: match top-bar for consistency.
+3. **Should the footer auto-hide after N seconds of no interaction?** Probably
+   not, but worth a UX call. Default recommendation: no auto-hide; visibility
+   is purely driven by the sentinel.

--- a/docs/specs/reader-native-action-footer-spec.md
+++ b/docs/specs/reader-native-action-footer-spec.md
@@ -69,10 +69,13 @@ architectural pattern applies to a footer.
 
 - Remove `WebViewActionsBridge` entirely.
 - Render favorite and archive as native Compose buttons.
-- The footer is hidden by default and animates in only when the user has
-  scrolled to the end of the article content.
-- The article content never sits underneath the footer when it is visible.
+- The footer is hidden by default and animates in when the user has scrolled to
+  the end of the reader content, for all three bookmark types
+  (article / picture / video).
+- The reader content never sits underneath the footer when it is visible.
 - Reader theme (light / sepia / dark) is honored without JS state injection.
+- The footer's enter/exit animation matches the top-app-bar animation already
+  in place, so the two overlays feel like one system.
 
 ## Non-goals
 
@@ -81,6 +84,9 @@ architectural pattern applies to a footer.
 - Adding new actions to the footer beyond favorite and archive. Other actions,
   if any, are a follow-up.
 - Touching the original-page WebView, which has no bridge today.
+- Changing the existing read-progress mechanics. The footer-visibility signal
+  is shared with the completion trigger but neither replaces the broader read
+  state machine.
 
 ## Design
 
@@ -119,14 +125,34 @@ Rationale for sentinel over scroll percentage:
   today. The bridge-removal goal applies to mutating bridges; event-report
   bridges are kept.
 
-### Shared signal with auto-mark-as-read
+### Shared signal with auto-mark-as-read (per type)
 
-Auto-mark-as-read at end-of-content already exists. The end-sentinel-visible
-signal should also feed that logic, so footer-visibility and read-completion
-are derived from the same source of truth and cannot drift. Practical
-implication: the existing scroll-bridge logic that decides "the user has
-finished the article" should either be replaced by, or call into, the same
-end-visible signal.
+Read-state behavior today, confirmed against `BookmarkDetailViewModel.kt`:
+
+- **Picture and Video bookmarks** are auto-marked to `readProgress = 100`
+  unconditionally on open, in `initializeBookmark()` at lines 250–257. The
+  sentinel does not change this; for these types it drives footer visibility
+  only.
+- **Article bookmarks** track read progress through
+  `onScrollProgressChanged(progress: Int)` (line 561), fed by
+  `WebViewScrollBridge`. The article is treated as completed and the tracker
+  is locked when `progress.coerceIn(0, 100) >= 100` (line 570), at which point
+  `isReadLocked = true` and further scroll updates are ignored. On open,
+  `isReadLocked` is initialized to `bookmark.isRead()` (line 314).
+
+The sentinel changes the article-completion trigger only. After this spec:
+
+- Intermediate scroll progress (`0..99`) still flows through
+  `WebViewScrollBridge` and `onScrollProgressChanged` — this is what feeds
+  resume-from-position and the in-list progress indicator. No change.
+- The completion trigger that flips `isReadLocked = true` and sets
+  `currentScrollProgress = 100` moves from "scroll progress reaches 100" to
+  "end sentinel becomes visible." This is more accurate on long articles with
+  embedded media where the scroll-percentage calculation can fail to hit
+  exactly 100. Footer visibility and read-completion now share the same
+  source of truth and cannot drift.
+- For Picture/Video, the existing immediate-100 path is untouched. The sentinel
+  is wired only to the footer-visibility state in the UiState for those types.
 
 ### Bottom clearance
 
@@ -179,111 +205,167 @@ it harmonises with sepia and reader-dark themes. Material ripple is automatic.
 `uiState.endVisible` is fed from the new bridge. `uiState.showFooter` gates on
 the layout/type conditions in the edge-cases section below.
 
+## Sentinel placement per bookmark type
+
+Each reader type composes its content differently in
+`BookmarkDetailViewModel.Bookmark.getContent()` (lines 1688–1766). The
+sentinel must render at the visual end of each type's content, not at the end
+of the DOM. The recommended placement, expressed against the existing
+composition:
+
+- **Article** (`Type.ARTICLE`, line 1760): the body is
+  `<div id="rd-article-content">$articleContent</div>` followed by the current
+  `footerHtml`. Sentinel goes immediately after the closing
+  `</div>` of `rd-article-content` and replaces the footer.
+- **Picture** (`Type.PHOTO`, line 1715): the body is an image element plus an
+  optional text caption. Sentinel goes after the caption when present, or
+  immediately after the `<img>` when not. Replaces the footer.
+- **Video** (`Type.VIDEO`, line 1737): the body is the embed (in
+  `<div class="video-embed">`) followed by
+  `<div id="rd-article-content">$textPart</div>` (transcript or description).
+  Sentinel goes after the closing `</div>` of `rd-article-content`. Replaces
+  the footer.
+
+The cleanest implementation is to replace `buildReaderFooterHtml(...)` with
+`buildReaderEndSentinelHtml()` returning
+`<div id="mydeck-end-sentinel" aria-hidden="true"></div>`, and remove the
+favorite/archive label parameters from `getContent()`'s signature entirely.
+The three type branches keep the same composition shape; only the trailing
+element changes.
+
 ## Edge cases
 
-1. **Bookmark type variance.** Picture and video reader templates differ from
-   article. The sentinel must render at the visual end of each template's
-   content (not the end of the DOM, which for video may be the embed iframe).
-   For picture bookmarks the sentinel goes after the image caption; for video,
-   after the embed. Alternatively, scope the footer to article-type bookmarks
-   for v1 and let picture/video continue surfacing favorite/archive via the
-   existing metadata view. **Recommendation: scope to article in v1; revisit
-   picture/video in a follow-up.**
-2. **Wide layouts (tablet landscape).** Bookmark details may already be
+1. **Wide layouts (tablet landscape).** Bookmark details may already be
    persistent on the side with favorite/archive controls available there.
    Verify against the current AppShell layout. If duplicate controls would
    result, suppress the floating footer in those layouts
    (`showFooter = false`).
-3. **Original-page WebView.** Do not render the footer there. The
+2. **Original-page WebView.** Do not render the footer there. The
    favorite/archive actions still apply to the underlying bookmark, but mixing
    them with non-extracted content is confusing UX, and the original-page
    WebView has no sentinel injected anyway.
-4. **Annotation / selection toolbars.** If text-selection or
+3. **Annotation / selection toolbars.** If text-selection or
    annotation-creation surfaces appear at the bottom of the reader, the footer
    must yield. Gate `showFooter` on "no active selection toolbar" and "no
    active annotation editor."
-5. **In-article search bar.** Currently at the top, so no collision. Document
+4. **In-article search bar.** Currently at the top, so no collision. Document
    the assumption and revisit if search ever moves to the bottom.
-6. **Embed-heavy pages with delayed layout.** Some video/embed pages finish
+5. **Embed-heavy pages with delayed layout.** Some video/embed pages finish
    layout slowly. The sentinel's first `IntersectionObserver` callback may
    fire late. Acceptable — the footer simply does not appear until the page
    is genuinely scrolled to end. Better than a percentage-based heuristic
    firing too early on slow-loading pages.
+6. **Picture and Video bookmarks where content fits without scrolling.** The
+   sentinel is visible at load time, so the footer appears immediately. That
+   is the right UX — these bookmark types are already auto-marked as read on
+   open, so showing the footer immediately matches the user's mental model
+   ("I can see the whole thing; here are my actions"). Debounce by ~150 ms so
+   the footer does not flash during initial page paint.
 7. **Very short articles where the sentinel is visible immediately on load.**
-   The footer appears right away, which is fine — the user has effectively
-   read the whole article. Optionally debounce by ~150 ms so the footer does
-   not flash during initial page paint.
+   Same as above — footer appears right away. Same ~150 ms debounce.
 8. **Theme changes mid-read.** The CSS clearance variable does not need to
    change with theme. The footer rerenders on palette change automatically.
    No special handling needed.
 
 ## Implementation outline
 
-1. Add sentinel element to article (and picture/video, if scoping wider)
-   reader HTML templates.
-2. Add reader JS: `IntersectionObserver` wiring, calls
-   `MyDeckEndSentinel.onEndVisible(visible)`.
-3. Add `WebViewEndSentinelBridge` Kotlin class. Register on the reader WebView
-   in `BookmarkDetailWebViews.kt`.
-4. Hoist `endVisible: Boolean` into `BookmarkDetailViewModel.UiState`.
-5. Add `--mydeck-bottom-clearance-px` to the article CSS and its injection
-   point in Kotlin (mirror `readerTopClearanceCssPx`).
-6. Build `ReaderActionFooter` composable.
-7. Wrap the existing WebView in the Compose `Box` + `AnimatedVisibility`
-   overlay.
-8. Wire auto-mark-as-read to consume `endVisible` (or share the signal).
-   Remove the old percentage-based trigger if no longer needed.
-9. Remove the in-template footer HTML, CSS, and the bridge wiring.
-10. Delete `WebViewActionsBridge.kt`, `WebViewActionsInjector.kt` (or trim if
-    other code uses parts of it).
-11. Update `SECURITY.md` reader-bridge enumeration to reflect the new set.
+1. Replace `buildReaderFooterHtml(...)` in
+   `BookmarkDetailViewModel.Bookmark` with `buildReaderEndSentinelHtml()`
+   returning `<div id="mydeck-end-sentinel" aria-hidden="true"></div>`. Drop
+   the favorite/archive label parameters from `getContent()`.
+2. Update each of the three type branches in `getContent()` (Article,
+   Picture, Video) so the sentinel is appended at the correct position per
+   the placement section above.
+3. Add reader JS: `IntersectionObserver` wiring on `#mydeck-end-sentinel`,
+   calls `MyDeckEndSentinel.onEndVisible(visible)`.
+4. Add `WebViewEndSentinelBridge` Kotlin class. Register on the reader WebView
+   in `BookmarkDetailWebViews.kt`. Remove the `WebViewActionsBridge`
+   registration.
+5. Hoist `endVisible: Boolean` into `BookmarkDetailViewModel.UiState`. Add a
+   `showFooter: Boolean` derived from `endVisible` AND the layout/type/
+   selection gates described in Edge Cases.
+6. Wire the Article completion trigger: when `endVisible` becomes `true` and
+   the bookmark is `Type.ARTICLE` and `isReadLocked == false`, set
+   `currentScrollProgress = 100` and `isReadLocked = true` (the same actions
+   currently performed by `onScrollProgressChanged` at line 570). Picture and
+   Video remain unchanged — they auto-mark on open.
+7. Add `--mydeck-bottom-clearance-px` to the reader CSS in the four template
+   files and its injection point in Kotlin (mirror `readerTopClearanceCssPx`).
+8. Build `ReaderActionFooter` composable — a `Row` of two `IconButton`s,
+   surfaces from the reader palette.
+9. Wrap the existing WebView in a Compose `Box` and add `AnimatedVisibility`
+   for the footer overlay, using the same enter/exit animation values as the
+   top app bar.
+10. Remove the in-template footer HTML and CSS from the four
+    `html_template_*.html` files.
+11. Delete `WebViewActionsBridge.kt` and `WebViewActionsInjector.kt` (or trim
+    if any non-footer code uses parts of it; on inspection, the icon
+    constants `FAV_ICON_FILLED` / `ARC_ICON_FILLED` etc. are referenced only
+    from `buildReaderFooterHtml`, so the whole file should be deletable).
+12. Update `SECURITY.md` reader-bridge enumeration to reflect the new set
+    (drop Actions, add EndSentinel; the count stays manageable).
 
 ## Code to remove
 
 - `app/src/main/java/com/mydeck/app/ui/detail/WebViewActionsBridge.kt`
-- The action-button HTML/CSS sections of the article/picture/video reader
-  templates under `app/src/main/assets/`.
-- `WebViewActionsInjector.setFavoriteStateScript` and `setArchiveStateScript`
-  (or the entire file, if these are its only uses).
+- `app/src/main/java/com/mydeck/app/ui/detail/WebViewActionsInjector.kt`
+  (the icon constants and state-injection scripts in this file are referenced
+  only from `buildReaderFooterHtml` and the bridge wiring; remove with the
+  rest).
+- `buildReaderFooterHtml(...)` in `BookmarkDetailViewModel.Bookmark`, and the
+  `favoriteLabel` / `unfavoriteLabel` / `archiveLabel` / `unarchiveLabel`
+  parameters from `getContent()`.
+- The footer-button CSS rules in the four `html_template_*.html` files under
+  `app/src/main/assets/`.
 - The bridge registration block for `WebViewActionsBridge` in
   `BookmarkDetailWebViews.kt`.
-- The JS state-sync calls that fire when favorite/archive state changes
-  outside the WebView.
+- The JS state-sync `evaluateJavascript` calls that fire when favorite/archive
+  state changes outside the WebView (the
+  `WebViewActionsInjector.setFavoriteStateScript` / `setArchiveStateScript`
+  call sites).
 
 ## Test plan
 
-- Unit tests for `endVisible` state transitions in
+- Unit tests for `endVisible` and `showFooter` state transitions in
   `BookmarkDetailViewModel`.
+- Unit test for the Article completion trigger: setting `endVisible = true`
+  on a not-yet-read article flips `isReadLocked` and `currentScrollProgress`
+  exactly once, and is a no-op when `isReadLocked` is already true.
+- Unit test confirming the Picture/Video auto-mark-on-open path at lines
+  250–257 is unchanged.
 - Robolectric test for `ReaderActionFooter` rendering with each palette
   variant.
 - Manual test matrix:
-  - Article / picture / video bookmark types
+  - All three bookmark types: article / picture / video
   - Phone portrait / phone landscape / tablet portrait / tablet landscape
   - Light / dark / sepia themes
   - Short article (sentinel visible at load) vs. long article
-  - Scroll to end, then scroll back up — footer hides
+  - Scroll to end, then scroll back up — footer hides for article; stays
+    visible for picture/video where it appeared on open
   - Toggle favorite/archive — state persists, no JS reload of WebView
   - Offline state — toggle queues to pending actions, footer reflects pending
     state via the existing UiState path
   - Original-page WebView — footer never shown
   - Wide layout — footer suppressed if duplicate controls present in side
     panel
+  - Video with iframe embed and long transcript — sentinel after the
+    transcript, not after the embed
+  - Picture with no caption — sentinel directly after the image
+  - Resume from mid-article position (saved `readProgress` < 100) — footer
+    hidden until user scrolls to end; intermediate scroll updates still
+    flow through `WebViewScrollBridge`
 
 ## Out of scope
 
 - Adding more actions to the footer (share, delete, add label). v1 is
   favorite + archive only.
 - Changing the top app bar.
-- Picture/video footer support if v1 is scoped to article only.
-- Auto-mark-as-read behavior changes beyond sharing the signal source.
+- Changing the existing Picture/Video auto-mark-on-open behavior or the
+  Article intermediate-progress tracking. Only the Article completion trigger
+  moves to the sentinel.
 
 ## Open questions
 
-1. **Article-only vs. all reader types in v1?** Scoping to article is simpler
-   and lower risk. Picture/video can adopt the pattern later. Recommendation:
-   article only in v1.
-2. **Animation duration and easing.** Match the top-bar animation, or pick
-   independently? Recommendation: match top-bar for consistency.
-3. **Should the footer auto-hide after N seconds of no interaction?** Probably
+1. **Should the footer auto-hide after N seconds of no interaction?** Probably
    not, but worth a UX call. Default recommendation: no auto-hide; visibility
-   is purely driven by the sentinel.
+   is purely driven by the sentinel and the gate conditions in Edge Cases.

--- a/docs/specs/release-default-https-only-spec.md
+++ b/docs/specs/release-default-https-only-spec.md
@@ -98,21 +98,16 @@ The standard release build now resolves to `network_security_config.xml`
 
 ### Permissive build artifact
 
-`release.yml` produces two APKs per release:
+`release.yml` produces two APKs per release, both distributed from GitHub Releases:
 
 1. `MyDeck-<version>.apk` — standard, HTTPS-only.
 2. `MyDeck-<version>-permissive.apk` — built with `ALLOW_INSECURE_HTTP_RELEASE=true`
    and `ALLOW_USER_CA_RELEASE=true`.
 
-Both are signed with the same key. The release notes carry a section explaining
-what the permissive variant is for and when not to use it.
-
-Recommendation: the permissive variant uses the same `applicationId`
-(`com.mydeck.app`) as the standard variant so users can replace one with the other
-in place. The alternative — `applicationIdSuffix = ".permissive"` — allows
-side-by-side installation but forces re-authentication when switching, and creates
-two visible app entries for what is effectively the same product. Same-ID
-in-place replacement is the better default; the trade-off is documented.
+Both are signed with the same key and share the same `applicationId`
+(`com.mydeck.app`), so a user can install one over the other in place without
+re-authenticating. The release notes carry a section explaining what the
+permissive variant is for and when not to use it.
 
 ### In-app warning copy (permissive build)
 
@@ -155,19 +150,35 @@ A `BuildConfig.IS_PERMISSIVE_BUILD` constant (derived from the existing
 
 When they install the new standard build over the old one:
 
-- The encrypted token remains on device.
-- The next network request to their `http://` server URL is blocked by the network
-  security config.
-- The app sees a network failure on first sync.
+- The encrypted token remains on device. **The user does not need to log out or
+  re-authenticate.** OAuth bearer tokens are not bound to URL scheme; the same
+  token works against `https://server` as against `http://server`, provided the
+  server is reachable on HTTPS.
+- The next network request to the saved `http://` URL is blocked by the network
+  security config (cleartext traffic not permitted), and the app sees a network
+  failure on first sync.
 
-This case must be handled cleanly. Proposed handling:
+What "hard stop" means here: instead of letting that network failure surface
+through the normal error path (where it would look like a transient connectivity
+problem and the user might retry repeatedly), the app detects the specific
+condition "saved URL is `http://` on a non-permissive build" at startup and
+routes to a dedicated screen explaining it.
 
-- On startup, if the saved URL has an `http://` scheme and the build is not
-  permissive, route the user to a dedicated screen that explains the situation and
-  offers two paths: download the permissive APK, or reconfigure the server for
-  HTTPS (with a link to Tailscale Serve and Readeck-proxy docs).
-- Do not silently clear credentials. Do not loop on retry. The screen is the
-  endpoint until the user takes action.
+That screen offers three paths in order of recommendation:
+
+1. **Change the server URL to HTTPS** — inline edit, no re-auth needed if the
+   server is reachable on HTTPS (Tailscale Serve, reverse proxy, native TLS).
+   Links to the Tailscale Serve docs and Readeck reverse-proxy docs for users
+   who don't already have HTTPS configured.
+2. **Install the permissive APK** — for users who genuinely cannot move to HTTPS
+   (direct tailnet-IP setups, etc.). Token survives the replacement.
+3. **Log out** — fallback only, presented last. Clears credentials and returns
+   to the welcome screen. Required only if the user wants to reconfigure from
+   scratch.
+
+The screen is the endpoint until the user takes action — it does not silently
+clear credentials, does not loop on retry, and does not let the user fall back
+into a state where they think the app is just broken.
 
 This screen ships in the same release as the default flip.
 
@@ -177,16 +188,9 @@ No change. Their URL still works.
 
 ## Open questions
 
-1. **Distribution channel for the permissive APK.** GitHub Releases is
-   straightforward (a second artifact in the release). F-Droid would require a
-   separate package or flavor. Recommendation: GitHub Releases only for the
-   permissive variant; F-Droid carries only the standard build.
-2. **Should the welcome/login screen in the standard build mention the permissive
+1. **Should the welcome/login screen in the standard build mention the permissive
    variant exists?** Likely yes, in fine print, so users hitting the blocked-HTTP
    path do not conclude the app is broken.
-3. **Should existing HTTP users be offered an in-app one-click "switch to
-   Tailscale Serve URL" guide?** Out of scope for v1; a future polish if demand
-   warrants.
 
 ## Code touch points
 

--- a/docs/specs/release-default-https-only-spec.md
+++ b/docs/specs/release-default-https-only-spec.md
@@ -1,0 +1,214 @@
+# Spec: Release Default to HTTPS-Only, with Optional Permissive Variant
+
+## Status
+
+Proposal — not yet scheduled for implementation.
+
+## Context
+
+### Current state (v0.13.1)
+
+`app/build.gradle.kts` defaults `ALLOW_INSECURE_HTTP_RELEASE` to `true` for release
+builds. The published APK from `release.yml` therefore accepts `http://` Readeck URLs
+at the URL-entry screen, with an inline warning that explains the risk but does not
+block login. OAuth tokens — bearer credentials with
+`bookmarks:read bookmarks:write profile:read` scope — flow over whatever scheme the
+user typed.
+
+The build infrastructure already supports an HTTPS-only release:
+
+- `networkSecurityConfigRef()` selects `network_security_config.xml` (HTTPS-only,
+  system CAs) when `allowHttp = false`.
+- `ALLOW_INSECURE_HTTP_RELEASE` and `ALLOW_USER_CA_RELEASE` can be toggled via
+  Gradle property or env var.
+
+What is missing is (a) a safer default for the artifact distributed from the public
+release page, and (b) a distinct, clearly labeled artifact for users who need HTTP.
+
+### Why this matters
+
+HTTP support was added specifically for a self-hosted user running Readeck behind
+Tailscale. That use case is real, but it is not the majority case, and shipping
+HTTP-permissive as the default means every user — including the ones connecting to
+a public-facing HTTPS Readeck — gets a binary that would accept a cleartext URL if
+they entered one.
+
+A listing on readeck.org would imply some level of endorsement. The default
+artifact for a listed client should be HTTPS-only.
+
+### Why the inline warning is not sufficient on its own
+
+The current warning informs but does not gate. A user who pastes an `http://` URL,
+ignores the warning (or does not read it), and logs in has already sent their bearer
+token in cleartext on whatever network the device is currently on. There is no
+recoverable signal that this happened; the token is valid until revoked.
+
+### Alternatives that exist for HTTP-only setups
+
+Two upstream changes have reduced the need for client-side HTTP support since the
+feature was added:
+
+- **Tailscale Serve** can proxy a local HTTP service as a tailnet HTTPS URL with an
+  auto-provisioned LetsEncrypt certificate
+  (`tailscale serve --https=443 http://127.0.0.1:8000`). This addresses the original
+  Tailscale-user motivation directly: the Readeck server stays HTTP on localhost,
+  the device sees HTTPS over the tailnet, and OAuth tokens are encrypted in transit.
+- **Readeck 0.22 Forwarded Authentication** enables SSO-style authentication via a
+  reverse proxy. It does not encrypt traffic on its own, but pairs naturally with a
+  proxy (including Tailscale Serve) that does.
+
+Some setups will still require HTTP — users connecting directly to a tailnet IP on
+HTTP, or installations without proxy access. The permissive build serves those.
+
+## Goals
+
+- The default public release artifact accepts `https://` URLs only.
+- The HTTP-permissive build remains available as a clearly labeled, separately
+  downloaded artifact for users who need it.
+- The in-app warning, when shown in the permissive build, points users at the safer
+  alternative (Tailscale Serve + HTTPS) so the HTTP path is the exception rather
+  than the default.
+- No silent breakage for existing users already logged in over HTTP. If their URL
+  becomes unusable in the new build, the path forward is clear.
+
+## Non-goals
+
+- Removing HTTP support from the codebase entirely. The build flag stays.
+- Changing the OAuth flow, token storage, or anything beyond network policy and
+  packaging.
+- Enforcing certificate pinning or otherwise restricting which HTTPS servers are
+  trusted. The user-CA flag continues to exist for private-CA users.
+
+## Design
+
+### Default flip
+
+In `app/build.gradle.kts`:
+
+```kotlin
+val allowInsecureHttpRelease = booleanBuildFlag(
+    propertyName = "allowInsecureHttpRelease",
+    envName = "ALLOW_INSECURE_HTTP_RELEASE",
+    default = false  // was true
+)
+```
+
+The standard release build now resolves to `network_security_config.xml`
+(HTTPS-only, system CAs).
+
+### Permissive build artifact
+
+`release.yml` produces two APKs per release:
+
+1. `MyDeck-<version>.apk` — standard, HTTPS-only.
+2. `MyDeck-<version>-permissive.apk` — built with `ALLOW_INSECURE_HTTP_RELEASE=true`
+   and `ALLOW_USER_CA_RELEASE=true`.
+
+Both are signed with the same key. The release notes carry a section explaining
+what the permissive variant is for and when not to use it.
+
+Recommendation: the permissive variant uses the same `applicationId`
+(`com.mydeck.app`) as the standard variant so users can replace one with the other
+in place. The alternative — `applicationIdSuffix = ".permissive"` — allows
+side-by-side installation but forces re-authentication when switching, and creates
+two visible app entries for what is effectively the same product. Same-ID
+in-place replacement is the better default; the trade-off is documented.
+
+### In-app warning copy (permissive build)
+
+When the permissive build sees an `http://` URL at the URL-entry screen, the
+inline warning is updated to:
+
+1. Explain the cleartext risk in one sentence.
+2. Link to documented alternatives:
+   - Tailscale Serve (for Tailscale users)
+   - Readeck's reverse-proxy + Forwarded Authentication docs (for Readeck 0.22+
+     users behind any proxy)
+3. Identify itself as the permissive build, so the user understands they are in
+   the opt-in distribution path.
+
+The standard build never shows this warning because `http://` cannot be entered.
+
+### Variant identification at runtime
+
+A `BuildConfig.IS_PERMISSIVE_BUILD` constant (derived from the existing
+`ALLOW_INSECURE_HTTP` and `ALLOW_USER_CA_CERTIFICATES` flags) drives:
+
+- Variant-specific copy in the in-app warning.
+- A small variant indicator on the About screen so users can confirm what they
+  installed.
+
+### Documentation updates
+
+- `SECURITY.md`: replace the "default release allows HTTP with a warning" language
+  with the new model (standard = HTTPS-only; permissive = separately downloaded
+  opt-in).
+- `release.yml` comments: update to match the new default and the dual-artifact
+  build.
+- `README.md`: add a short "Which APK do I want?" section above the download link.
+- The permissive build's release-notes blurb should be templated so each release's
+  notes carry it consistently.
+
+## Migration
+
+### Users already logged in over HTTP on the existing standard build
+
+When they install the new standard build over the old one:
+
+- The encrypted token remains on device.
+- The next network request to their `http://` server URL is blocked by the network
+  security config.
+- The app sees a network failure on first sync.
+
+This case must be handled cleanly. Proposed handling:
+
+- On startup, if the saved URL has an `http://` scheme and the build is not
+  permissive, route the user to a dedicated screen that explains the situation and
+  offers two paths: download the permissive APK, or reconfigure the server for
+  HTTPS (with a link to Tailscale Serve and Readeck-proxy docs).
+- Do not silently clear credentials. Do not loop on retry. The screen is the
+  endpoint until the user takes action.
+
+This screen ships in the same release as the default flip.
+
+### Users on the permissive build
+
+No change. Their URL still works.
+
+## Open questions
+
+1. **Distribution channel for the permissive APK.** GitHub Releases is
+   straightforward (a second artifact in the release). F-Droid would require a
+   separate package or flavor. Recommendation: GitHub Releases only for the
+   permissive variant; F-Droid carries only the standard build.
+2. **Should the welcome/login screen in the standard build mention the permissive
+   variant exists?** Likely yes, in fine print, so users hitting the blocked-HTTP
+   path do not conclude the app is broken.
+3. **Should existing HTTP users be offered an in-app one-click "switch to
+   Tailscale Serve URL" guide?** Out of scope for v1; a future polish if demand
+   warrants.
+
+## Code touch points
+
+- `app/build.gradle.kts` — default flip; optional `IS_PERMISSIVE_BUILD`
+  buildConfigField.
+- `.github/workflows/release.yml` — second build step + artifact upload + release
+  notes templating.
+- `SECURITY.md`, `README.md` — copy updates.
+- `app/src/main/res/values*/strings.xml` — updated warning copy and new
+  variant-specific strings (English placeholders in all locales per project
+  convention).
+- `app/src/main/java/com/mydeck/app/ui/welcome/WelcomeScreen.kt` and/or
+  `AccountSettingsScreen.kt` — warning text and link rendering.
+- New screen for "HTTP URL no longer supported in this build" — wired from
+  `MainActivity` startup check on saved-URL scheme.
+- `app/src/main/java/com/mydeck/app/ui/about/AboutScreen.kt` — variant indicator.
+
+## Out of scope
+
+- Replacing the OAuth flow.
+- Enforcing certificate pinning.
+- Removing the `ALLOW_USER_CA_RELEASE` build flag (it remains independently
+  toggleable for private-CA users).
+- Telemetry on which variant users run. MyDeck has no telemetry and this spec
+  introduces none.


### PR DESCRIPTION
Two proposal specs drafted from code-review discussion:

- release-default-https-only-spec.md: flip ALLOW_INSECURE_HTTP_RELEASE
  default to false; ship a separately labeled permissive APK for HTTP
  use cases (Tailscale-IP, no-proxy); migration screen for users
  currently saved against an http:// URL.

- reader-native-action-footer-spec.md: replace WebView-rendered favorite
  and archive buttons + WebViewActionsBridge with a native Compose
  footer driven by an end-of-content IntersectionObserver sentinel
  reported through a read-only bridge; mirrors the top-bar overlay
  pattern.

Both are Status: Proposal — not yet scheduled.

https://claude.ai/code/session_014WDeeG3ybUjojd1aBfAQHp