### PR TITLE
Feat/reading time filter

### DIFF
--- a/app/src/androidTest/java/com/mydeck/app/ui/FilterBottomSheetValidationTest.kt
+++ b/app/src/androidTest/java/com/mydeck/app/ui/FilterBottomSheetValidationTest.kt
@@ -1,0 +1,77 @@
+package com.mydeck.app.ui
+
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performTextClearance
+import androidx.compose.ui.test.performTextInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.mydeck.app.domain.model.FilterFormState
+import com.mydeck.app.ui.components.FilterBottomSheet
+import com.mydeck.app.ui.theme.MyDeckTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class FilterBottomSheetValidationTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private fun launchSheet() {
+        composeTestRule.setContent {
+            MyDeckTheme {
+                FilterBottomSheet(
+                    currentFilter = FilterFormState(),
+                    onApply = {},
+                    onReset = {},
+                    onDismiss = {},
+                )
+            }
+        }
+    }
+
+    @Test
+    fun searchButtonEnabledWhenNoReadingTimeInput() {
+        launchSheet()
+        composeTestRule.onNodeWithText("Search").assertIsEnabled()
+    }
+
+    @Test
+    fun errorShownAndSearchDisabledWhenMinExceedsMax() {
+        launchSheet()
+
+        composeTestRule.onNode(hasText("Min")).performTextInput("20")
+        composeTestRule.onNode(hasText("Max")).performTextInput("5")
+
+        composeTestRule.onNodeWithText("Min must be less than or equal to max").assertExists()
+        composeTestRule.onNodeWithText("Search").assertIsNotEnabled()
+    }
+
+    @Test
+    fun errorClearedWhenMinEqualToMax() {
+        launchSheet()
+
+        composeTestRule.onNode(hasText("Min")).performTextInput("10")
+        composeTestRule.onNode(hasText("Max")).performTextInput("10")
+
+        composeTestRule.onNodeWithText("Min must be less than or equal to max").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Search").assertIsEnabled()
+    }
+
+    @Test
+    fun errorClearedWhenMaxFieldCleared() {
+        launchSheet()
+
+        composeTestRule.onNode(hasText("Min")).performTextInput("20")
+        composeTestRule.onNode(hasText("Max")).performTextInput("5")
+        // Now clear max — one field empty means no error
+        composeTestRule.onNode(hasText("Max")).performTextClearance()
+
+        composeTestRule.onNodeWithText("Min must be less than or equal to max").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Search").assertIsEnabled()
+    }
+}

--- a/app/src/androidTest/java/com/mydeck/app/ui/FilterBottomSheetValidationTest.kt
+++ b/app/src/androidTest/java/com/mydeck/app/ui/FilterBottomSheetValidationTest.kt
@@ -2,9 +2,10 @@ package com.mydeck.app.ui
 
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
-import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -35,43 +36,46 @@ class FilterBottomSheetValidationTest {
     }
 
     @Test
