### PR TITLE
ci: phase 3 — release RC handling + SHA pins

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -24,19 +24,19 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Setup JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4.8.0
         with:
           distribution: temurin
           java-version: '17.0.13'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a  # v4.4.3
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407  # v3.2.2
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
@@ -52,7 +52,7 @@ jobs:
 
       - name: Upload JVM crash logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: jvm-crash-logs
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,24 +11,25 @@ env:
 jobs:
   build-and-sign:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     permissions:
       contents: read
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4.8.0
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a  # v4.4.3
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407  # v3.2.2
 
       - name: Decode Keystore
         run: |
@@ -61,50 +62,73 @@ jobs:
       # the APK to trust weaker transport settings.
       - name: Build and Sign Release APK
         run: ./gradlew assembleGithubReleaseRelease
-        env: 
+        env:
           KEY_ALIAS: ${{ secrets.ALIAS }}
           KEYSTORE_PASSWORD: ${{ secrets.KEY_STORE_PASSWORD }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
           KEYSTORE: ${{ github.workspace }}/keystore.jks
 
+      - name: Remove keystore
+        if: always()
+        run: rm -f "${{ github.workspace }}/keystore.jks"
+
       - name: Get Version from Tag
         id: get_version
         run: echo "version=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_OUTPUT
 
+      - name: Create Checksum
+        id: create_checksum
+        run: |
+          FILENAME=$(echo app/build/outputs/apk/githubRelease/release/*.apk)
+          sha256sum "$FILENAME" > checksums.txt
+          echo "ARTIFACT_FILENAME=$FILENAME" >> "$GITHUB_OUTPUT"
+
       - name: Upload APK to GitHub Release Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: app-release-${{ steps.get_version.outputs.version }}
-          path: app/build/outputs/apk/githubRelease/release/*.apk
+          path: |
+            ${{ steps.create_checksum.outputs.ARTIFACT_FILENAME }}
+            checksums.txt
 
   create-release:
     needs: build-and-sign
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Get Version from Tag
         id: get_version
-        run: echo "version=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_OUTPUT
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG#v}"
+          if [[ "$TAG" == *-* ]]; then
+            IS_PRERELEASE=true
+          else
+            IS_PRERELEASE=false
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "is_prerelease=$IS_PRERELEASE" >> "$GITHUB_OUTPUT"
 
       - name: Download Release Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: app-release-${{ steps.get_version.outputs.version }}
-          path: ./artifacts # Download to a dedicated directory
+          path: ./artifacts
 
       - name: Create Release
         id: create_release
-        uses: ncipollo/release-action@v1.16.0
+        uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174  # v1.16.0
         with:
           allowUpdates: false
-          prerelease: true
+          prerelease: ${{ steps.get_version.outputs.is_prerelease }}
           draft: true
           name: MyDeck Release v${{ steps.get_version.outputs.version }}
           tag: ${{ github.ref }}
-          artifacts: "./artifacts/*.apk"
+          artifacts: "./artifacts/**/*.apk,./artifacts/checksums.txt"
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -37,19 +37,19 @@ jobs:
       contents: read
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Setup JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4.8.0
         with:
           distribution: temurin
           java-version: 17
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a  # v4.4.3
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407  # v3.2.2
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
@@ -115,7 +115,7 @@ jobs:
       # main / schedule / dispatch use 7-day retention.
       - name: Upload PR Debug APK Artifact
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: tester-snapshot-${{ steps.build_vars.outputs.APK_DIR }}
           path: |
@@ -125,7 +125,7 @@ jobs:
 
       - name: Upload Snapshot Artifact
         if: github.event_name != 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: tester-snapshot-${{ steps.build_vars.outputs.APK_DIR }}
           path: |
@@ -142,7 +142,7 @@ jobs:
       contents: write
     steps:
       - name: Download Snapshot Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: tester-snapshot-release
           path: ./artifacts
@@ -191,7 +191,7 @@ jobs:
           fi
 
       - name: Publish to GitHub Releases
-        uses: ncipollo/release-action@v1.16.0
+        uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174  # v1.16.0
         with:
           allowUpdates: true
           prerelease: true

--- a/docs/specs/github-actions-release-lanes-v0132-spec.md
+++ b/docs/specs/github-actions-release-lanes-v0132-spec.md
@@ -5,8 +5,8 @@
 Proposal accepted 2026-05-27. Implementation in progress.
 
 - [x] Phase 1 — Cleanup + PR signing fix (merged 2026-05-27, PR #168)
-- [x] Phase 2 — Snapshot rework (this PR)
-- [ ] Phase 3 — Release candidate handling + SHA pins
+- [x] Phase 2 — Snapshot rework (merged 2026-05-27, PR #169)
+- [x] Phase 3 — Release candidate handling + SHA pins (this PR)
 - [ ] Phase 4 — Branch protection, Dependabot, docs
 
 ## Context


### PR DESCRIPTION
## Summary

Implements Phase 3 of [docs/specs/github-actions-release-lanes-v0132-spec.md](docs/specs/github-actions-release-lanes-v0132-spec.md) (§5–§10).

### User-visible changes
- **RC tags get prerelease drafts.** Pushing `vX.Y.Z-rc.N` (or any tag with a hyphen after the version) now creates a draft GitHub Release with `prerelease: true`. Pushing a plain `vX.Y.Z` creates a draft with `prerelease: false`. Both remain drafts pending manual review.
- **checksums.txt attached to every release.** `release.yml` now generates `checksums.txt` alongside the signed APK and uploads both, matching the snapshot lane.
- **All actions SHA-pinned.** Every `uses:` reference across `checks.yml`, `snapshot.yml`, and `release.yml` is pinned to a 40-char commit SHA with a trailing `# vX.Y.Z` comment, per §10. Dependabot (Phase 4) will keep these current.

### Other hygiene (per spec)
- `if: always()` keystore cleanup step on `release.yml` `build-and-sign` (§8).
- `timeout-minutes: 45` on `build-and-sign`, `timeout-minutes: 10` on `create-release` (§9).
- Explicit `permissions:` blocks were already in place on both jobs (§7) — verified, no change needed.
- `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env preserved.

### Scope notes
- No changes to branch protection, Dependabot config, or docs (Phase 4).
- `checks.yml` and `snapshot.yml` only change in their `uses:` SHA pins; no behavioral changes.

## Test plan

- [ ] CI passes on this PR (only `checks.yml` runs; `snapshot.yml` runs in PR mode and produces the debug-signed APK artifact).
- [ ] Confirm pinned SHAs resolve to expected versions (each `uses:` line carries a `# vX.Y.Z` comment).
- [ ] **Post-merge validation**: push a throwaway `v0.0.0-ci.test` tag and confirm `release.yml` creates a draft prerelease with APK + `checksums.txt` attached; delete the draft and the tag afterward. The final-release (no-hyphen) path is harder to test without consuming a real version number — leave that to the actual v0.13.2 cut.