### PR TITLE
fix(ci): attach snapshot APK to latest-snapshot release

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -183,5 +183,5 @@ jobs:
           tag: latest-snapshot
           removeArtifacts: true
           omitDraftDuringUpdate: true
-          artifacts: "./artifacts/*.apk,./artifacts/checksums.txt"
+          artifacts: "./artifacts/**/*.apk,./artifacts/checksums.txt"
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

The moving `latest-snapshot` GitHub Release has been silently APK-less. Only `checksums.txt` was being attached. The build job's workflow artifact has always contained the APK, so this only affected the published Release; PR-mode artifacts are unaffected.

## Root cause

`actions/upload-artifact@v4` picks the least common ancestor of all `path:` entries as the artifact root ([docs](https://github.com/actions/upload-artifact?tab=readme-ov-file#upload-using-multiple-paths-and-exclusions)). The snapshot upload step passes two paths:

- `app/build/outputs/apk/githubSnapshot/release/MyDeck-<ts>-<sha>.apk`
- `checksums.txt`

LCA is the workspace root, so the artifact zip preserves the APK at its full nested path. The publish job downloads into `./artifacts/`, and the APK ends up at `./artifacts/app/build/outputs/apk/githubSnapshot/release/MyDeck-….apk`. The release step's `artifacts:` glob was `./artifacts/*.apk` (shallow), which matched nothing — `checksums.txt` at `./artifacts/checksums.txt` did match.

The action even logs this:

> `##[warning]Artifact pattern :./artifacts/*.apk did not match any files`

Pre-existing bug; same warning appears on every `latest-snapshot` publish run going back to at least PR #127. `removeArtifacts: true` cleared old assets each run, so the missing APK never accumulated visibly — it just kept re-publishing nothing.

## Fix

One-line change: switch the glob to recursive (`./artifacts/**/*.apk`) so the APK is picked up regardless of how `upload-artifact` lays out the zip. `ncipollo/release-action` uses `@actions/glob` which supports `**`.

An alternative was to stage the APK and checksums into a flat directory before upload. Rejected as more change for the same outcome.

## Test plan

- [ ] After merge, watch the resulting `main`-push Actions run. The `Publish to GitHub Releases` step should no longer log `Artifact pattern … did not match any files`.
- [ ] On the `latest-snapshot` release page, confirm the APK asset is attached alongside `checksums.txt`.
- [ ] Download the APK and confirm it installs on a test device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)