-    fun searchButtonEnabledWhenNoReadingTimeInput() {
+    fun searchButtonEnabledWhenNoLengthInput() {
         launchSheet()
         composeTestRule.onNodeWithText("Search").assertIsEnabled()
     }
 
     @Test
-    fun errorShownAndSearchDisabledWhenMinExceedsMax() {
+    fun errorShownAndOkDisabledWhenDialogMinExceedsMax() {
         launchSheet()
 
-        composeTestRule.onNode(hasText("Min")).performTextInput("20")
-        composeTestRule.onNode(hasText("Max")).performTextInput("5")
+        composeTestRule.onNodeWithText("Length").performClick()
+        composeTestRule.onAllNodesWithText("Min")[0].performTextInput("20")
+        composeTestRule.onAllNodesWithText("Max")[0].performTextInput("5")
 
         composeTestRule.onNodeWithText("Min must be less than or equal to max").assertExists()
-        composeTestRule.onNodeWithText("Search").assertIsNotEnabled()
+        composeTestRule.onNodeWithText("OK").assertIsNotEnabled()
     }
 
     @Test
-    fun errorClearedWhenMinEqualToMax() {
+    fun errorClearedWhenDialogMinEqualToMax() {
         launchSheet()
 
-        composeTestRule.onNode(hasText("Min")).performTextInput("10")
-        composeTestRule.onNode(hasText("Max")).performTextInput("10")
+        composeTestRule.onNodeWithText("Length").performClick()
+        composeTestRule.onAllNodesWithText("Min")[0].performTextInput("10")
+        composeTestRule.onAllNodesWithText("Max")[0].performTextInput("10")
 
         composeTestRule.onNodeWithText("Min must be less than or equal to max").assertDoesNotExist()
-        composeTestRule.onNodeWithText("Search").assertIsEnabled()
+        composeTestRule.onNodeWithText("OK").assertIsEnabled()
     }
 
     @Test
-    fun errorClearedWhenMaxFieldCleared() {
+    fun errorClearedWhenDialogMaxFieldCleared() {
         launchSheet()
 
-        composeTestRule.onNode(hasText("Min")).performTextInput("20")
-        composeTestRule.onNode(hasText("Max")).performTextInput("5")
+        composeTestRule.onNodeWithText("Length").performClick()
+        composeTestRule.onAllNodesWithText("Min")[0].performTextInput("20")
+        composeTestRule.onAllNodesWithText("Max")[0].performTextInput("5")
         // Now clear max — one field empty means no error
-        composeTestRule.onNode(hasText("Max")).performTextClearance()
+        composeTestRule.onAllNodesWithText("Max")[0].performTextClearance()
 
         composeTestRule.onNodeWithText("Min must be less than or equal to max").assertDoesNotExist()
-        composeTestRule.onNodeWithText("Search").assertIsEnabled()
+        composeTestRule.onNodeWithText("OK").assertIsEnabled()
     }
 }

--- a/app/src/main/assets/guide/en/your-bookmarks.md
+++ b/app/src/main/assets/guide/en/your-bookmarks.md
@@ -146,6 +146,16 @@ When no bookmarks match the current filters, the list shows a "No bookmarks matc
 **Date range:**
 - **From Date / To Date** — filter by when the bookmark was added
 
+**Reading time:**
+- **Min / Max** — filter by estimated reading time in minutes. Enter a whole number in either or both fields; leaving a field blank means no bound in that direction.
+- **Null checkbox** — when checked, bookmarks with no reading time estimate are included in results. If you check Null with both Min and Max left blank, only bookmarks with no estimate are shown.
+- The active reading time filter is shown as a single chip in the filter bar (e.g. *Read time: 5–15 min*). Dismissing the chip clears all three values.
+
+**Word count:**
+- **Min / Max** — filter by article word count. Enter a whole number in either or both fields; leaving a field blank means no bound in that direction.
+- **Null checkbox** — when checked, bookmarks with no word count (typical for very short articles, videos, and pictures) are included. Checking Null with both fields blank returns only those bookmarks.
+- The active word count filter is shown as a single chip in the filter bar (e.g. *Words: 100–500*). Dismissing the chip clears all three values.
+
 **Type** (choose one or more):
 - Article, Video, Picture
 

--- a/app/src/main/assets/guide/en/your-bookmarks.md
+++ b/app/src/main/assets/guide/en/your-bookmarks.md
@@ -146,15 +146,11 @@ When no bookmarks match the current filters, the list shows a "No bookmarks matc
 **Date range:**
 - **From Date / To Date** — filter by when the bookmark was added
 
-**Reading time:**
-- **Min / Max** — filter by estimated reading time in minutes. Enter a whole number in either or both fields; leaving a field blank means no bound in that direction.
-- **Null checkbox** — when checked, bookmarks with no reading time estimate are included in results. If you check Null with both Min and Max left blank, only bookmarks with no estimate are shown.
-- The active reading time filter is shown as a single chip in the filter bar (e.g. *Read time: 5–15 min*). Dismissing the chip clears all three values.
-
-**Word count:**
-- **Min / Max** — filter by article word count. Enter a whole number in either or both fields; leaving a field blank means no bound in that direction.
-- **Null checkbox** — when checked, bookmarks with no word count (typical for very short articles, videos, and pictures) are included. Checking Null with both fields blank returns only those bookmarks.
-- The active word count filter is shown as a single chip in the filter bar (e.g. *Words: 100–500*). Dismissing the chip clears all three values.
+**Length:**
+- **Length** — opens a dialog for reading time and word count filters
+- **Min / Max** — filter by estimated reading time in minutes or by article word count. Enter a whole number in either or both fields; leaving a field blank means no bound in that direction.
+- **Include unknown** — when checked, bookmarks with no reading time estimate or no word count are included in results. If you check Include unknown with both Min and Max left blank, only bookmarks with unknown values are shown.
+- Active reading time and word count filters are shown as chips in the filter bar (e.g. *Read time: 5–15 min* or *Words: 100–500*). Dismissing a chip clears that range and its unknown-value setting.
 
 **Type** (choose one or more):
 - Article, Video, Picture

--- a/app/src/main/java/com/mydeck/app/domain/BookmarkRepository.kt
+++ b/app/src/main/java/com/mydeck/app/domain/BookmarkRepository.kt
@@ -24,6 +24,12 @@ interface BookmarkRepository {
         favorite: Boolean? = null,
         label: String? = null,
         state: Bookmark.State? = null,
+        minReadingTime: Int? = null,
+        maxReadingTime: Int? = null,
+        includeNullReadingTime: Boolean = false,
+        minWordCount: Int? = null,
+        maxWordCount: Int? = null,
+        includeNullWordCount: Boolean = false,
         orderBy: String = "created DESC"
     ): Flow<List<BookmarkListItem>>
 
@@ -72,6 +78,12 @@ interface BookmarkRepository {
         isLoaded: Boolean? = null,
         withLabels: Boolean? = null,
         withErrors: Boolean? = null,
+        minReadingTime: Int? = null,
+        maxReadingTime: Int? = null,
+        includeNullReadingTime: Boolean = false,
+        minWordCount: Int? = null,
+        maxWordCount: Int? = null,
+        includeNullWordCount: Boolean = false,
         orderBy: String = "created DESC"
     ): Flow<List<BookmarkListItem>>
 

--- a/app/src/main/java/com/mydeck/app/domain/BookmarkRepositoryImpl.kt
+++ b/app/src/main/java/com/mydeck/app/domain/BookmarkRepositoryImpl.kt
@@ -108,6 +108,12 @@ class BookmarkRepositoryImpl @Inject constructor(
         favorite: Boolean?,
         label: String?,
         state: Bookmark.State?,
+        minReadingTime: Int?,
+        maxReadingTime: Int?,
+        includeNullReadingTime: Boolean,
+        minWordCount: Int?,
+        maxWordCount: Int?,
+        includeNullWordCount: Boolean,
         orderBy: String
     ): Flow<List<BookmarkListItem>> {
         return bookmarkDao.getBookmarkListItemsByFilters(
@@ -129,6 +135,12 @@ class BookmarkRepositoryImpl @Inject constructor(
                     Bookmark.State.LOADING -> BookmarkEntity.State.LOADING
                 }
             },
+            minReadingTime = minReadingTime,
+            maxReadingTime = maxReadingTime,
+            includeNullReadingTime = includeNullReadingTime,
+            minWordCount = minWordCount,
+            maxWordCount = maxWordCount,
+            includeNullWordCount = includeNullWordCount,
             orderBy = orderBy
         ).map { listItems ->
             listItems.map { listItem ->
@@ -238,6 +250,12 @@ class BookmarkRepositoryImpl @Inject constructor(
         isLoaded: Boolean?,
         withLabels: Boolean?,
         withErrors: Boolean?,
+        minReadingTime: Int?,
+        maxReadingTime: Int?,
+        includeNullReadingTime: Boolean,
+        minWordCount: Int?,
+        maxWordCount: Int?,
+        includeNullWordCount: Boolean,
         orderBy: String
     ): Flow<List<BookmarkListItem>> {
         val entityTypes = types.mapTo(mutableSetOf()) {
@@ -269,6 +287,12 @@ class BookmarkRepositoryImpl @Inject constructor(
             isLoaded = isLoaded,
             withLabels = withLabels,
             withErrors = withErrors,
+            minReadingTime = minReadingTime,
+            maxReadingTime = maxReadingTime,
+            includeNullReadingTime = includeNullReadingTime,
+            minWordCount = minWordCount,
+            maxWordCount = maxWordCount,
+            includeNullWordCount = includeNullWordCount,
             orderBy = orderBy
         ).map { listItems ->
             listItems.map { listItem ->

--- a/app/src/main/java/com/mydeck/app/domain/model/FilterFormState.kt
+++ b/app/src/main/java/com/mydeck/app/domain/model/FilterFormState.kt
@@ -17,6 +17,12 @@ data class FilterFormState(
     val isLoaded: Boolean? = null,
     val withLabels: Boolean? = null,
     val withErrors: Boolean? = null,
+    val minReadingTime: Int? = null,
+    val maxReadingTime: Int? = null,
+    val includeNullReadingTime: Boolean = false,
+    val minWordCount: Int? = null,
+    val maxWordCount: Int? = null,
+    val includeNullWordCount: Boolean = false,
 ) {
     fun hasActiveFilters(): Boolean =
         search != null ||
@@ -32,7 +38,9 @@ data class FilterFormState(
         isArchived != null ||
         isLoaded != null ||
         withLabels != null ||
-        withErrors != null
+        withErrors != null ||
+        minReadingTime != null || maxReadingTime != null || includeNullReadingTime ||
+        minWordCount != null || maxWordCount != null || includeNullWordCount
 
     fun differsFromPreset(preset: DrawerPreset): Boolean = this != fromPreset(preset)
 

--- a/app/src/main/java/com/mydeck/app/io/db/dao/BookmarkDao.kt
+++ b/app/src/main/java/com/mydeck/app/io/db/dao/BookmarkDao.kt
@@ -239,6 +239,12 @@ interface BookmarkDao {
         isArchived: Boolean? = null,
         isFavorite: Boolean? = null,
         state: BookmarkEntity.State? = null,
+        minReadingTime: Int? = null,
+        maxReadingTime: Int? = null,
+        includeNullReadingTime: Boolean = false,
+        minWordCount: Int? = null,
+        maxWordCount: Int? = null,
+        includeNullWordCount: Boolean = false,
         orderBy: String = "created DESC"
     ): Flow<List<BookmarkEntity>> {
         val args = mutableListOf<Any>()
@@ -270,6 +276,39 @@ interface BookmarkDao {
                 append(" AND isMarked = ?")
                 args.add(it)
             }
+
+            val hasRange = minReadingTime != null || maxReadingTime != null
+            if (hasRange || includeNullReadingTime) {
+                val rangeParts = buildList {
+                    if (hasRange) {
+                        val rangeSql = buildString {
+                            if (minReadingTime != null) { append("readingTime >= ?"); args.add(minReadingTime) }
+                            if (minReadingTime != null && maxReadingTime != null) append(" AND ")
+                            if (maxReadingTime != null) { append("readingTime <= ?"); args.add(maxReadingTime) }
+                        }
+                        add(rangeSql)
+                    }
+                    if (includeNullReadingTime) add("readingTime IS NULL")
+                }
+                append(" AND (${rangeParts.joinToString(" OR ")})")
+            }
+
+            val hasWordRange = minWordCount != null || maxWordCount != null
+            if (hasWordRange || includeNullWordCount) {
+                val rangeParts = buildList {
+                    if (hasWordRange) {
+                        val rangeSql = buildString {
+                            if (minWordCount != null) { append("wordCount >= ?"); args.add(minWordCount) }
+                            if (minWordCount != null && maxWordCount != null) append(" AND ")
+                            if (maxWordCount != null) { append("wordCount <= ?"); args.add(maxWordCount) }
+                        }
+                        add(rangeSql)
+                    }
+                    if (includeNullWordCount) add("wordCount IS NULL")
+                }
+                append(" AND (${rangeParts.joinToString(" OR ")})")
+            }
+
             append(" ORDER BY $orderBy")
         }.let { SimpleSQLiteQuery(it, args.toTypedArray()) }
         Timber.d("query=${sqlQuery.sql}")
@@ -303,6 +342,12 @@ interface BookmarkDao {
         isFavorite: Boolean? = null,
         label: String? = null,
         state: BookmarkEntity.State? = null,
+        minReadingTime: Int? = null,
+        maxReadingTime: Int? = null,
+        includeNullReadingTime: Boolean = false,
+        minWordCount: Int? = null,
+        maxWordCount: Int? = null,
+        includeNullWordCount: Boolean = false,
         orderBy: String = "created DESC"
     ): Flow<List<BookmarkListItemEntity>> {
         val args = mutableListOf<Any>()
@@ -362,6 +407,38 @@ interface BookmarkDao {
             label?.let {
                 append(" AND INSTR(b.labels, ?) > 0")
                 args.add("\"$it\"")
+            }
+
+            val hasRange = minReadingTime != null || maxReadingTime != null
+            if (hasRange || includeNullReadingTime) {
+                val rangeParts = buildList {
+                    if (hasRange) {
+                        val rangeSql = buildString {
+                            if (minReadingTime != null) { append("b.readingTime >= ?"); args.add(minReadingTime) }
+                            if (minReadingTime != null && maxReadingTime != null) append(" AND ")
+                            if (maxReadingTime != null) { append("b.readingTime <= ?"); args.add(maxReadingTime) }
+                        }
+                        add(rangeSql)
+                    }
+                    if (includeNullReadingTime) add("b.readingTime IS NULL")
+                }
+                append(" AND (${rangeParts.joinToString(" OR ")})")
+            }
+
+            val hasWordRange = minWordCount != null || maxWordCount != null
+            if (hasWordRange || includeNullWordCount) {
+                val rangeParts = buildList {
+                    if (hasWordRange) {
+                        val rangeSql = buildString {
+                            if (minWordCount != null) { append("b.wordCount >= ?"); args.add(minWordCount) }
+                            if (minWordCount != null && maxWordCount != null) append(" AND ")
+                            if (maxWordCount != null) { append("b.wordCount <= ?"); args.add(maxWordCount) }
+                        }
+                        add(rangeSql)
+                    }
+                    if (includeNullWordCount) add("b.wordCount IS NULL")
+                }
+                append(" AND (${rangeParts.joinToString(" OR ")})")
             }
 
             append(" ORDER BY b.$orderBy")
@@ -558,6 +635,12 @@ interface BookmarkDao {
         isLoaded: Boolean? = null,
         withLabels: Boolean? = null,
         withErrors: Boolean? = null,
+        minReadingTime: Int? = null,
+        maxReadingTime: Int? = null,
+        includeNullReadingTime: Boolean = false,
+        minWordCount: Int? = null,
+        maxWordCount: Int? = null,
+        includeNullWordCount: Boolean = false,
         orderBy: String = "created DESC"
     ): Flow<List<BookmarkListItemEntity>> {
         val args = mutableListOf<Any>()
@@ -661,6 +744,38 @@ interface BookmarkDao {
                 } else {
                     append(" AND b.state != 1 AND b.hasServerErrors = 0")
                 }
+            }
+
+            val hasRange = minReadingTime != null || maxReadingTime != null
+            if (hasRange || includeNullReadingTime) {
+                val rangeParts = buildList {
+                    if (hasRange) {
+                        val rangeSql = buildString {
+                            if (minReadingTime != null) { append("b.readingTime >= ?"); args.add(minReadingTime) }
+                            if (minReadingTime != null && maxReadingTime != null) append(" AND ")
+                            if (maxReadingTime != null) { append("b.readingTime <= ?"); args.add(maxReadingTime) }
+                        }
+                        add(rangeSql)
+                    }
+                    if (includeNullReadingTime) add("b.readingTime IS NULL")
+                }
+                append(" AND (${rangeParts.joinToString(" OR ")})")
+            }
+
+            val hasWordRange = minWordCount != null || maxWordCount != null
+            if (hasWordRange || includeNullWordCount) {
+                val rangeParts = buildList {
+                    if (hasWordRange) {
+                        val rangeSql = buildString {
+                            if (minWordCount != null) { append("b.wordCount >= ?"); args.add(minWordCount) }
+                            if (minWordCount != null && maxWordCount != null) append(" AND ")
+                            if (maxWordCount != null) { append("b.wordCount <= ?"); args.add(maxWordCount) }
+                        }
+                        add(rangeSql)
+                    }
+                    if (includeNullWordCount) add("b.wordCount IS NULL")
+                }
+                append(" AND (${rangeParts.joinToString(" OR ")})")
             }
 
             append(" ORDER BY b.$orderBy")

--- a/app/src/main/java/com/mydeck/app/ui/components/FilterBar.kt
+++ b/app/src/main/java/com/mydeck/app/ui/components/FilterBar.kt
@@ -161,6 +161,7 @@ fun FilterBar(
                 onFilterChanged(filterFormState.copy(withErrors = null))
             })
         }
+        val unknownLabel = stringResource(R.string.filter_length_unknown)
         val minRt = filterFormState.minReadingTime
         val maxRt = filterFormState.maxReadingTime
         val nullRt = filterFormState.includeNullReadingTime
@@ -173,9 +174,9 @@ fun FilterBar(
                 else -> null
             }
             val chipLabel = when {
-                rangeLabel != null && nullRt -> "$readTimePrefix: $rangeLabel + Null"
+                rangeLabel != null && nullRt -> "$readTimePrefix: $rangeLabel + $unknownLabel"
                 rangeLabel != null -> "$readTimePrefix: $rangeLabel"
-                else -> "$readTimePrefix: Null"
+                else -> "$readTimePrefix: $unknownLabel"
             }
             add(Chip(chipLabel) {
                 onFilterChanged(filterFormState.copy(minReadingTime = null, maxReadingTime = null, includeNullReadingTime = false))
@@ -193,9 +194,9 @@ fun FilterBar(
                 else -> null
             }
             val chipLabel = when {
-                rangeLabel != null && nullWc -> "$wordsPrefix: $rangeLabel + Null"
+                rangeLabel != null && nullWc -> "$wordsPrefix: $rangeLabel + $unknownLabel"
                 rangeLabel != null -> "$wordsPrefix: $rangeLabel"
-                else -> "$wordsPrefix: Null"
+                else -> "$wordsPrefix: $unknownLabel"
             }
             add(Chip(chipLabel) {
                 onFilterChanged(filterFormState.copy(minWordCount = null, maxWordCount = null, includeNullWordCount = false))

--- a/app/src/main/java/com/mydeck/app/ui/components/FilterBar.kt
+++ b/app/src/main/java/com/mydeck/app/ui/components/FilterBar.kt
@@ -161,6 +161,46 @@ fun FilterBar(
                 onFilterChanged(filterFormState.copy(withErrors = null))
             })
         }
+        val minRt = filterFormState.minReadingTime
+        val maxRt = filterFormState.maxReadingTime
+        val nullRt = filterFormState.includeNullReadingTime
+        val readTimePrefix = stringResource(R.string.filter_reading_time)
+        if (minRt != null || maxRt != null || nullRt) {
+            val rangeLabel = when {
+                minRt != null && maxRt != null -> "$minRt–$maxRt min"
+                minRt != null -> "≥$minRt min"
+                maxRt != null -> "≤$maxRt min"
+                else -> null
+            }
+            val chipLabel = when {
+                rangeLabel != null && nullRt -> "$readTimePrefix: $rangeLabel + Null"
+                rangeLabel != null -> "$readTimePrefix: $rangeLabel"
+                else -> "$readTimePrefix: Null"
+            }
+            add(Chip(chipLabel) {
+                onFilterChanged(filterFormState.copy(minReadingTime = null, maxReadingTime = null, includeNullReadingTime = false))
+            })
+        }
+        val minWc = filterFormState.minWordCount
+        val maxWc = filterFormState.maxWordCount
+        val nullWc = filterFormState.includeNullWordCount
+        val wordsPrefix = stringResource(R.string.filter_word_count)
+        if (minWc != null || maxWc != null || nullWc) {
+            val rangeLabel = when {
+                minWc != null && maxWc != null -> "$minWc–$maxWc"
+                minWc != null -> "≥$minWc"
+                maxWc != null -> "≤$maxWc"
+                else -> null
+            }
+            val chipLabel = when {
+                rangeLabel != null && nullWc -> "$wordsPrefix: $rangeLabel + Null"
+                rangeLabel != null -> "$wordsPrefix: $rangeLabel"
+                else -> "$wordsPrefix: Null"
+            }
+            add(Chip(chipLabel) {
+                onFilterChanged(filterFormState.copy(minWordCount = null, maxWordCount = null, includeNullWordCount = false))
+            })
+        }
     }
 
     if (chips.isEmpty()) return

--- a/app/src/main/java/com/mydeck/app/ui/components/FilterBottomSheet.kt
+++ b/app/src/main/java/com/mydeck/app/ui/components/FilterBottomSheet.kt
@@ -34,6 +34,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -43,9 +44,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusEvent
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
@@ -56,6 +59,7 @@ import com.mydeck.app.domain.model.FilterFormState
 import com.mydeck.app.domain.model.ProgressFilter
 import com.mydeck.app.ui.list.LabelPickerBottomSheet
 import com.mydeck.app.ui.list.LabelPickerMode
+import kotlinx.coroutines.launch
 import kotlinx.datetime.Instant
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -70,7 +74,23 @@ fun FilterBottomSheet(
     onReset: () -> Unit,
     onDismiss: () -> Unit,
 ) {
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val keepExpanded = remember { mutableStateOf(false) }
+    val confirmSheetValue: (SheetValue) -> Boolean = remember {
+        { newValue -> !(keepExpanded.value && newValue == SheetValue.PartiallyExpanded) }
+    }
+    val sheetState = rememberModalBottomSheetState(
+        skipPartiallyExpanded = false,
+        confirmValueChange = confirmSheetValue,
+    )
+    val sheetScope = rememberCoroutineScope()
+    val expandSheetOnFocus = Modifier.onFocusEvent { state ->
+        if (state.isFocused) {
+            keepExpanded.value = true
+            if (sheetState.currentValue != SheetValue.Expanded) {
+                sheetScope.launch { sheetState.expand() }
+            }
+        }
+    }
 
     var search by remember(currentFilter) { mutableStateOf(currentFilter.search ?: "") }
     var title by remember(currentFilter) { mutableStateOf(currentFilter.title ?: "") }
@@ -315,7 +335,7 @@ fun FilterBottomSheet(
                     singleLine = true,
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number, imeAction = ImeAction.Next),
                     isError = readingTimeError,
-                    modifier = Modifier.weight(1f)
+                    modifier = Modifier.weight(1f).then(expandSheetOnFocus)
                 )
                 OutlinedTextField(
                     value = maxReadingTime,
@@ -325,7 +345,7 @@ fun FilterBottomSheet(
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number, imeAction = ImeAction.Search),
                     keyboardActions = KeyboardActions(onSearch = { applyFilter() }),
                     isError = readingTimeError,
-                    modifier = Modifier.weight(1f)
+                    modifier = Modifier.weight(1f).then(expandSheetOnFocus)
                 )
                 Row(
                     modifier = Modifier.align(Alignment.CenterVertically),
@@ -359,7 +379,7 @@ fun FilterBottomSheet(
                     singleLine = true,
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number, imeAction = ImeAction.Next),
                     isError = wordCountError,
-                    modifier = Modifier.weight(1f)
+                    modifier = Modifier.weight(1f).then(expandSheetOnFocus)
                 )
                 OutlinedTextField(
                     value = maxWordCount,
@@ -369,7 +389,7 @@ fun FilterBottomSheet(
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number, imeAction = ImeAction.Search),
                     keyboardActions = KeyboardActions(onSearch = { applyFilter() }),
                     isError = wordCountError,
-                    modifier = Modifier.weight(1f)
+                    modifier = Modifier.weight(1f).then(expandSheetOnFocus)
                 )
                 Row(
                     modifier = Modifier.align(Alignment.CenterVertically),

--- a/app/src/main/java/com/mydeck/app/ui/components/FilterBottomSheet.kt
+++ b/app/src/main/java/com/mydeck/app/ui/components/FilterBottomSheet.kt
@@ -14,12 +14,15 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.relocation.BringIntoViewRequester
+import androidx.compose.foundation.relocation.bringIntoViewRequester
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.DatePicker
@@ -34,17 +37,16 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
-import androidx.compose.material3.SheetValue
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -59,11 +61,13 @@ import com.mydeck.app.domain.model.FilterFormState
 import com.mydeck.app.domain.model.ProgressFilter
 import com.mydeck.app.ui.list.LabelPickerBottomSheet
 import com.mydeck.app.ui.list.LabelPickerMode
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.delay
 import kotlinx.datetime.Instant
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+
+private const val FOCUSED_FIELD_BRING_INTO_VIEW_DELAY_MS = 250L
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
@@ -74,23 +78,7 @@ fun FilterBottomSheet(
     onReset: () -> Unit,
     onDismiss: () -> Unit,
 ) {
-    val keepExpanded = remember { mutableStateOf(false) }
-    val confirmSheetValue: (SheetValue) -> Boolean = remember {
-        { newValue -> !(keepExpanded.value && newValue == SheetValue.PartiallyExpanded) }
-    }
-    val sheetState = rememberModalBottomSheetState(
-        skipPartiallyExpanded = false,
-        confirmValueChange = confirmSheetValue,
-    )
-    val sheetScope = rememberCoroutineScope()
-    val expandSheetOnFocus = Modifier.onFocusEvent { state ->
-        if (state.isFocused) {
-            keepExpanded.value = true
-            if (sheetState.currentValue != SheetValue.Expanded) {
-                sheetScope.launch { sheetState.expand() }
-            }
-        }
-    }
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false)
 
     var search by remember(currentFilter) { mutableStateOf(currentFilter.search ?: "") }
     var title by remember(currentFilter) { mutableStateOf(currentFilter.title ?: "") }
@@ -122,6 +110,7 @@ fun FilterBottomSheet(
     var showLabelPicker by remember { mutableStateOf(false) }
     var showFromDatePicker by remember { mutableStateOf(false) }
     var showToDatePicker by remember { mutableStateOf(false) }
+    var showLengthFilterDialog by remember { mutableStateOf(false) }
 
     val hasActiveFilters = search.isNotBlank() || title.isNotBlank() || author.isNotBlank() ||
         site.isNotBlank() || label != null || fromDate != null || toDate != null ||
@@ -169,6 +158,14 @@ fun FilterBottomSheet(
     )
 
     val dateFormatter = remember { SimpleDateFormat("MMM d, yyyy", Locale.getDefault()) }
+    val lengthSummary = lengthFilterSummary(
+        minReadingTime = minReadingTime.toIntOrNull(),
+        maxReadingTime = maxReadingTime.toIntOrNull(),
+        includeNullReadingTime = includeNullReadingTime,
+        minWordCount = minWordCount.toIntOrNull(),
+        maxWordCount = maxWordCount.toIntOrNull(),
+        includeNullWordCount = includeNullWordCount,
+    )
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,
@@ -177,12 +174,11 @@ fun FilterBottomSheet(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .imePadding()
                 .verticalScroll(rememberScrollState())
                 .padding(horizontal = 24.dp)
                 .navigationBarsPadding()
         ) {
-            // ── Search (full width, keyboard entry) ──────────────────────────
+            // -- Search (full width, keyboard entry)
             OutlinedTextField(
                 value = search,
                 onValueChange = { search = it },
@@ -203,7 +199,7 @@ fun FilterBottomSheet(
 
             Spacer(Modifier.height(12.dp))
 
-            // ── Title / Author (side-by-side) ────────────────────────────────
+            // -- Title / Author (side-by-side)
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                 OutlinedTextField(
                     value = title,
@@ -241,7 +237,7 @@ fun FilterBottomSheet(
 
             Spacer(Modifier.height(12.dp))
 
-            // ── Site / Label (side-by-side) ──────────────────────────────────
+            // -- Site / Label (side-by-side)
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                 OutlinedTextField(
                     value = site,
@@ -282,7 +278,7 @@ fun FilterBottomSheet(
 
             Spacer(Modifier.height(12.dp))
 
-            // ── From Date / To Date (side-by-side) ───────────────────────────
+            // -- From Date / To Date (side-by-side)
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                 OutlinedTextField(
                     value = fromDate?.let { dateFormatter.format(Date(it.toEpochMilliseconds())) } ?: "",
@@ -324,95 +320,21 @@ fun FilterBottomSheet(
 
             Spacer(Modifier.height(12.dp))
 
-            // ── Reading Time Est. ─────────────────────────────────────────────
-            Text(stringResource(R.string.filter_reading_time_est), style = MaterialTheme.typography.labelLarge)
-            Spacer(Modifier.height(8.dp))
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                OutlinedTextField(
-                    value = minReadingTime,
-                    onValueChange = { v -> if (v.all { it.isDigit() }) minReadingTime = v },
-                    label = { Text(stringResource(R.string.filter_reading_time_min)) },
-                    singleLine = true,
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number, imeAction = ImeAction.Next),
-                    isError = readingTimeError,
-                    modifier = Modifier.weight(1f).then(expandSheetOnFocus)
-                )
-                OutlinedTextField(
-                    value = maxReadingTime,
-                    onValueChange = { v -> if (v.all { it.isDigit() }) maxReadingTime = v },
-                    label = { Text(stringResource(R.string.filter_reading_time_max)) },
-                    singleLine = true,
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number, imeAction = ImeAction.Search),
-                    keyboardActions = KeyboardActions(onSearch = { applyFilter() }),
-                    isError = readingTimeError,
-                    modifier = Modifier.weight(1f).then(expandSheetOnFocus)
-                )
-                Row(
-                    modifier = Modifier.align(Alignment.CenterVertically),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Checkbox(
-                        checked = includeNullReadingTime,
-                        onCheckedChange = { includeNullReadingTime = it }
-                    )
-                    Text(stringResource(R.string.filter_reading_time_null))
-                }
-            }
-            if (readingTimeError) {
-                Text(
-                    text = stringResource(R.string.filter_reading_time_error),
-                    color = MaterialTheme.colorScheme.error,
-                    style = MaterialTheme.typography.bodySmall
-                )
-            }
+            OutlinedTextField(
+                value = lengthSummary,
+                onValueChange = {},
+                readOnly = true,
+                enabled = false,
+                colors = pickerColors,
+                label = { Text(stringResource(R.string.filter_length)) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { showLengthFilterDialog = true }
+            )
 
             Spacer(Modifier.height(12.dp))
 
-            // ── Word Count ─────────────────────────────────────────────────────
-            Text(stringResource(R.string.filter_word_count_est), style = MaterialTheme.typography.labelLarge)
-            Spacer(Modifier.height(8.dp))
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                OutlinedTextField(
-                    value = minWordCount,
-                    onValueChange = { v -> if (v.all { it.isDigit() }) minWordCount = v },
-                    label = { Text(stringResource(R.string.filter_reading_time_min)) },
-                    singleLine = true,
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number, imeAction = ImeAction.Next),
-                    isError = wordCountError,
-                    modifier = Modifier.weight(1f).then(expandSheetOnFocus)
-                )
-                OutlinedTextField(
-                    value = maxWordCount,
-                    onValueChange = { v -> if (v.all { it.isDigit() }) maxWordCount = v },
-                    label = { Text(stringResource(R.string.filter_reading_time_max)) },
-                    singleLine = true,
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number, imeAction = ImeAction.Search),
-                    keyboardActions = KeyboardActions(onSearch = { applyFilter() }),
-                    isError = wordCountError,
-                    modifier = Modifier.weight(1f).then(expandSheetOnFocus)
-                )
-                Row(
-                    modifier = Modifier.align(Alignment.CenterVertically),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Checkbox(
-                        checked = includeNullWordCount,
-                        onCheckedChange = { includeNullWordCount = it }
-                    )
-                    Text(stringResource(R.string.filter_reading_time_null))
-                }
-            }
-            if (wordCountError) {
-                Text(
-                    text = stringResource(R.string.filter_reading_time_error),
-                    color = MaterialTheme.colorScheme.error,
-                    style = MaterialTheme.typography.bodySmall
-                )
-            }
-
-            Spacer(Modifier.height(12.dp))
-
-            // ── Type chips ───────────────────────────────────────────────────
+            // -- Type chips
             Text(stringResource(R.string.filter_type), style = MaterialTheme.typography.labelLarge)
             Spacer(Modifier.height(8.dp))
             FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -435,7 +357,7 @@ fun FilterBottomSheet(
 
             Spacer(Modifier.height(16.dp))
 
-            // ── Progress chips ───────────────────────────────────────────────
+            // -- Progress chips
             Text(stringResource(R.string.filter_progress), style = MaterialTheme.typography.labelLarge)
             Spacer(Modifier.height(8.dp))
             FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -458,7 +380,7 @@ fun FilterBottomSheet(
 
             Spacer(Modifier.height(16.dp))
 
-            // ── Boolean filters (compact label-beside-control rows) ──────────
+            // -- Boolean filters (compact label-beside-control rows)
             CompactTriStateRow(stringResource(R.string.filter_is_favorite), isFavorite) { isFavorite = it }
             Spacer(Modifier.height(8.dp))
             CompactTriStateRow(stringResource(R.string.filter_is_archived), isArchived) { isArchived = it }
@@ -471,7 +393,7 @@ fun FilterBottomSheet(
 
             Spacer(Modifier.height(20.dp))
 
-            // ── Action buttons ───────────────────────────────────────────────
+            // -- Action buttons
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
                 if (hasActiveFilters) {
                     TextButton(onClick = onReset) { Text(stringResource(R.string.filter_reset)) }
@@ -482,6 +404,32 @@ fun FilterBottomSheet(
 
             Spacer(Modifier.height(16.dp))
         }
+    }
+
+    if (showLengthFilterDialog) {
+        LengthFilterDialog(
+            initialMinReadingTime = minReadingTime,
+            initialMaxReadingTime = maxReadingTime,
+            initialIncludeNullReadingTime = includeNullReadingTime,
+            initialMinWordCount = minWordCount,
+            initialMaxWordCount = maxWordCount,
+            initialIncludeNullWordCount = includeNullWordCount,
+            onApply = { newMinReadingTime,
+                    newMaxReadingTime,
+                    newIncludeNullReadingTime,
+                    newMinWordCount,
+                    newMaxWordCount,
+                    newIncludeNullWordCount ->
+                minReadingTime = newMinReadingTime
+                maxReadingTime = newMaxReadingTime
+                includeNullReadingTime = newIncludeNullReadingTime
+                minWordCount = newMinWordCount
+                maxWordCount = newMaxWordCount
+                includeNullWordCount = newIncludeNullWordCount
+                showLengthFilterDialog = false
+            },
+            onDismiss = { showLengthFilterDialog = false }
+        )
     }
 
     // Label picker (selection-only — no rename/delete)
@@ -532,6 +480,239 @@ fun FilterBottomSheet(
             }
         ) { DatePicker(state = state) }
     }
+}
+
+@Composable
+private fun lengthFilterSummary(
+    minReadingTime: Int?,
+    maxReadingTime: Int?,
+    includeNullReadingTime: Boolean,
+    minWordCount: Int?,
+    maxWordCount: Int?,
+    includeNullWordCount: Boolean,
+): String {
+    val nullLabel = stringResource(R.string.filter_reading_time_null)
+    val parts = listOfNotNull(
+        rangeFilterSummary(
+            label = stringResource(R.string.filter_reading_time),
+            min = minReadingTime,
+            max = maxReadingTime,
+            includeNull = includeNullReadingTime,
+            unit = " min",
+            nullLabel = nullLabel,
+        ),
+        rangeFilterSummary(
+            label = stringResource(R.string.filter_word_count),
+            min = minWordCount,
+            max = maxWordCount,
+            includeNull = includeNullWordCount,
+            unit = "",
+            nullLabel = nullLabel,
+        ),
+    )
+
+    return parts.joinToString(" / ").ifBlank {
+        stringResource(R.string.filter_length_summary_none)
+    }
+}
+
+private fun rangeFilterSummary(
+    label: String,
+    min: Int?,
+    max: Int?,
+    includeNull: Boolean,
+    unit: String,
+    nullLabel: String,
+): String? {
+    if (min == null && max == null && !includeNull) return null
+
+    val rangeLabel = when {
+        min != null && max != null -> "$min-$max$unit"
+        min != null -> ">=$min$unit"
+        max != null -> "<=$max$unit"
+        else -> null
+    }
+
+    return when {
+        rangeLabel != null && includeNull -> "$label: $rangeLabel + $nullLabel"
+        rangeLabel != null -> "$label: $rangeLabel"
+        else -> "$label: $nullLabel"
+    }
+}
+
+@Composable
+private fun LengthFilterDialog(
+    initialMinReadingTime: String,
+    initialMaxReadingTime: String,
+    initialIncludeNullReadingTime: Boolean,
+    initialMinWordCount: String,
+    initialMaxWordCount: String,
+    initialIncludeNullWordCount: Boolean,
+    onApply: (String, String, Boolean, String, String, Boolean) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var minReadingTime by remember(initialMinReadingTime) { mutableStateOf(initialMinReadingTime) }
+    var maxReadingTime by remember(initialMaxReadingTime) { mutableStateOf(initialMaxReadingTime) }
+    var includeNullReadingTime by remember(initialIncludeNullReadingTime) {
+        mutableStateOf(initialIncludeNullReadingTime)
+    }
+    var minWordCount by remember(initialMinWordCount) { mutableStateOf(initialMinWordCount) }
+    var maxWordCount by remember(initialMaxWordCount) { mutableStateOf(initialMaxWordCount) }
+    var includeNullWordCount by remember(initialIncludeNullWordCount) {
+        mutableStateOf(initialIncludeNullWordCount)
+    }
+
+    val readingTimeError = minReadingTime.isNotEmpty() && maxReadingTime.isNotEmpty() &&
+        (minReadingTime.toIntOrNull() ?: 0) > (maxReadingTime.toIntOrNull() ?: 0)
+    val wordCountError = minWordCount.isNotEmpty() && maxWordCount.isNotEmpty() &&
+        (minWordCount.toIntOrNull() ?: 0) > (maxWordCount.toIntOrNull() ?: 0)
+    val hasValidationError = readingTimeError || wordCountError
+
+    val applyDialog = {
+        if (!hasValidationError) {
+            onApply(
+                minReadingTime,
+                maxReadingTime,
+                includeNullReadingTime,
+                minWordCount,
+                maxWordCount,
+                includeNullWordCount,
+            )
+        }
+    }
+    val clearDialog = {
+        minReadingTime = ""
+        maxReadingTime = ""
+        includeNullReadingTime = false
+        minWordCount = ""
+        maxWordCount = ""
+        includeNullWordCount = false
+    }
+
+    AlertDialog(
+        modifier = Modifier.imePadding(),
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.filter_length_dialog_title)) },
+        text = {
+            Column(
+                modifier = Modifier.verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                LengthRangeSection(
+                    title = stringResource(R.string.filter_reading_time_est),
+                    minValue = minReadingTime,
+                    maxValue = maxReadingTime,
+                    includeNull = includeNullReadingTime,
+                    hasError = readingTimeError,
+                    maxImeAction = ImeAction.Next,
+                    onMinValueChange = { minReadingTime = it },
+                    onMaxValueChange = { maxReadingTime = it },
+                    onIncludeNullChange = { includeNullReadingTime = it },
+                )
+                LengthRangeSection(
+                    title = stringResource(R.string.filter_word_count_est),
+                    minValue = minWordCount,
+                    maxValue = maxWordCount,
+                    includeNull = includeNullWordCount,
+                    hasError = wordCountError,
+                    maxImeAction = ImeAction.Done,
+                    onMinValueChange = { minWordCount = it },
+                    onMaxValueChange = { maxWordCount = it },
+                    onIncludeNullChange = { includeNullWordCount = it },
+                    onDone = applyDialog,
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = applyDialog, enabled = !hasValidationError) {
+                Text(stringResource(R.string.ok))
+            }
+        },
+        dismissButton = {
+            Row {
+                TextButton(onClick = clearDialog) {
+                    Text(stringResource(R.string.filter_length_clear))
+                }
+                TextButton(onClick = onDismiss) {
+                    Text(stringResource(R.string.cancel))
+                }
+            }
+        }
+    )
+}
+
+@Composable
+private fun LengthRangeSection(
+    title: String,
+    minValue: String,
+    maxValue: String,
+    includeNull: Boolean,
+    hasError: Boolean,
+    maxImeAction: ImeAction,
+    onMinValueChange: (String) -> Unit,
+    onMaxValueChange: (String) -> Unit,
+    onIncludeNullChange: (Boolean) -> Unit,
+    onDone: (() -> Unit)? = null,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(title, style = MaterialTheme.typography.labelLarge)
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            OutlinedTextField(
+                value = minValue,
+                onValueChange = { v -> if (v.all { it.isDigit() }) onMinValueChange(v) },
+                label = { Text(stringResource(R.string.filter_reading_time_min)) },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number, imeAction = ImeAction.Next),
+                isError = hasError,
+                modifier = Modifier
+                    .weight(1f)
+                    .bringFocusedFieldIntoView()
+            )
+            OutlinedTextField(
+                value = maxValue,
+                onValueChange = { v -> if (v.all { it.isDigit() }) onMaxValueChange(v) },
+                label = { Text(stringResource(R.string.filter_reading_time_max)) },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number, imeAction = maxImeAction),
+                keyboardActions = KeyboardActions(onDone = { onDone?.invoke() }),
+                isError = hasError,
+                modifier = Modifier
+                    .weight(1f)
+                    .bringFocusedFieldIntoView()
+            )
+        }
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Checkbox(
+                checked = includeNull,
+                onCheckedChange = onIncludeNullChange
+            )
+            Text(stringResource(R.string.filter_length_include_unknown))
+        }
+        if (hasError) {
+            Text(
+                text = stringResource(R.string.filter_reading_time_error),
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodySmall
+            )
+        }
+    }
+}
+
+@Composable
+private fun Modifier.bringFocusedFieldIntoView(): Modifier {
+    val bringIntoViewRequester = remember { BringIntoViewRequester() }
+    var isFocused by remember { mutableStateOf(false) }
+
+    LaunchedEffect(isFocused) {
+        if (isFocused) {
+            delay(FOCUSED_FIELD_BRING_INTO_VIEW_DELAY_MS)
+            bringIntoViewRequester.bringIntoView()
+        }
+    }
+
+    return this
+        .bringIntoViewRequester(bringIntoViewRequester)
+        .onFocusEvent { state -> isFocused = state.isFocused }
 }
 
 /** Single-row tri-state control: label on the left, [N/A | Yes | No] on the right. */

--- a/app/src/main/java/com/mydeck/app/ui/components/FilterBottomSheet.kt
+++ b/app/src/main/java/com/mydeck/app/ui/components/FilterBottomSheet.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -20,6 +21,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material3.Button
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.DatePicker
 import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -46,6 +48,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.mydeck.app.R
 import com.mydeck.app.domain.model.Bookmark
@@ -67,7 +70,7 @@ fun FilterBottomSheet(
     onReset: () -> Unit,
     onDismiss: () -> Unit,
 ) {
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false)
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
     var search by remember(currentFilter) { mutableStateOf(currentFilter.search ?: "") }
     var title by remember(currentFilter) { mutableStateOf(currentFilter.title ?: "") }
@@ -83,6 +86,18 @@ fun FilterBottomSheet(
     var isLoaded by remember(currentFilter) { mutableStateOf(currentFilter.isLoaded) }
     var withLabels by remember(currentFilter) { mutableStateOf(currentFilter.withLabels) }
     var withErrors by remember(currentFilter) { mutableStateOf(currentFilter.withErrors) }
+    var minReadingTime by remember(currentFilter) { mutableStateOf(currentFilter.minReadingTime?.toString() ?: "") }
+    var maxReadingTime by remember(currentFilter) { mutableStateOf(currentFilter.maxReadingTime?.toString() ?: "") }
+    var includeNullReadingTime by remember(currentFilter) { mutableStateOf(currentFilter.includeNullReadingTime) }
+    var minWordCount by remember(currentFilter) { mutableStateOf(currentFilter.minWordCount?.toString() ?: "") }
+    var maxWordCount by remember(currentFilter) { mutableStateOf(currentFilter.maxWordCount?.toString() ?: "") }
+    var includeNullWordCount by remember(currentFilter) { mutableStateOf(currentFilter.includeNullWordCount) }
+
+    val readingTimeError = minReadingTime.isNotEmpty() && maxReadingTime.isNotEmpty() &&
+        (minReadingTime.toIntOrNull() ?: 0) > (maxReadingTime.toIntOrNull() ?: 0)
+    val wordCountError = minWordCount.isNotEmpty() && maxWordCount.isNotEmpty() &&
+        (minWordCount.toIntOrNull() ?: 0) > (maxWordCount.toIntOrNull() ?: 0)
+    val hasValidationError = readingTimeError || wordCountError
 
     var showLabelPicker by remember { mutableStateOf(false) }
     var showFromDatePicker by remember { mutableStateOf(false) }
@@ -91,25 +106,35 @@ fun FilterBottomSheet(
     val hasActiveFilters = search.isNotBlank() || title.isNotBlank() || author.isNotBlank() ||
         site.isNotBlank() || label != null || fromDate != null || toDate != null ||
         types.isNotEmpty() || progress.isNotEmpty() || isFavorite != null ||
-        isArchived != null || isLoaded != null || withLabels != null || withErrors != null
+        isArchived != null || isLoaded != null || withLabels != null || withErrors != null ||
+        minReadingTime.isNotBlank() || maxReadingTime.isNotBlank() || includeNullReadingTime ||
+        minWordCount.isNotBlank() || maxWordCount.isNotBlank() || includeNullWordCount
 
     val applyFilter = {
-        onApply(FilterFormState(
-            search = search.ifBlank { null },
-            title = title.ifBlank { null },
-            author = author.ifBlank { null },
-            site = site.ifBlank { null },
-            label = label,
-            fromDate = fromDate,
-            toDate = toDate,
-            types = types,
-            progress = progress,
-            isFavorite = isFavorite,
-            isArchived = isArchived,
-            isLoaded = isLoaded,
-            withLabels = withLabels,
-            withErrors = withErrors,
-        ))
+        if (!hasValidationError) {
+            onApply(FilterFormState(
+                search = search.ifBlank { null },
+                title = title.ifBlank { null },
+                author = author.ifBlank { null },
+                site = site.ifBlank { null },
+                label = label,
+                fromDate = fromDate,
+                toDate = toDate,
+                types = types,
+                progress = progress,
+                isFavorite = isFavorite,
+                isArchived = isArchived,
+                isLoaded = isLoaded,
+                withLabels = withLabels,
+                withErrors = withErrors,
+                minReadingTime = minReadingTime.toIntOrNull(),
+                maxReadingTime = maxReadingTime.toIntOrNull(),
+                includeNullReadingTime = includeNullReadingTime,
+                minWordCount = minWordCount.toIntOrNull(),
+                maxWordCount = maxWordCount.toIntOrNull(),
+                includeNullWordCount = includeNullWordCount,
+            ))
+        }
     }
 
     // Colors that make a disabled OutlinedTextField look like an enabled one.
@@ -132,6 +157,7 @@ fun FilterBottomSheet(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
+                .imePadding()
                 .verticalScroll(rememberScrollState())
                 .padding(horizontal = 24.dp)
                 .navigationBarsPadding()
@@ -276,7 +302,95 @@ fun FilterBottomSheet(
                 )
             }
 
-            Spacer(Modifier.height(16.dp))
+            Spacer(Modifier.height(12.dp))
+
+            // ── Reading Time Est. ─────────────────────────────────────────────
+            Text(stringResource(R.string.filter_reading_time_est), style = MaterialTheme.typography.labelLarge)
+            Spacer(Modifier.height(8.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(
+                    value = minReadingTime,
+                    onValueChange = { v -> if (v.all { it.isDigit() }) minReadingTime = v },
+                    label = { Text(stringResource(R.string.filter_reading_time_min)) },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number, imeAction = ImeAction.Next),
+                    isError = readingTimeError,
+                    modifier = Modifier.weight(1f)
+                )
+                OutlinedTextField(
+                    value = maxReadingTime,
+                    onValueChange = { v -> if (v.all { it.isDigit() }) maxReadingTime = v },
+                    label = { Text(stringResource(R.string.filter_reading_time_max)) },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number, imeAction = ImeAction.Search),
+                    keyboardActions = KeyboardActions(onSearch = { applyFilter() }),
+                    isError = readingTimeError,
+                    modifier = Modifier.weight(1f)
+                )
+                Row(
+                    modifier = Modifier.align(Alignment.CenterVertically),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Checkbox(
+                        checked = includeNullReadingTime,
+                        onCheckedChange = { includeNullReadingTime = it }
+                    )
+                    Text(stringResource(R.string.filter_reading_time_null))
+                }
+            }
+            if (readingTimeError) {
+                Text(
+                    text = stringResource(R.string.filter_reading_time_error),
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodySmall
+                )
+            }
+
+            Spacer(Modifier.height(12.dp))
+
+            // ── Word Count ─────────────────────────────────────────────────────
+            Text(stringResource(R.string.filter_word_count_est), style = MaterialTheme.typography.labelLarge)
+            Spacer(Modifier.height(8.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(
+                    value = minWordCount,
+                    onValueChange = { v -> if (v.all { it.isDigit() }) minWordCount = v },
+                    label = { Text(stringResource(R.string.filter_reading_time_min)) },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number, imeAction = ImeAction.Next),
+                    isError = wordCountError,
+                    modifier = Modifier.weight(1f)
+                )
+                OutlinedTextField(
+                    value = maxWordCount,
+                    onValueChange = { v -> if (v.all { it.isDigit() }) maxWordCount = v },
+                    label = { Text(stringResource(R.string.filter_reading_time_max)) },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number, imeAction = ImeAction.Search),
+                    keyboardActions = KeyboardActions(onSearch = { applyFilter() }),
+                    isError = wordCountError,
+                    modifier = Modifier.weight(1f)
+                )
+                Row(
+                    modifier = Modifier.align(Alignment.CenterVertically),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Checkbox(
+                        checked = includeNullWordCount,
+                        onCheckedChange = { includeNullWordCount = it }
+                    )
+                    Text(stringResource(R.string.filter_reading_time_null))
+                }
+            }
+            if (wordCountError) {
+                Text(
+                    text = stringResource(R.string.filter_reading_time_error),
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodySmall
+                )
+            }
+
+            Spacer(Modifier.height(12.dp))
 
             // ── Type chips ───────────────────────────────────────────────────
             Text(stringResource(R.string.filter_type), style = MaterialTheme.typography.labelLarge)
@@ -343,7 +457,7 @@ fun FilterBottomSheet(
                     TextButton(onClick = onReset) { Text(stringResource(R.string.filter_reset)) }
                     Spacer(Modifier.width(8.dp))
                 }
-                Button(onClick = { applyFilter() }) { Text(stringResource(R.string.search)) }
+                Button(onClick = { applyFilter() }, enabled = !hasValidationError) { Text(stringResource(R.string.search)) }
             }
 
             Spacer(Modifier.height(16.dp))

--- a/app/src/main/java/com/mydeck/app/ui/components/FilterBottomSheet.kt
+++ b/app/src/main/java/com/mydeck/app/ui/components/FilterBottomSheet.kt
@@ -2,6 +2,7 @@ package com.mydeck.app.ui.components
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
@@ -52,6 +53,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusEvent
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
@@ -321,12 +323,27 @@ fun FilterBottomSheet(
             Spacer(Modifier.height(12.dp))
 
             OutlinedTextField(
-                value = lengthSummary,
+                value = lengthSummary ?: "",
                 onValueChange = {},
                 readOnly = true,
                 enabled = false,
                 colors = pickerColors,
                 label = { Text(stringResource(R.string.filter_length)) },
+                placeholder = { Text(stringResource(R.string.filter_length_summary_none)) },
+                trailingIcon = {
+                    if (lengthSummary != null) {
+                        IconButton(onClick = {
+                            minReadingTime = ""
+                            maxReadingTime = ""
+                            includeNullReadingTime = false
+                            minWordCount = ""
+                            maxWordCount = ""
+                            includeNullWordCount = false
+                        }) {
+                            Icon(Icons.Filled.Clear, contentDescription = null, modifier = Modifier.size(16.dp))
+                        }
+                    }
+                },
                 modifier = Modifier
                     .fillMaxWidth()
                     .clickable { showLengthFilterDialog = true }
@@ -490,8 +507,8 @@ private fun lengthFilterSummary(
     minWordCount: Int?,
     maxWordCount: Int?,
     includeNullWordCount: Boolean,
-): String {
-    val nullLabel = stringResource(R.string.filter_reading_time_null)
+): String? {
+    val unknownLabel = stringResource(R.string.filter_length_unknown)
     val parts = listOfNotNull(
         rangeFilterSummary(
             label = stringResource(R.string.filter_reading_time),
@@ -499,7 +516,7 @@ private fun lengthFilterSummary(
             max = maxReadingTime,
             includeNull = includeNullReadingTime,
             unit = " min",
-            nullLabel = nullLabel,
+            unknownLabel = unknownLabel,
         ),
         rangeFilterSummary(
             label = stringResource(R.string.filter_word_count),
@@ -507,13 +524,11 @@ private fun lengthFilterSummary(
             max = maxWordCount,
             includeNull = includeNullWordCount,
             unit = "",
-            nullLabel = nullLabel,
+            unknownLabel = unknownLabel,
         ),
     )
 
-    return parts.joinToString(" / ").ifBlank {
-        stringResource(R.string.filter_length_summary_none)
-    }
+    return parts.joinToString(" / ").ifBlank { null }
 }
 
 private fun rangeFilterSummary(
@@ -522,21 +537,21 @@ private fun rangeFilterSummary(
     max: Int?,
     includeNull: Boolean,
     unit: String,
-    nullLabel: String,
+    unknownLabel: String,
 ): String? {
     if (min == null && max == null && !includeNull) return null
 
     val rangeLabel = when {
-        min != null && max != null -> "$min-$max$unit"
-        min != null -> ">=$min$unit"
-        max != null -> "<=$max$unit"
+        min != null && max != null -> "$min–$max$unit"
+        min != null -> "≥$min$unit"
+        max != null -> "≤$max$unit"
         else -> null
     }
 
     return when {
-        rangeLabel != null && includeNull -> "$label: $rangeLabel + $nullLabel"
+        rangeLabel != null && includeNull -> "$label: $rangeLabel + $unknownLabel"
         rangeLabel != null -> "$label: $rangeLabel"
-        else -> "$label: $nullLabel"
+        else -> "$label: $unknownLabel"
     }
 }
 
@@ -567,6 +582,10 @@ private fun LengthFilterDialog(
     val wordCountError = minWordCount.isNotEmpty() && maxWordCount.isNotEmpty() &&
         (minWordCount.toIntOrNull() ?: 0) > (maxWordCount.toIntOrNull() ?: 0)
     val hasValidationError = readingTimeError || wordCountError
+
+    val hasAnyValue = minReadingTime.isNotEmpty() || maxReadingTime.isNotEmpty() ||
+        includeNullReadingTime ||
+        minWordCount.isNotEmpty() || maxWordCount.isNotEmpty() || includeNullWordCount
 
     val applyDialog = {
         if (!hasValidationError) {
@@ -621,6 +640,13 @@ private fun LengthFilterDialog(
                     onIncludeNullChange = { includeNullWordCount = it },
                     onDone = applyDialog,
                 )
+                TextButton(
+                    onClick = clearDialog,
+                    enabled = hasAnyValue,
+                    modifier = Modifier.align(Alignment.Start)
+                ) {
+                    Text(stringResource(R.string.filter_length_clear))
+                }
             }
         },
         confirmButton = {
@@ -629,13 +655,8 @@ private fun LengthFilterDialog(
             }
         },
         dismissButton = {
-            Row {
-                TextButton(onClick = clearDialog) {
-                    Text(stringResource(R.string.filter_length_clear))
-                }
-                TextButton(onClick = onDismiss) {
-                    Text(stringResource(R.string.cancel))
-                }
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.cancel))
             }
         }
     )
@@ -681,10 +702,19 @@ private fun LengthRangeSection(
                     .bringFocusedFieldIntoView()
             )
         }
-        Row(verticalAlignment = Alignment.CenterVertically) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .toggleable(
+                    value = includeNull,
+                    onValueChange = onIncludeNullChange,
+                    role = Role.Checkbox,
+                )
+        ) {
             Checkbox(
                 checked = includeNull,
-                onCheckedChange = onIncludeNullChange
+                onCheckedChange = null,
             )
             Text(stringResource(R.string.filter_length_include_unknown))
         }

--- a/app/src/main/java/com/mydeck/app/ui/list/BookmarkListViewModel.kt
+++ b/app/src/main/java/com/mydeck/app/ui/list/BookmarkListViewModel.kt
@@ -270,6 +270,12 @@ class BookmarkListViewModel @Inject constructor(
                         isLoaded = filter.isLoaded,
                         withLabels = filter.withLabels,
                         withErrors = filter.withErrors,
+                        minReadingTime = filter.minReadingTime,
+                        maxReadingTime = filter.maxReadingTime,
+                        includeNullReadingTime = filter.includeNullReadingTime,
+                        minWordCount = filter.minWordCount,
+                        maxWordCount = filter.maxWordCount,
+                        includeNullWordCount = filter.includeNullWordCount,
                         orderBy = sort.sqlOrderBy
                     )
                 }

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -419,6 +419,11 @@ other{}
     <string name="filter_label">Label</string>
     <string name="filter_from_date">From date</string>
     <string name="filter_to_date">To date</string>
+    <string name="filter_length">Length</string>
+    <string name="filter_length_dialog_title">Length filters</string>
+    <string name="filter_length_summary_none">Any reading time / any word count</string>
+    <string name="filter_length_include_unknown">Include unknown</string>
+    <string name="filter_length_clear">Clear</string>
     <string name="filter_reading_time_est">Reading Time Est.</string>
     <string name="filter_reading_time_min">Min</string>
     <string name="filter_reading_time_max">Max</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -419,6 +419,14 @@ other{}
     <string name="filter_label">Label</string>
     <string name="filter_from_date">From date</string>
     <string name="filter_to_date">To date</string>
+    <string name="filter_reading_time_est">Reading Time Est.</string>
+    <string name="filter_reading_time_min">Min</string>
+    <string name="filter_reading_time_max">Max</string>
+    <string name="filter_reading_time_null">Null</string>
+    <string name="filter_reading_time_error">Min must be less than or equal to max</string>
+    <string name="filter_reading_time">Read time</string>
+    <string name="filter_word_count_est">Word Count</string>
+    <string name="filter_word_count">Words</string>
     <string name="filter_is_loaded">Is downloaded</string>
     <string name="filtered_list">Filtered List</string>
     <string name="filter_with_labels">With labels</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -423,6 +423,7 @@ other{}
     <string name="filter_length_dialog_title">Length filters</string>
     <string name="filter_length_summary_none">Any reading time / any word count</string>
     <string name="filter_length_include_unknown">Include unknown</string>
+    <string name="filter_length_unknown">unknown</string>
     <string name="filter_length_clear">Clear</string>
     <string name="filter_reading_time_est">Reading Time Est.</string>
     <string name="filter_reading_time_min">Min</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -402,6 +402,14 @@ other{}
     <string name="filter_label">Etiqueta</string>
     <string name="filter_from_date">Desde la fecha</string>
     <string name="filter_to_date">Hasta la fecha</string>
+    <string name="filter_reading_time_est">Reading Time Est.</string>
+    <string name="filter_reading_time_min">Min</string>
+    <string name="filter_reading_time_max">Max</string>
+    <string name="filter_reading_time_null">Null</string>
+    <string name="filter_reading_time_error">Min must be less than or equal to max</string>
+    <string name="filter_reading_time">Read time</string>
+    <string name="filter_word_count_est">Word Count</string>
+    <string name="filter_word_count">Words</string>
     <string name="filter_is_loaded">Está descargado</string>
     <string name="filtered_list">Filtered List</string>
     <string name="filter_with_labels">Con etiquetas</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -406,6 +406,7 @@ other{}
     <string name="filter_length_dialog_title">Length filters</string>
     <string name="filter_length_summary_none">Any reading time / any word count</string>
     <string name="filter_length_include_unknown">Include unknown</string>
+    <string name="filter_length_unknown">unknown</string>
     <string name="filter_length_clear">Clear</string>
     <string name="filter_reading_time_est">Reading Time Est.</string>
     <string name="filter_reading_time_min">Min</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -402,6 +402,11 @@ other{}
     <string name="filter_label">Etiqueta</string>
     <string name="filter_from_date">Desde la fecha</string>
     <string name="filter_to_date">Hasta la fecha</string>
+    <string name="filter_length">Length</string>
+    <string name="filter_length_dialog_title">Length filters</string>
+    <string name="filter_length_summary_none">Any reading time / any word count</string>
+    <string name="filter_length_include_unknown">Include unknown</string>
+    <string name="filter_length_clear">Clear</string>
     <string name="filter_reading_time_est">Reading Time Est.</string>
     <string name="filter_reading_time_min">Min</string>
     <string name="filter_reading_time_max">Max</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -279,6 +279,7 @@
     <string name="filter_length_dialog_title">Length filters</string>
     <string name="filter_length_summary_none">Any reading time / any word count</string>
     <string name="filter_length_include_unknown">Include unknown</string>
+    <string name="filter_length_unknown">unknown</string>
     <string name="filter_length_clear">Clear</string>
     <string name="filter_reading_time_est">Reading Time Est.</string>
     <string name="filter_reading_time_min">Min</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -275,6 +275,14 @@
     <string name="filter_label">Label</string>
     <string name="filter_from_date">From date</string>
     <string name="filter_to_date">To date</string>
+    <string name="filter_reading_time_est">Reading Time Est.</string>
+    <string name="filter_reading_time_min">Min</string>
+    <string name="filter_reading_time_max">Max</string>
+    <string name="filter_reading_time_null">Null</string>
+    <string name="filter_reading_time_error">Min must be less than or equal to max</string>
+    <string name="filter_reading_time">Read time</string>
+    <string name="filter_word_count_est">Word Count</string>
+    <string name="filter_word_count">Words</string>
     <string name="filter_is_loaded">Is downloaded</string>
     <string name="filtered_list">Filtered List</string>
     <string name="filter_with_labels">With labels</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -275,6 +275,11 @@
     <string name="filter_label">Label</string>
     <string name="filter_from_date">From date</string>
     <string name="filter_to_date">To date</string>
+    <string name="filter_length">Length</string>
+    <string name="filter_length_dialog_title">Length filters</string>
+    <string name="filter_length_summary_none">Any reading time / any word count</string>
+    <string name="filter_length_include_unknown">Include unknown</string>
+    <string name="filter_length_clear">Clear</string>
     <string name="filter_reading_time_est">Reading Time Est.</string>
     <string name="filter_reading_time_min">Min</string>
     <string name="filter_reading_time_max">Max</string>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -342,6 +342,11 @@ other{}
     <string name="filter_label">Label</string>
     <string name="filter_from_date">From date</string>
     <string name="filter_to_date">To date</string>
+    <string name="filter_length">Length</string>
+    <string name="filter_length_dialog_title">Length filters</string>
+    <string name="filter_length_summary_none">Any reading time / any word count</string>
+    <string name="filter_length_include_unknown">Include unknown</string>
+    <string name="filter_length_clear">Clear</string>
     <string name="filter_reading_time_est">Reading Time Est.</string>
     <string name="filter_reading_time_min">Min</string>
     <string name="filter_reading_time_max">Max</string>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -342,6 +342,14 @@ other{}
     <string name="filter_label">Label</string>
     <string name="filter_from_date">From date</string>
     <string name="filter_to_date">To date</string>
+    <string name="filter_reading_time_est">Reading Time Est.</string>
+    <string name="filter_reading_time_min">Min</string>
+    <string name="filter_reading_time_max">Max</string>
+    <string name="filter_reading_time_null">Null</string>
+    <string name="filter_reading_time_error">Min must be less than or equal to max</string>
+    <string name="filter_reading_time">Read time</string>
+    <string name="filter_word_count_est">Word Count</string>
+    <string name="filter_word_count">Words</string>
     <string name="filter_is_loaded">Is downloaded</string>
     <string name="filtered_list">Filtered List</string>
     <string name="filter_with_labels">With labels</string>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -346,6 +346,7 @@ other{}
     <string name="filter_length_dialog_title">Length filters</string>
     <string name="filter_length_summary_none">Any reading time / any word count</string>
     <string name="filter_length_include_unknown">Include unknown</string>
+    <string name="filter_length_unknown">unknown</string>
     <string name="filter_length_clear">Clear</string>
     <string name="filter_reading_time_est">Reading Time Est.</string>
     <string name="filter_reading_time_min">Min</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -279,6 +279,7 @@
     <string name="filter_length_dialog_title">Length filters</string>
     <string name="filter_length_summary_none">Any reading time / any word count</string>
     <string name="filter_length_include_unknown">Include unknown</string>
+    <string name="filter_length_unknown">unknown</string>
     <string name="filter_length_clear">Clear</string>
     <string name="filter_reading_time_est">Reading Time Est.</string>
     <string name="filter_reading_time_min">Min</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -275,6 +275,14 @@
     <string name="filter_label">Label</string>
     <string name="filter_from_date">From date</string>
     <string name="filter_to_date">To date</string>
+    <string name="filter_reading_time_est">Reading Time Est.</string>
+    <string name="filter_reading_time_min">Min</string>
+    <string name="filter_reading_time_max">Max</string>
+    <string name="filter_reading_time_null">Null</string>
+    <string name="filter_reading_time_error">Min must be less than or equal to max</string>
+    <string name="filter_reading_time">Read time</string>
+    <string name="filter_word_count_est">Word Count</string>
+    <string name="filter_word_count">Words</string>
     <string name="filter_is_loaded">Is downloaded</string>
     <string name="filtered_list">Filtered List</string>
     <string name="filter_with_labels">With labels</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -275,6 +275,11 @@
     <string name="filter_label">Label</string>
     <string name="filter_from_date">From date</string>
     <string name="filter_to_date">To date</string>
+    <string name="filter_length">Length</string>
+    <string name="filter_length_dialog_title">Length filters</string>
+    <string name="filter_length_summary_none">Any reading time / any word count</string>
+    <string name="filter_length_include_unknown">Include unknown</string>
+    <string name="filter_length_clear">Clear</string>
     <string name="filter_reading_time_est">Reading Time Est.</string>
     <string name="filter_reading_time_min">Min</string>
     <string name="filter_reading_time_max">Max</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -279,6 +279,7 @@
     <string name="filter_length_dialog_title">Length filters</string>
     <string name="filter_length_summary_none">Any reading time / any word count</string>
     <string name="filter_length_include_unknown">Include unknown</string>
+    <string name="filter_length_unknown">unknown</string>
     <string name="filter_length_clear">Clear</string>
     <string name="filter_reading_time_est">Reading Time Est.</string>
     <string name="filter_reading_time_min">Min</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -275,6 +275,14 @@
     <string name="filter_label">Label</string>
     <string name="filter_from_date">From date</string>
     <string name="filter_to_date">To date</string>
+    <string name="filter_reading_time_est">Reading Time Est.</string>
+    <string name="filter_reading_time_min">Min</string>
+    <string name="filter_reading_time_max">Max</string>
+    <string name="filter_reading_time_null">Null</string>
+    <string name="filter_reading_time_error">Min must be less than or equal to max</string>
+    <string name="filter_reading_time">Read time</string>
+    <string name="filter_word_count_est">Word Count</string>
+    <string name="filter_word_count">Words</string>
     <string name="filter_is_loaded">Is downloaded</string>
     <string name="filtered_list">Filtered List</string>
     <string name="filter_with_labels">With labels</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -275,6 +275,11 @@
     <string name="filter_label">Label</string>
     <string name="filter_from_date">From date</string>
     <string name="filter_to_date">To date</string>
+    <string name="filter_length">Length</string>
+    <string name="filter_length_dialog_title">Length filters</string>
+    <string name="filter_length_summary_none">Any reading time / any word count</string>
+    <string name="filter_length_include_unknown">Include unknown</string>
+    <string name="filter_length_clear">Clear</string>
     <string name="filter_reading_time_est">Reading Time Est.</string>
     <string name="filter_reading_time_min">Min</string>
     <string name="filter_reading_time_max">Max</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -279,6 +279,7 @@
     <string name="filter_length_dialog_title">Length filters</string>
     <string name="filter_length_summary_none">Any reading time / any word count</string>
     <string name="filter_length_include_unknown">Include unknown</string>
+    <string name="filter_length_unknown">unknown</string>
     <string name="filter_length_clear">Clear</string>
     <string name="filter_reading_time_est">Reading Time Est.</string>
     <string name="filter_reading_time_min">Min</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -275,6 +275,14 @@
     <string name="filter_label">Label</string>
     <string name="filter_from_date">From date</string>
     <string name="filter_to_date">To date</string>
+    <string name="filter_reading_time_est">Reading Time Est.</string>
+    <string name="filter_reading_time_min">Min</string>
+    <string name="filter_reading_time_max">Max</string>
+    <string name="filter_reading_time_null">Null</string>
+    <string name="filter_reading_time_error">Min must be less than or equal to max</string>
+    <string name="filter_reading_time">Read time</string>
+    <string name="filter_word_count_est">Word Count</string>
+    <string name="filter_word_count">Words</string>
     <string name="filter_is_loaded">Is downloaded</string>
     <string name="filtered_list">Filtered List</string>
     <string name="filter_with_labels">With labels</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -275,6 +275,11 @@
     <string name="filter_label">Label</string>
     <string name="filter_from_date">From date</string>
     <string name="filter_to_date">To date</string>
+    <string name="filter_length">Length</string>
+    <string name="filter_length_dialog_title">Length filters</string>
+    <string name="filter_length_summary_none">Any reading time / any word count</string>
+    <string name="filter_length_include_unknown">Include unknown</string>
+    <string name="filter_length_clear">Clear</string>
     <string name="filter_reading_time_est">Reading Time Est.</string>
     <string name="filter_reading_time_min">Min</string>
     <string name="filter_reading_time_max">Max</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -279,6 +279,7 @@
     <string name="filter_length_dialog_title">Length filters</string>
     <string name="filter_length_summary_none">Any reading time / any word count</string>
     <string name="filter_length_include_unknown">Include unknown</string>
+    <string name="filter_length_unknown">unknown</string>
     <string name="filter_length_clear">Clear</string>
     <string name="filter_reading_time_est">Reading Time Est.</string>
     <string name="filter_reading_time_min">Min</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -275,6 +275,14 @@
     <string name="filter_label">Label</string>
     <string name="filter_from_date">From date</string>
     <string name="filter_to_date">To date</string>
+    <string name="filter_reading_time_est">Reading Time Est.</string>
+    <string name="filter_reading_time_min">Min</string>
+    <string name="filter_reading_time_max">Max</string>
+    <string name="filter_reading_time_null">Null</string>
+    <string name="filter_reading_time_error">Min must be less than or equal to max</string>
+    <string name="filter_reading_time">Read time</string>
+    <string name="filter_word_count_est">Word Count</string>
+    <string name="filter_word_count">Words</string>
     <string name="filter_is_loaded">Is downloaded</string>
     <string name="filtered_list">Filtered List</string>
     <string name="filter_with_labels">With labels</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -275,6 +275,11 @@
     <string name="filter_label">Label</string>
     <string name="filter_from_date">From date</string>
     <string name="filter_to_date">To date</string>
+    <string name="filter_length">Length</string>
+    <string name="filter_length_dialog_title">Length filters</string>
+    <string name="filter_length_summary_none">Any reading time / any word count</string>
+    <string name="filter_length_include_unknown">Include unknown</string>
+    <string name="filter_length_clear">Clear</string>
     <string name="filter_reading_time_est">Reading Time Est.</string>
     <string name="filter_reading_time_min">Min</string>
     <string name="filter_reading_time_max">Max</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -399,6 +399,7 @@
     <string name="filter_length_dialog_title">Length filters</string>
     <string name="filter_length_summary_none">Any reading time / any word count</string>
     <string name="filter_length_include_unknown">Include unknown</string>
+    <string name="filter_length_unknown">unknown</string>
     <string name="filter_length_clear">Clear</string>
     <string name="filter_reading_time_est">Reading Time Est.</string>
     <string name="filter_reading_time_min">Min</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -395,6 +395,14 @@
     <string name="filter_label">Label</string>
     <string name="filter_from_date">From date</string>
     <string name="filter_to_date">To date</string>
+    <string name="filter_reading_time_est">Reading Time Est.</string>
+    <string name="filter_reading_time_min">Min</string>
+    <string name="filter_reading_time_max">Max</string>
+    <string name="filter_reading_time_null">Null</string>
+    <string name="filter_reading_time_error">Min must be less than or equal to max</string>
+    <string name="filter_reading_time">Read time</string>
+    <string name="filter_word_count_est">Word Count</string>
+    <string name="filter_word_count">Words</string>
     <string name="filter_is_loaded">Is downloaded</string>
     <string name="filtered_list">Filtered List</string>
     <string name="filter_with_labels">With labels</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -395,6 +395,11 @@
     <string name="filter_label">Label</string>
     <string name="filter_from_date">From date</string>
     <string name="filter_to_date">To date</string>
+    <string name="filter_length">Length</string>
+    <string name="filter_length_dialog_title">Length filters</string>
+    <string name="filter_length_summary_none">Any reading time / any word count</string>
+    <string name="filter_length_include_unknown">Include unknown</string>
+    <string name="filter_length_clear">Clear</string>
     <string name="filter_reading_time_est">Reading Time Est.</string>
     <string name="filter_reading_time_min">Min</string>
     <string name="filter_reading_time_max">Max</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -602,6 +602,11 @@ other{}
     <string name="filter_label">Label</string>
     <string name="filter_from_date">From date</string>
     <string name="filter_to_date">To date</string>
+    <string name="filter_length">Length</string>
+    <string name="filter_length_dialog_title">Length filters</string>
+    <string name="filter_length_summary_none">Any reading time / any word count</string>
+    <string name="filter_length_include_unknown">Include unknown</string>
+    <string name="filter_length_clear">Clear</string>
     <string name="filter_reading_time_est">Reading Time Est.</string>
     <string name="filter_reading_time_min">Min</string>
     <string name="filter_reading_time_max">Max</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -602,6 +602,14 @@ other{}
     <string name="filter_label">Label</string>
     <string name="filter_from_date">From date</string>
     <string name="filter_to_date">To date</string>
+    <string name="filter_reading_time_est">Reading Time Est.</string>
+    <string name="filter_reading_time_min">Min</string>
+    <string name="filter_reading_time_max">Max</string>
+    <string name="filter_reading_time_null">Null</string>
+    <string name="filter_reading_time_error">Min must be less than or equal to max</string>
+    <string name="filter_reading_time">Read time</string>
+    <string name="filter_word_count_est">Word Count</string>
+    <string name="filter_word_count">Words</string>
     <string name="filter_is_loaded">Is downloaded</string>
     <string name="filtered_list">Filtered List</string>
     <string name="filter_with_labels">With labels</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -606,6 +606,7 @@ other{}
     <string name="filter_length_dialog_title">Length filters</string>
     <string name="filter_length_summary_none">Any reading time / any word count</string>
     <string name="filter_length_include_unknown">Include unknown</string>
+    <string name="filter_length_unknown">unknown</string>
     <string name="filter_length_clear">Clear</string>
     <string name="filter_reading_time_est">Reading Time Est.</string>
     <string name="filter_reading_time_min">Min</string>

--- a/app/src/test/java/com/mydeck/app/io/db/BookmarkDaoTest.kt
+++ b/app/src/test/java/com/mydeck/app/io/db/BookmarkDaoTest.kt
@@ -503,4 +503,232 @@ class BookmarkDaoTest {
             assertTrue(list.none { it.id == "test-29" })
         }
     }
+
+    // Null-checkbox truth table (8 rows from the reading-time-filter spec)
+    @RunWith(RobolectricTestRunner::class)
+    internal class ReadingTimeFilterTest : BaseTest() {
+
+        // Base data: 30 bookmarks, readingTime = 5+index (5..34), all non-null.
+        // We supplement with 3 null-readingTime bookmarks so every truth-table branch is reachable.
+        private val nullIds = listOf("rt-null-0", "rt-null-1", "rt-null-2")
+
+        @Before
+        fun insertNullReadingTimeBookmarks() = runTest {
+            val base = BookmarkEntity(
+                id = "rt-null-0",
+                href = "http://example.com/rtnull",
+                created = kotlinx.datetime.Instant.parse("2025-06-01T00:00:00Z"),
+                updated = kotlinx.datetime.Instant.parse("2025-06-01T00:00:00Z"),
+                state = BookmarkEntity.State.LOADED,
+                loaded = true,
+                url = "http://example.com/rtnull",
+                title = "Null RT Bookmark",
+                siteName = "Example",
+                site = "example.com",
+                authors = emptyList(),
+                lang = "en",
+                textDirection = "ltr",
+                documentTpe = "article",
+                type = BookmarkEntity.Type.ARTICLE,
+                hasArticle = false,
+                description = "",
+                isDeleted = false,
+                isMarked = false,
+                isArchived = false,
+                labels = emptyList(),
+                readProgress = 0,
+                wordCount = null,
+                readingTime = null,
+                published = null,
+                embed = null,
+                embedHostname = null,
+                article = com.mydeck.app.io.db.model.ResourceEntity(""),
+                icon = com.mydeck.app.io.db.model.ImageResourceEntity("", 0, 0),
+                image = com.mydeck.app.io.db.model.ImageResourceEntity("", 0, 0),
+                log = com.mydeck.app.io.db.model.ResourceEntity(""),
+                props = com.mydeck.app.io.db.model.ResourceEntity(""),
+                thumbnail = com.mydeck.app.io.db.model.ImageResourceEntity("", 0, 0),
+            )
+            bookmarkDao.insertBookmarks(nullIds.mapIndexed { i, id -> base.copy(id = id, href = "${base.href}/$i", url = "${base.url}/$i") })
+        }
+
+        // Row 1 — no reading-time filter → all rows returned
+        @Test
+        fun `no reading time filter returns all bookmarks`() = runTest(testDispatcher) {
+            val list = bookmarkDao.getFilteredBookmarkListItems().first()
+            assertEquals(33, list.size)
+        }
+
+        // Row 2 — min=10 max=20 null=false → range only, nulls excluded
+        @Test
+        fun `min and max set null false returns range only`() = runTest(testDispatcher) {
+            val list = bookmarkDao.getFilteredBookmarkListItems(minReadingTime = 10, maxReadingTime = 20).first()
+            // readingTime = 5+index, so 10<=5+index<=20 → 5<=index<=15 → 11 bookmarks
+            assertEquals(11, list.size)
+            assertTrue(list.all { (it.readingTime ?: -1) in 10..20 })
+            assertTrue(list.none { it.id in nullIds })
+        }
+
+        // Row 3 — min=30 only, null=false → lower bound only
+        @Test
+        fun `min only set null false returns bookmarks with readingTime gte min`() = runTest(testDispatcher) {
+            val list = bookmarkDao.getFilteredBookmarkListItems(minReadingTime = 30).first()
+            // 5+index >= 30 → index >= 25 → 5 bookmarks (test-25..test-29)
+            assertEquals(5, list.size)
+            assertTrue(list.all { (it.readingTime ?: -1) >= 30 })
+        }
+
+        // Row 4 — max=7 only, null=false → upper bound only
+        @Test
+        fun `max only set null false returns bookmarks with readingTime lte max`() = runTest(testDispatcher) {
+            val list = bookmarkDao.getFilteredBookmarkListItems(maxReadingTime = 7).first()
+            // 5+index <= 7 → index <= 2 → 3 bookmarks (test-0..test-2)
+            assertEquals(3, list.size)
+            assertTrue(list.all { (it.readingTime ?: Int.MAX_VALUE) <= 7 })
+        }
+
+        // Row 5 — null=true, no min/max → only null-readingTime bookmarks
+        @Test
+        fun `null only returns only null reading time bookmarks`() = runTest(testDispatcher) {
+            val list = bookmarkDao.getFilteredBookmarkListItems(includeNullReadingTime = true).first()
+            assertEquals(3, list.size)
+            assertTrue(list.all { it.id in nullIds })
+        }
+
+        // Row 6 — min=10 max=20 null=true → range OR null
+        @Test
+        fun `min and max set null true returns range plus null bookmarks`() = runTest(testDispatcher) {
+            val list = bookmarkDao.getFilteredBookmarkListItems(minReadingTime = 10, maxReadingTime = 20, includeNullReadingTime = true).first()
+            assertEquals(14, list.size) // 11 in range + 3 null
+            assertTrue(list.filter { it.id !in nullIds }.all { (it.readingTime ?: -1) in 10..20 })
+            assertTrue(list.filter { it.id in nullIds }.all { it.readingTime == null })
+        }
+
+        // Row 7 — min=30 null=true → readingTime >= 30 OR null
+        @Test
+        fun `min only set null true returns gte min plus null bookmarks`() = runTest(testDispatcher) {
+            val list = bookmarkDao.getFilteredBookmarkListItems(minReadingTime = 30, includeNullReadingTime = true).first()
+            assertEquals(8, list.size) // 5 in range + 3 null
+        }
+
+        // Row 8 — max=7 null=true → readingTime <= 7 OR null
+        @Test
+        fun `max only set null true returns lte max plus null bookmarks`() = runTest(testDispatcher) {
+            val list = bookmarkDao.getFilteredBookmarkListItems(maxReadingTime = 7, includeNullReadingTime = true).first()
+            assertEquals(6, list.size) // 3 in range + 3 null
+        }
+    }
+
+    // Word-count null-checkbox truth table — mirrors the reading-time filter spec
+    @RunWith(RobolectricTestRunner::class)
+    internal class WordCountFilterTest : BaseTest() {
+
+        // Base data: 30 bookmarks, wordCount = 100 + index*10 (100..390), all non-null.
+        // Supplement with 3 null-wordCount bookmarks.
+        private val nullIds = listOf("wc-null-0", "wc-null-1", "wc-null-2")
+
+        @Before
+        fun insertNullWordCountBookmarks() = runTest {
+            val base = BookmarkEntity(
+                id = "wc-null-0",
+                href = "http://example.com/wcnull",
+                created = kotlinx.datetime.Instant.parse("2025-07-01T00:00:00Z"),
+                updated = kotlinx.datetime.Instant.parse("2025-07-01T00:00:00Z"),
+                state = BookmarkEntity.State.LOADED,
+                loaded = true,
+                url = "http://example.com/wcnull",
+                title = "Null WC Bookmark",
+                siteName = "Example",
+                site = "example.com",
+                authors = emptyList(),
+                lang = "en",
+                textDirection = "ltr",
+                documentTpe = "article",
+                type = BookmarkEntity.Type.ARTICLE,
+                hasArticle = false,
+                description = "",
+                isDeleted = false,
+                isMarked = false,
+                isArchived = false,
+                labels = emptyList(),
+                readProgress = 0,
+                wordCount = null,
+                readingTime = 5,
+                published = null,
+                embed = null,
+                embedHostname = null,
+                article = com.mydeck.app.io.db.model.ResourceEntity(""),
+                icon = com.mydeck.app.io.db.model.ImageResourceEntity("", 0, 0),
+                image = com.mydeck.app.io.db.model.ImageResourceEntity("", 0, 0),
+                log = com.mydeck.app.io.db.model.ResourceEntity(""),
+                props = com.mydeck.app.io.db.model.ResourceEntity(""),
+                thumbnail = com.mydeck.app.io.db.model.ImageResourceEntity("", 0, 0),
+            )
+            bookmarkDao.insertBookmarks(nullIds.mapIndexed { i, id -> base.copy(id = id, href = "${base.href}/$i", url = "${base.url}/$i") })
+        }
+
+        // Row 1 — no word-count filter → all rows returned
+        @Test
+        fun `no word count filter returns all bookmarks`() = runTest(testDispatcher) {
+            val list = bookmarkDao.getFilteredBookmarkListItems().first()
+            assertEquals(33, list.size)
+        }
+
+        // Row 2 — min=200 max=300 null=false → range only, nulls excluded
+        @Test
+        fun `min and max set null false returns range only`() = runTest(testDispatcher) {
+            val list = bookmarkDao.getFilteredBookmarkListItems(minWordCount = 200, maxWordCount = 300).first()
+            // wordCount = 100+index*10; 200<=100+index*10<=300 → 10<=index<=20 → 11 bookmarks
+            assertEquals(11, list.size)
+            assertTrue(list.all { (it.wordCount ?: -1) in 200..300 })
+            assertTrue(list.none { it.id in nullIds })
+        }
+
+        // Row 3 — min=300 only, null=false → lower bound only
+        @Test
+        fun `min only set null false returns bookmarks with wordCount gte min`() = runTest(testDispatcher) {
+            val list = bookmarkDao.getFilteredBookmarkListItems(minWordCount = 300).first()
+            // 100+index*10 >= 300 → index >= 20 → 10 bookmarks (test-20..test-29)
+            assertEquals(10, list.size)
+            assertTrue(list.all { (it.wordCount ?: -1) >= 300 })
+        }
+
+        // Row 4 — max=150 only, null=false → upper bound only
+        @Test
+        fun `max only set null false returns bookmarks with wordCount lte max`() = runTest(testDispatcher) {
+            val list = bookmarkDao.getFilteredBookmarkListItems(maxWordCount = 150).first()
+            // 100+index*10 <= 150 → index <= 5 → 6 bookmarks
+            assertEquals(6, list.size)
+            assertTrue(list.all { (it.wordCount ?: Int.MAX_VALUE) <= 150 })
+        }
+
+        // Row 5 — null=true, no min/max → only null-wordCount bookmarks
+        @Test
+        fun `null only returns only null word count bookmarks`() = runTest(testDispatcher) {
+            val list = bookmarkDao.getFilteredBookmarkListItems(includeNullWordCount = true).first()
+            assertEquals(3, list.size)
+            assertTrue(list.all { it.id in nullIds })
+        }
+
+        // Row 6 — min=200 max=300 null=true → range OR null
+        @Test
+        fun `min and max set null true returns range plus null bookmarks`() = runTest(testDispatcher) {
+            val list = bookmarkDao.getFilteredBookmarkListItems(minWordCount = 200, maxWordCount = 300, includeNullWordCount = true).first()
+            assertEquals(14, list.size) // 11 in range + 3 null
+        }
+
+        // Row 7 — min=300 null=true → wordCount >= 300 OR null
+        @Test
+        fun `min only set null true returns gte min plus null bookmarks`() = runTest(testDispatcher) {
+            val list = bookmarkDao.getFilteredBookmarkListItems(minWordCount = 300, includeNullWordCount = true).first()
+            assertEquals(13, list.size) // 10 in range + 3 null
+        }
+
+        // Row 8 — max=150 null=true → wordCount <= 150 OR null
+        @Test
+        fun `max only set null true returns lte max plus null bookmarks`() = runTest(testDispatcher) {
+            val list = bookmarkDao.getFilteredBookmarkListItems(maxWordCount = 150, includeNullWordCount = true).first()
+            assertEquals(9, list.size) // 6 in range + 3 null
+        }
+    }
 }

--- a/app/src/test/java/com/mydeck/app/ui/list/BookmarkListViewModelTest.kt
+++ b/app/src/test/java/com/mydeck/app/ui/list/BookmarkListViewModelTest.kt
@@ -114,7 +114,7 @@ class BookmarkListViewModelTest {
         coEvery { settingsDataStore.isSyncOnAppOpenEnabled() } returns false // Disable sync on app open by default
         every { fullSyncUseCase.performFullSync() } returns Unit
         // Use any() for all arguments to be safe, then specialize
-        every { bookmarkRepository.observeFilteredBookmarkListItems(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns flowOf(emptyList())
+        every { bookmarkRepository.observeFilteredBookmarkListItems(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns flowOf(emptyList())
 
         every { savedStateHandle.get<String>(any()) } returns null // no sharedUrl initially
         every { workManager.getWorkInfosForUniqueWorkFlow(any()) } returns workInfoFlow
@@ -482,6 +482,12 @@ class BookmarkListViewModelTest {
                 isLoaded = any(),
                 withLabels = any(),
                 withErrors = any(),
+                minReadingTime = any(),
+                maxReadingTime = any(),
+                includeNullReadingTime = any(),
+                minWordCount = any(),
+                maxWordCount = any(),
+                includeNullWordCount = any(),
                 orderBy = any()
             )
         } returns bookmarkFlow
@@ -765,7 +771,7 @@ class BookmarkListViewModelTest {
 
             val bookmarkFlow = MutableStateFlow(bookmarks)
             every {
-                bookmarkRepository.observeFilteredBookmarkListItems(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+                bookmarkRepository.observeFilteredBookmarkListItems(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
             } returns bookmarkFlow
 
             coEvery {
@@ -836,7 +842,7 @@ class BookmarkListViewModelTest {
 
             val bookmarkFlow = MutableStateFlow(bookmarks)
             every {
-                bookmarkRepository.observeFilteredBookmarkListItems(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+                bookmarkRepository.observeFilteredBookmarkListItems(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
             } returns bookmarkFlow
 
             viewModel = BookmarkListViewModel(
@@ -893,7 +899,7 @@ class BookmarkListViewModelTest {
 
             val bookmarkFlow = MutableStateFlow(bookmarks)
             every {
-                bookmarkRepository.observeFilteredBookmarkListItems(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+                bookmarkRepository.observeFilteredBookmarkListItems(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
             } returns bookmarkFlow
 
             coEvery {
@@ -956,7 +962,7 @@ class BookmarkListViewModelTest {
 
             val bookmarkFlow = MutableStateFlow(bookmarks)
             every {
-                bookmarkRepository.observeFilteredBookmarkListItems(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+                bookmarkRepository.observeFilteredBookmarkListItems(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
             } returns bookmarkFlow
 
             coEvery {
@@ -1027,7 +1033,7 @@ class BookmarkListViewModelTest {
 
             val bookmarkFlow = MutableStateFlow(bookmarks)
             every {
-                bookmarkRepository.observeFilteredBookmarkListItems(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+                bookmarkRepository.observeFilteredBookmarkListItems(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
             } returns bookmarkFlow
 
             viewModel = BookmarkListViewModel(
@@ -1084,7 +1090,7 @@ class BookmarkListViewModelTest {
 
             val bookmarkFlow = MutableStateFlow(bookmarks)
             every {
-                bookmarkRepository.observeFilteredBookmarkListItems(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+                bookmarkRepository.observeFilteredBookmarkListItems(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
             } returns bookmarkFlow
 
             coEvery {
@@ -1148,7 +1154,7 @@ class BookmarkListViewModelTest {
 
             val bookmarkFlow = MutableStateFlow(bookmarks)
             every {
-                bookmarkRepository.observeFilteredBookmarkListItems(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+                bookmarkRepository.observeFilteredBookmarkListItems(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
             } returns bookmarkFlow
 
             coEvery {
@@ -1219,7 +1225,7 @@ class BookmarkListViewModelTest {
 
             val bookmarkFlow = MutableStateFlow(bookmarks)
             every {
-                bookmarkRepository.observeFilteredBookmarkListItems(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+                bookmarkRepository.observeFilteredBookmarkListItems(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
             } returns bookmarkFlow
 
             viewModel = BookmarkListViewModel(
@@ -1276,7 +1282,7 @@ class BookmarkListViewModelTest {
 
             val bookmarkFlow = MutableStateFlow(bookmarks)
             every {
-                bookmarkRepository.observeFilteredBookmarkListItems(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+                bookmarkRepository.observeFilteredBookmarkListItems(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
             } returns bookmarkFlow
 
             coEvery {
@@ -1333,7 +1339,7 @@ class BookmarkListViewModelTest {
     @Test
     fun `onClickLabel updates activeLabel with selected label`() = runTest {
         coEvery { settingsDataStore.isInitialSyncPerformed() } returns false
-        every { bookmarkRepository.observeFilteredBookmarkListItems(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns flowOf(bookmarks)
+        every { bookmarkRepository.observeFilteredBookmarkListItems(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns flowOf(bookmarks)
 
         viewModel = BookmarkListViewModel(
             updateBookmarkUseCase,
@@ -1358,7 +1364,7 @@ class BookmarkListViewModelTest {
     @Test
     fun `onRenameLabel calls repository and updates activeLabel if label was active`() = runTest {
         coEvery { settingsDataStore.isInitialSyncPerformed() } returns false
-        every { bookmarkRepository.observeFilteredBookmarkListItems(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns flowOf(bookmarks)
+        every { bookmarkRepository.observeFilteredBookmarkListItems(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns flowOf(bookmarks)
         coEvery { bookmarkRepository.renameLabel(any(), any()) } returns BookmarkRepository.UpdateResult.Success
 
         viewModel = BookmarkListViewModel(
@@ -1392,7 +1398,7 @@ class BookmarkListViewModelTest {
     @Test
     fun `onLayoutModeSelected persists to settings and updates flow`() = runTest {
         coEvery { settingsDataStore.isInitialSyncPerformed() } returns false
-        every { bookmarkRepository.observeFilteredBookmarkListItems(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns flowOf(bookmarks)
+        every { bookmarkRepository.observeFilteredBookmarkListItems(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns flowOf(bookmarks)
         coEvery { settingsDataStore.saveLayoutMode(any()) } returns Unit
 
         viewModel = BookmarkListViewModel(
@@ -1420,7 +1426,7 @@ class BookmarkListViewModelTest {
     @Test
     fun `onSortOptionSelected persists to settings and updates flow`() = runTest {
         coEvery { settingsDataStore.isInitialSyncPerformed() } returns false
-        every { bookmarkRepository.observeFilteredBookmarkListItems(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns flowOf(bookmarks)
+        every { bookmarkRepository.observeFilteredBookmarkListItems(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns flowOf(bookmarks)
         coEvery { settingsDataStore.saveSortOption(any()) } returns Unit
 
         viewModel = BookmarkListViewModel(

--- a/docs/specs/reading-time-filter-spec.md
+++ b/docs/specs/reading-time-filter-spec.md
@@ -1,56 +1,149 @@
-# Reading Time Filter — Spec
+# Length Filters — Reading Time & Word Count
 
 ## Overview
 
-Add a reading time range filter to the Filter bottom sheet. Users can specify a minimum and/or maximum reading time in minutes, optionally including bookmarks that have no reading time estimate. The filter is applied locally against the `readingTime` column already stored in the Room database.
+Adds two local filters to the bookmark list:
+
+- **Reading time** — the per-bookmark `readingTime` estimate (minutes) from Readeck.
+- **Word count** — the per-bookmark `wordCount` value from Readeck.
+
+Each filter accepts a **Min** and/or **Max** integer bound and an **Include unknown** option that captures bookmarks where the field is `NULL` (typical for very short articles, videos, and pictures — Readeck does not estimate reading time for sub-minute content). Filtering is applied locally against the Room database; no parameter is sent to the Readeck server (consistent with other filters except the initial search field).
+
+Both filters share a single UI surface — a **Length** picker on the filter sheet that opens an `AlertDialog`. This consolidation keeps the bottom sheet uncluttered and sidesteps a Material3 `ModalBottomSheet` IME-handling quirk (see *Implementation Notes* at the bottom).
 
 ---
 
 ## UI — Filter Bottom Sheet
 
-### Placement
+### Length Picker
 
-Insert the new row immediately after the existing From Date / To Date row and before the Type chips section. The visual structure mirrors the date row: an external section label above a single `Row`.
+A single read-only `OutlinedTextField` placed immediately after the From Date / To Date row and before the Type chips section. Visual idiom mirrors the existing Date and Label pickers in this sheet:
+
+| Element | Treatment |
+|---|---|
+| **Label** | `"Length"` |
+| **Value** (empty state) | `value = ""` + `placeholder = "Any reading time / any word count"` (muted `onSurfaceVariant`) |
+| **Value** (active state) | Summary string built from the two range filters (see *Summary String* below) |
+| **Trailing icon** (active state only) | `Icons.Filled.Clear` (X) — one tap clears all six values without opening the dialog |
+| **Modifier** | `enabled = false` + `pickerColors` so the field reads as enabled, and `Modifier.clickable { showLengthFilterDialog = true }` |
+
+#### Summary String
+
+The picker value is built from the dialog's six current values:
 
 ```
-Reading Time Est.
-┌──────────┐  ┌──────────┐  ☐ Null
-│   Min    │  │   Max    │
-└──────────┘  └──────────┘
-Min must be less than or equal to max   ← shown only on error
+Read time: ≥{min} min            // min only
+Read time: ≤{max} min            // max only
+Read time: {min}–{max} min       // min + max
+Read time: unknown               // include unknown only
+Read time: {range} + unknown     // range + include unknown
 ```
 
-### Section Label
+Same format for word count, prefix `Words:`, no unit suffix:
 
-`Text("Reading Time Est.", style = MaterialTheme.typography.labelLarge)`
+```
+Words: ≥{min}
+Words: 100–500
+Words: 100–500 + unknown
+```
 
-Preceded by `Spacer(12.dp)` (matching the spacer used between the date row and Type section, which is currently `16.dp` — adjust the split to `12.dp` above the label and `8.dp` below, consistent with the Type/Progress sections).
+When both filters are active the parts are joined with ` / `, e.g.:
 
-### Row Layout
+```
+Read time: 5–15 min / Words: ≥500
+```
 
-A single `Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp))`:
+When no length filter is active, the summary is `null` and the placeholder text is shown instead.
 
-| Element | Weight / Size | Notes |
-|---|---|---|
-| **Min** `OutlinedTextField` | `weight(1f)` | `label = "Min"`, `keyboardType = Number`, `imeAction = Next`, digits only, no negatives |
-| **Max** `OutlinedTextField` | `weight(1f)` | `label = "Max"`, `keyboardType = Number`, `imeAction = Search` → triggers apply |
-| **Null** checkbox + label | fixed, `wrapContentWidth` | `Checkbox` + `Text("Null")` in a nested `Row(verticalAlignment = CenterVertically)` |
+### Length Filter Dialog
 
-Both text fields accept integers ≥ 0 with no enforced upper bound. Empty string means "not set" (treated as `null`).
+Tapping the Length picker opens an `AlertDialog` with the following structure:
 
-### Validation
+```
+┌──────────────────────────────────────┐
+│ Length filters                       │
+│                                      │
+│ Reading Time Est.                    │
+│ ┌──────┐ ┌──────┐                    │
+│ │ Min  │ │ Max  │                    │
+│ └──────┘ └──────┘                    │
+│ ☐ Include unknown                    │
+│ Min must be less than or equal to max│ ← shown only on error
+│                                      │
+│ Word Count                           │
+│ ┌──────┐ ┌──────┐                    │
+│ │ Min  │ │ Max  │                    │
+│ └──────┘ └──────┘                    │
+│ ☐ Include unknown                    │
+│                                      │
+│ Clear                                │ ← disabled when nothing to clear
+│                                      │
+│            [ Cancel ]  [ OK ]        │
+└──────────────────────────────────────┘
+```
 
-Evaluated whenever either numeric field changes:
+#### Dialog Structure
 
-- **Error condition:** both Min and Max are non-empty and `min.toInt() > max.toInt()`
-- **Effect:** error text `"Min must be less than or equal to max"` appears below the row in `MaterialTheme.colorScheme.error` / `typography.bodySmall`; the **Search** button is disabled
-- **No error:** one or both fields empty, or `min <= max`
+- `title`: `"Length filters"`.
+- `text`: A scrollable `Column(verticalArrangement = Arrangement.spacedBy(16.dp))` containing:
+  1. Reading Time `LengthRangeSection`.
+  2. Word Count `LengthRangeSection`.
+  3. `TextButton(onClick = clearDialog, enabled = hasAnyValue, modifier = Modifier.align(Alignment.Start))` labelled `"Clear"`.
+- `confirmButton`: `TextButton` labelled `"OK"`, `enabled = !hasValidationError`. Calls `onApply(...)` with the six current values.
+- `dismissButton`: `TextButton` labelled `"Cancel"`. Calls `onDismiss`.
+- `modifier = Modifier.imePadding()` so the dialog content respects the IME inset.
 
-### Null Checkbox Behavior
+#### `LengthRangeSection`
 
-| Min | Max | Null checked | SQL effect |
+Each section is a private composable rendering:
+
+- Section title (`labelLarge`, e.g. `"Reading Time Est."` / `"Word Count"`).
+- Row with two `OutlinedTextField`s (`Modifier.weight(1f)` each):
+  - `keyboardType = KeyboardType.Number`, digits-only filter on `onValueChange`.
+  - **Min** field: `imeAction = ImeAction.Next`.
+  - **Max** field: `imeAction = ImeAction.Next` (Reading Time, focus moves to Word Count) or `ImeAction.Done` (Word Count, triggers apply via `onDone`).
+  - `isError = hasError` (this section's error flag only).
+  - Each field gets a `Modifier.bringFocusedFieldIntoView()` modifier — a `BringIntoViewRequester` driven by an `onFocusEvent` listener that calls `bringIntoView()` after a `FOCUSED_FIELD_BRING_INTO_VIEW_DELAY_MS` (250 ms) delay, allowing the IME animation to complete before scroll.
+- Toggleable row containing the **Include unknown** Checkbox + label:
+  ```kotlin
+  Row(
+      verticalAlignment = Alignment.CenterVertically,
+      modifier = Modifier
+          .fillMaxWidth()
+          .toggleable(value = includeNull, onValueChange = onIncludeNullChange, role = Role.Checkbox)
+  ) {
+      Checkbox(checked = includeNull, onCheckedChange = null)
+      Text(stringResource(R.string.filter_length_include_unknown))
+  }
+  ```
+  The whole row toggles the checkbox; screen readers announce a single checkbox control.
+- Error text below the row when the section is invalid:
+  ```
+  Min must be less than or equal to max
+  ```
+
+#### Validation
+
+Per section, evaluated whenever Min or Max changes:
+
+- **Error condition:** both Min and Max are non-empty *and* `min.toInt() > max.toInt()`.
+- **Effect:** error text appears in `MaterialTheme.colorScheme.error` / `typography.bodySmall`; the section's `OutlinedTextField`s show `isError = true`; the dialog's **OK** button is disabled (gate is `readingTimeError || wordCountError`).
+- **No error:** one or both fields empty, or `min <= max`.
+
+#### Clear / Reset Behavior
+
+The dialog has its own **Clear** button (resets only the six length values inside the dialog without dismissing). Outside the dialog, two other resets exist:
+
+- The Length picker's trailing **X** icon — clears all six values immediately, without opening the dialog.
+- The filter sheet's bottom **Reset** button — clears all filters in the sheet (length included).
+
+#### Truth Table — `Include unknown`
+
+The same truth table applies independently to Reading Time and Word Count. Listed here for the `readingTime` column; word count is identical with `wordCount` substituted.
+
+| Min | Max | Include unknown | SQL effect |
 |---|---|---|---|
-| — | — | false | No reading time filter |
+| — | — | false | No filter |
 | set | set | false | `b.readingTime BETWEEN min AND max` |
 | set | — | false | `b.readingTime >= min` |
 | — | set | false | `b.readingTime <= max` |
@@ -59,66 +152,79 @@ Evaluated whenever either numeric field changes:
 | set | — | true | `(b.readingTime >= min OR b.readingTime IS NULL)` |
 | — | set | true | `(b.readingTime <= max OR b.readingTime IS NULL)` |
 
-Bookmarks with `readingTime IS NULL` are excluded from range results unless the Null checkbox is checked.
-
-### Clear / Reset Behavior
-
-- Tapping the existing **Reset** button clears all three fields (Min, Max, Null checkbox) along with all other filters.
-- There is no per-field clear icon on the numeric fields (they are free-text and easily cleared by the user). The Null checkbox unchecks to clear itself.
+Bookmarks with `IS NULL` are excluded from range results unless **Include unknown** is checked.
 
 ---
 
 ## UI — Filter Bar (active filter chips)
 
-A single chip is emitted for the reading time filter whenever any of the three values is active. The chip label is built as follows:
+Two independent chips are emitted — one for reading time, one for word count — whenever any of that filter's three values is active. Each chip can be dismissed without affecting the other filter.
+
+### Reading time chip
 
 | State | Chip label |
 |---|---|
 | Min only | `Read time: ≥{min} min` |
 | Max only | `Read time: ≤{max} min` |
 | Min + Max | `Read time: {min}–{max} min` |
-| Null only | `Read time: Null` |
-| Range + Null | `Read time: {min}–{max} min + Null` |
-| Min + Null (no max) | `Read time: ≥{min} min + Null` |
-| Max + Null (no min) | `Read time: ≤{max} min + Null` |
+| Include unknown only | `Read time: unknown` |
+| Range + unknown | `Read time: {range} + unknown` |
 
-Dismissing the chip clears all three values (`minReadingTime = null`, `maxReadingTime = null`, `includeNullReadingTime = false`).
+Dismissing clears `minReadingTime`, `maxReadingTime`, `includeNullReadingTime`.
+
+### Word count chip
+
+Same format, prefix `Words:`, no unit suffix:
+
+| State | Chip label |
+|---|---|
+| Min + Max | `Words: {min}–{max}` |
+| Range + unknown | `Words: {range} + unknown` |
+
+Dismissing clears `minWordCount`, `maxWordCount`, `includeNullWordCount`.
 
 ---
 
 ## Model — `FilterFormState`
 
-Add three fields:
+Add six fields:
 
 ```kotlin
 val minReadingTime: Int? = null,
 val maxReadingTime: Int? = null,
 val includeNullReadingTime: Boolean = false,
+val minWordCount: Int? = null,
+val maxWordCount: Int? = null,
+val includeNullWordCount: Boolean = false,
 ```
 
 Update `hasActiveFilters()`:
 
 ```kotlin
 minReadingTime != null || maxReadingTime != null || includeNullReadingTime ||
+minWordCount != null || maxWordCount != null || includeNullWordCount
 ```
 
-No change needed to `fromPreset()` — all three default to "inactive".
+No change to `fromPreset()` — all six default to inactive.
 
 ---
 
 ## Data Layer — `BookmarkDao`
 
-### `getBookmarkListItemsByFilters`
+The SQL clause is applied at three call sites for parity: `getFilteredBookmarkListItems` (primary path used by the ViewModel), `getBookmarkListItemsByFilters`, and `getBookmarksByFilters`.
 
-Add parameters:
+Add six parameters to each function:
 
 ```kotlin
 minReadingTime: Int? = null,
 maxReadingTime: Int? = null,
 includeNullReadingTime: Boolean = false,
+minWordCount: Int? = null,
+maxWordCount: Int? = null,
+includeNullWordCount: Boolean = false,
 ```
 
-Append to the dynamic query builder after the existing `label` clause:
+Append two parallel clauses to each dynamic query builder (after existing clauses, before `ORDER BY`). The pattern below shows the reading-time clause for the `b.readingTime` aliased query; the word-count clause is the same with `wordCount` substituted, and the simpler `getBookmarksByFilters` query uses the unaliased column name (`readingTime` / `wordCount`):
 
 ```kotlin
 val hasRange = minReadingTime != null || maxReadingTime != null
@@ -138,13 +244,11 @@ if (hasRange || includeNullReadingTime) {
 }
 ```
 
-Apply the same pattern to `getBookmarksByFilters` (the `BookmarkEntity` variant used by other callers) for consistency.
-
 ---
 
 ## Data Layer — `BookmarkRepositoryImpl`
 
-Add the three parameters to `observeBookmarkListItems(...)` and thread them through to the DAO call.
+Add the six parameters to both `observeBookmarkListItems(...)` and `observeFilteredBookmarkListItems(...)` and thread them through to the DAO calls. The `BookmarkListViewModel` passes them in directly from `FilterFormState`.
 
 ---
 
@@ -153,12 +257,25 @@ Add the three parameters to `observeBookmarkListItems(...)` and thread them thro
 Add to `app/src/main/res/values/strings.xml` and all nine language files (English placeholder in each):
 
 ```xml
+<!-- Length picker + dialog -->
+<string name="filter_length">Length</string>
+<string name="filter_length_dialog_title">Length filters</string>
+<string name="filter_length_summary_none">Any reading time / any word count</string>
+<string name="filter_length_include_unknown">Include unknown</string>
+<string name="filter_length_unknown">unknown</string>
+<string name="filter_length_clear">Clear</string>
+
+<!-- Reading time section + chip -->
 <string name="filter_reading_time_est">Reading Time Est.</string>
 <string name="filter_reading_time_min">Min</string>
 <string name="filter_reading_time_max">Max</string>
-<string name="filter_reading_time_null">Null</string>
+<string name="filter_reading_time_null">Null</string>          <!-- retained, no longer surfaced in UI -->
 <string name="filter_reading_time_error">Min must be less than or equal to max</string>
 <string name="filter_reading_time">Read time</string>
+
+<!-- Word count section + chip -->
+<string name="filter_word_count_est">Word Count</string>
+<string name="filter_word_count">Words</string>
 ```
 
 Language files to update:
@@ -168,16 +285,37 @@ Language files to update:
 
 ## User Guide
 
-Update `app/src/main/assets/guide/en/your-bookmarks.md` to document the new filter under the Filter section. Describe:
+`app/src/main/assets/guide/en/your-bookmarks.md` documents a **Length** section under Filter, describing the picker, the dialog, the Min / Max / Include unknown semantics, and chip dismissal behavior.
 
-- The Min / Max fields accept whole numbers (minutes); either or both may be left blank
-- Checking Null includes bookmarks that have no reading time estimate; checking Null with both fields blank returns only those bookmarks
-- The filter chip in the bar shows the active range and dismisses all three values when tapped
+---
+
+## Implementation Notes
+
+### Why a dialog instead of inline rows in the sheet
+
+The first attempt placed the Min/Max fields directly in the bottom sheet (one row each for Reading Time and Word Count). That ran into a Material3 `ModalBottomSheet` behavior where the sheet auto-collapses to its `PartiallyExpanded` anchor when the IME opens for a low-positioned field — leaving the field hidden under the keyboard. Each workaround had a trade-off:
+
+| Workaround | Problem |
+|---|---|
+| `skipPartiallyExpanded = true` | Sheet opens fully expanded; drag handle becomes hard to notice. |
+| `confirmValueChange` to lock `PartiallyExpanded` | Visible "drop then re-expand" flash because the anchor recompute happens before the override can fire. |
+| Explicit `sheetState.expand()` on focus | Same flash — `expand()` animates ~300ms, the partial-anchor snap happens earlier. |
+| `sheetState.snapTo(Expanded)` | `snapTo` is `internal` in Material3 BOM 2025.04.01; not callable. |
+
+Hoisting the editing UI into an `AlertDialog` dissolves the problem entirely: the dialog hosts its own `Window` with native soft-input handling, the bottom sheet keeps its partial-anchor opening (drag handle visible), and the Length picker is the same idiom as the existing Date and Label pickers in this sheet.
+
+### Why "unknown" rather than "null"
+
+`null` is precise but technical. End-users see bookmarks without a reading-time estimate or word count as "unknown" or "missing" — "Include unknown" reads naturally without explaining what null means. The internal API still uses `includeNull*` for the boolean.
+
+### Chip independence
+
+The two chips are independent so a user can clear "Read time: 5–15 min" without losing "Words: ≥500" — useful when iterating on a search. The dialog itself edits both at once because they're conceptually peer "length" measures.
 
 ---
 
 ## Out of Scope
 
-- No server-side filter parameter is sent to Readeck; filtering is local only (consistent with all other filters except the initial search field).
-- No change to sort options — duration sort already exists.
-- Tablet layout requires no special treatment; the row will reflow the same as the date row on wider screens.
+- No server-side filter parameter is sent to Readeck; filtering is local only.
+- No new sort option — sort-by-duration already exists.
+- Tablet/landscape layout — both the picker (full-width OutlinedTextField) and the dialog reflow naturally.


### PR DESCRIPTION
## Summary

Adds two new local filters to the bookmark list — **reading time** (minutes) and **word count** — with Min / Max range fields plus an "Include unknown" option that captures bookmarks where Readeck didn't produce an estimate (typical for very short articles, videos, and pictures). Both filters share a single read-only **Length** picker on the filter sheet that opens an `AlertDialog`, keeping the main sheet uncluttered.

Targeted for the v0.13.2 patch release. Implements `docs/specs/reading-time-filter-spec.md` (reading time) and extends it with parallel word count support per follow-on user request.

Closes #163 

## What changed

### Model + data layer
- `FilterFormState`: six new fields — `minReadingTime`, `maxReadingTime`, `includeNullReadingTime`, `minWordCount`, `maxWordCount`, `includeNullWordCount`.
- `BookmarkDao`: range + IS NULL SQL clauses appended to all three dynamic-query functions (`getFilteredBookmarkListItems`, `getBookmarkListItemsByFilters`, `getBookmarksByFilters`). Implements the full Null-checkbox truth table per spec via `AND (range OR column IS NULL)`.
- `BookmarkRepository` / `Impl` + `BookmarkListViewModel`: parameters threaded through to the DAO.

### UI — Length picker + dialog
- The filter sheet gets a single read-only **Length** field that mirrors the Date / Label picker idiom: muted placeholder when empty (`"Any reading time / any word count"`), summary value when active (`Read time: ≥5 min / Words: 100–500`), trailing **X** to clear all six values without opening the dialog.
- Tapping the picker opens an `AlertDialog` with two range sections (Reading Time, Word Count), each with Min / Max / **Include unknown**.
- Validation lives in the dialog: error text under the offending section, **OK** disabled when `min > max`.
- Dialog action row is the standard M3 `[Cancel] [OK]`; **Clear** is a tertiary left-aligned `TextButton` inside the dialog body, disabled when there's nothing to clear.
- "Include unknown" rows use `Modifier.toggleable(role = Checkbox)` so the whole row toggles and announces as a single checkbox control.
- Within-dialog `BringIntoViewRequester` + post-IME delay keeps focused fields above the keyboard.

### Filter bar chips
- Independent chip per filter (`Read time: …`, `Words: …`); dismissing one clears that filter's three values without affecting the other.
- Chip labels: `≥N`, `≤N`, `N–M`, optionally `+ unknown` — matches the dialog's terminology.

### Why the dialog rather than in-sheet rows
First attempt put the Min/Max fields directly in the bottom sheet. That ran into `ModalBottomSheet`'s auto-collapse on focus / IME insets — the sheet would snap to its partial anchor when a low field took focus, leaving the field under the keyboard. Workarounds (`skipPartiallyExpanded`, `confirmValueChange`, focus-driven `expand()`) each had visual flashes or UX regressions. Moving the editing surface into an `AlertDialog` dissolves the problem (Dialog hosts its own Window with native IME handling) and lets the bottom sheet stay at its partial anchor with the drag handle visible — better discoverability too.

### Strings + guide
- 8 new strings added in English and propagated to all 9 locale files (de, es, fr, gl, pl, pt, ru, uk, zh-CN) as English placeholders per CLAUDE.md localization rule.
- User guide section under Filter documents the Length picker, dialog, "Include unknown" semantics, and chip dismissal.

### Tests
- `BookmarkDaoTest.ReadingTimeFilterTest`: 8 tests covering every row of the Null-checkbox truth table.
- `BookmarkDaoTest.WordCountFilterTest`: 8 parallel tests for word count.
- `BookmarkListViewModelTest`: mock signatures bumped to match the new repository parameter count.
- `FilterBottomSheetValidationTest`: instrumentation tests for the dialog's error state (Min > Max → error text + OK disabled; clearing one field restores OK).
