### PR TITLE
ci: phase 4 — contributor readiness (docs, Dependabot, validation log)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,6 +129,6 @@ jobs:
           prerelease: ${{ steps.get_version.outputs.is_prerelease }}
           draft: true
           name: MyDeck Release v${{ steps.get_version.outputs.version }}
-          tag: ${{ github.ref }}
+          tag: ${{ github.ref_name }}
           artifacts: "./artifacts/**/*.apk,./artifacts/checksums.txt"
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,16 @@ If changes touch UI/resources/build config/dependencies, also run:
 Avoid emulator/device-required tasks:
 - `connectedAndroidTest`, `connectedDebugAndroidTest`, etc.
 
+## Triggering a snapshot build from a cloud environment
+
+If your sandbox does not allow `gh workflow run` (authentication scope, network restrictions, etc.):
+
+1. Push your branch and open a PR as normal.
+2. Note in the PR description that a snapshot build is needed and name the branch.
+3. The repo maintainer will dispatch **Snapshot Build** against that branch manually from the Actions tab.
+
+Do not fail silently — surface the request in the PR description so the maintainer can act.
+
 ## Notes
 - Prefer Debug tasks (avoid release signing requirements).
 - Keep changes focused and avoid unrelated formatting churn.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,20 @@ For any state-changing action, **list the exact command(s) for the user to run**
 
 This applies to `git push`, branch/tag deletions, and force pushes as well — propose, don't execute.
 
+**`gh` default repo.** This working copy has both `origin` (`NateEaton/mydeck-android`) and `upstream` (`jensomato/ReadeckApp`). `gh` may resolve the default to the upstream, which causes `gh pr view`, `gh pr list`, `gh run view`, and `gh api repos/...` calls to silently return data from the wrong repo. Always pass `--repo NateEaton/mydeck-android` (or rely on `gh repo set-default NateEaton/mydeck-android` having been run in this working copy). When in doubt, run `gh repo view --json nameWithOwner` and confirm it says `NateEaton/mydeck-android` before trusting `gh` output.
+
+---
+
+## CI/CD — Triggering Snapshot Builds
+
+If your environment does not allow `gh workflow run` (authentication scope, network restrictions, etc.):
+
+1. Push your branch and open a PR as normal.
+2. Note in the PR description that a snapshot build is needed and name the branch.
+3. The repo maintainer will dispatch **Snapshot Build** against that branch manually from the Actions tab.
+
+Do not fail silently — surface the request in the PR description so the maintainer can act.
+
 ---
 
 ## Other Guidelines

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -24,29 +24,106 @@ We use a **Main-First** (Trunk-based) workflow.
 
 We use GitHub Actions to automate testing and build delivery.
 
-### Automated Checks (`checks.yml`)
-Runs on pushes to `main`, `feature/**`, `enhancement/**`, `fix/**`, `chore/**`, `claude/**`, and `codex/**`, plus Pull Requests targeting `main`.
+### Quality Checks (`checks.yml`)
+Runs on pushes to `main`, Pull Requests targeting `main`, and manual dispatch.
 *   **Tasks:** Runs `:app:assembleDebugAll`, `:app:lintDebugAll`, and `:app:testDebugUnitTestAll` in sequence.
 *   **Goal:** Catch compile, lint, and unit-test regressions early without waiting for release packaging.
+*   Plain development branch pushes (e.g., `feature/*`, `fix/*`) do **not** trigger this workflow automatically — use a PR or manual dispatch.
 
-### Tester Builds & Snapshots (`snapshot.yml`)
-To provide a production-like, side-by-side installable APK for functional testing without overwriting your daily-driver app.
+### Snapshots (`snapshot.yml`)
+Provides a side-by-side installable APK (`com.mydeck.app.snapshot`) for functional testing without overwriting the production app. Four trigger paths:
 
-1.  **Development Branch Pushes**: Automatically builds a **Release Snapshot** (minified/optimized) and uploads it as a GitHub Actions artifact.
-    *   **Use case:** Share the latest branch build with a tester before opening or updating a PR.
-2.  **Pull Requests to `main`**: Automatically builds the same **Release Snapshot** and uploads it as a GitHub Actions artifact.
-    *   **Side-by-Side:** Installs as `com.mydeck.app.snapshot`.
-    *   **Behavior:** Uses the Release build type, so performance and shrinking are closer to production than a Debug APK.
-    *   **Usage:** Download from the workflow run's "Artifacts" section, unzip, and install.
-3.  **Pushes to `main`**: Automatically rebuilds the Release Snapshot and updates the revolving **"MyDeck Continuous Snapshot"** GitHub release with the latest merged code.
-    *   **Direct pushes to `main`:** Treated the same as a post-merge `main` update. The same checks and snapshot packaging still run.
-4.  **Manual Trigger**: You can trigger a Snapshot build on any branch from the Actions tab.
+1.  **Pull Requests to `main`**: Builds a **debug-signed APK** (`assembleGithubSnapshotDebug`) and uploads it as a workflow artifact with 30-day retention. No release keystore is decoded; no signing secrets are in scope for PR runs.
+    *   **Install limitation:** The PR debug APK and the `latest-snapshot` release-signed APK share the same `applicationId` but different signing keys. They cannot coexist on a device — uninstall the existing snapshot first. Both install alongside the production app.
+2.  **Push to `main`**: Builds a **release-signed snapshot** and updates the single moving `latest-snapshot` GitHub prerelease. The release body identifies the source commit.
+3.  **Scheduled nightly** (07:23 UTC daily): Same as a main push — updates `latest-snapshot`. Only runs in `NateEaton/mydeck-android`; forks do not inherit this schedule.
+4.  **Manual dispatch** (Actions → Snapshot Build → Run workflow): Build any branch with `build_type: debug` (default) or `release`. The APK appears in the workflow run's Artifacts section with 7-day retention.
 
-### Official Releases (`release.yml`)
-Runs when a tag starting with `v` is pushed (e.g., `v0.12.0`).
-*   **Build Type:** Official Release (non-debug).
-*   **Package ID:** `com.mydeck.app` (standard).
-*   **Distribution:** Creates a GitHub Release draft for publication.
+### Releases (`release.yml`)
+Runs when a tag matching `v*` is pushed.
+*   **Build Type:** Release-signed, `com.mydeck.app`.
+*   **Pre-release detection:** Tags containing a hyphen (e.g., `v0.13.2-rc.1`, `v0.13.2-beta.1`) create a draft GitHub Release marked `prerelease: true`. Tags without a hyphen (e.g., `v0.13.2`) create a draft marked `prerelease: false`.
+*   **Artifacts:** APK + `checksums.txt` attached to the draft release.
+*   All draft releases require a manual **Publish release** click after review.
+
+### CI/CD Scenarios
+
+Every common situation, what CI does, and where to find the artifact.
+
+#### Local feature work, no PR yet
+
+You're iterating on a `feature/*` (or `enhancement/*`, `fix/*`, `chore/*`) branch and want a tester to install your build.
+
+1. Commit and push the branch. **Nothing in CI runs automatically.** This is intentional — branch pushes used to create skipped workflow runs that cluttered the Actions page.
+2. Go to **Actions → Snapshot Build → Run workflow** and select your branch.
+3. Choose `build_type`: `debug` (default, debug-signed) or `release` (release-signed snapshot APK).
+4. When the run finishes, the APK is in the workflow run's **Artifacts** section. Download, unzip, install. Retention: 7 days (manual dispatch path). PR-triggered builds use 30 days — see "Opening a PR" below.
+
+#### Opening (or updating) a PR to `main`
+
+Includes draft PRs.
+
+- **`Quality Checks` runs**: assembles all debug variants, lint, unit tests.
+- **`Snapshot Build` runs in PR mode**: builds the **debug-signed APK** (`assembleGithubSnapshotDebug`, signed with the auto-generated Android debug keystore) and uploads it as a workflow artifact. No release keystore is decoded; no release-signing secrets are exposed. Retention: 30 days.
+- Where to find the APK: the PR's **Checks** tab or the workflow run's **Artifacts** section.
+- **Install limitation:** the PR debug APK and the `latest-snapshot` release-signed APK share the same `applicationId` (`com.mydeck.app.snapshot`) but use different signing keys. They cannot coexist on a device. To install a PR APK, first uninstall any existing `latest-snapshot` install. Both still install alongside the production app (`com.mydeck.app`).
+
+#### PR from a fork
+
+Same as above. Forked PRs do not receive repository secrets from GitHub by default; since we are not signing on PRs anyway, this is safe. Debug APK shows up as a workflow artifact like any other PR.
+
+#### PR merges to `main`
+
+- **`Snapshot Build` runs in main-push mode**: builds a **signed release snapshot** APK and updates the single moving `latest-snapshot` GitHub prerelease.
+- Release body identifies the source, e.g. `**Source:** main push @ abc1234 — 2026-05-27 14:02 UTC`.
+- Where to find the APK: Releases tab → `latest-snapshot`.
+
+#### Scheduled nightly build
+
+- Runs daily at **07:23 UTC**. GitHub Actions cron is UTC and does not follow DST, so the local equivalent shifts by an hour twice a year (≈ 01:23 CST / 02:23 CDT). The UTC time is the stable one.
+- Builds a signed release snapshot from `main` and updates the same `latest-snapshot` prerelease.
+- Release body identifies the source as nightly, e.g. `**Source:** nightly @ abc1234 — 2026-05-27 07:23 UTC`.
+- The release name and tag do not change. There is **no** separate `latest-nightly` release — `latest-snapshot` is the one moving prerelease.
+- Only runs in `NateEaton/mydeck-android`. Forks that enable Actions do not inherit the scheduled build.
+
+#### Pushing a pre-release tag
+
+Tag pattern: `vX.Y.Z-<anything>`, e.g. `v0.13.2-rc.1`, `v0.13.2-beta.1`.
+
+- **`Release Build` runs**: builds a signed release APK, computes `prerelease: true` from the tag (any hyphen after the version), creates a **draft GitHub Release** named `MyDeck Release vX.Y.Z-...`.
+- Artifacts attached to the release: APK + `checksums.txt`.
+- The release is created as a **draft**. Review the release notes, then click **Publish release** when ready.
+
+#### Pushing a final release tag
+
+Tag pattern: `vX.Y.Z` with no hyphen, e.g. `v0.13.2`.
+
+- Same as the pre-release flow, but the draft release is marked `prerelease: false` (final).
+- Still a draft until you publish.
+
+#### Tagging the wrong commit
+
+`Release Build` will still run — the workflow trusts the tag. Catch it during the draft review and either delete the tag (and re-push to the correct commit) or edit the draft release.
+
+If you re-push a tag after deleting it, the workflow runs again, but the release-creation step is configured with `allowUpdates: false`, so it will fail rather than silently overwrite the existing draft. Delete the previous draft first.
+
+#### Force-pushing a feature branch
+
+Allowed. Branch protection only protects `main`. Under the new trigger model, plain branch pushes do not start any CI run, so there is usually nothing to cancel. The `concurrency` block only matters when a run is already in flight from another trigger on the same ref — typically an open PR (pushes to a branch with an open PR re-trigger `pull_request` runs that share a concurrency group keyed on the PR number) or a manual `workflow_dispatch`. In those cases the in-flight run is cancelled in favor of the new commit.
+
+#### Pushing directly to `main`
+
+Blocked by the branch protection ruleset. All changes to `main` go through a PR (squash-and-merge). If you genuinely need to bypass — emergency hotfix, broken CI, etc. — and you've added yourself to the ruleset's bypass list, the push is allowed but logged in the audit log.
+
+#### AI agent (Claude Code, Codex cloud) cannot trigger a workflow itself
+
+If the agent's sandbox does not allow `gh workflow run`, the convention is:
+
+1. The agent pushes its branch and opens a PR as normal.
+2. The agent notes in the PR description that a snapshot build is needed and names the branch.
+3. A maintainer dispatches **Snapshot Build** against that branch manually.
+
+This is documented in `AGENTS.md` and `CLAUDE.md` so the agent knows to ask rather than fail silently.
 
 ---
 

--- a/docs/specs/github-actions-release-lanes-v0132-spec.md
+++ b/docs/specs/github-actions-release-lanes-v0132-spec.md
@@ -2,12 +2,12 @@
 
 ## Status
 
-Proposal accepted 2026-05-27. Implementation in progress.
+Proposal accepted 2026-05-27. Implementation complete.
 
 - [x] Phase 1 — Cleanup + PR signing fix (merged 2026-05-27, PR #168)
 - [x] Phase 2 — Snapshot rework (merged 2026-05-27, PR #169)
-- [x] Phase 3 — Release candidate handling + SHA pins (this PR)
-- [ ] Phase 4 — Branch protection, Dependabot, docs
+- [x] Phase 3 — Release candidate handling + SHA pins (merged 2026-05-28, PR #172)
+- [x] Phase 4 — Branch protection, Dependabot, docs (this PR)
 
 ## Context
 
@@ -644,6 +644,47 @@ behavior rather than local Gradle execution alone:
   `prerelease: false`.
 - Confirm APK checksums are uploaded for snapshot, prerelease, and final
   release artifacts.
+
+### Validation Results (2026-05-28)
+
+Phases 1–3 validated post-merge on `main` at commit `cc638a5`.
+
+**Phase 1 + 2 (checks.yml, snapshot.yml) — confirmed via PR #172 CI run:**
+
+- `Quality Checks` and `Snapshot Build` both ran on the PR with all SHA-pinned
+  actions resolving cleanly. Runner logs confirmed every action was downloaded
+  by exact commit SHA (e.g. `actions/checkout@34e114876b...`).
+- Post-merge main push (run 26587177877): `build-snapshot` succeeded, keystore
+  cleanup ran, `publish-latest-snapshot` updated `latest-snapshot` release. All
+  steps green.
+
+**Phase 3 (release.yml) — confirmed via throwaway tag `v0.0.0-ci.test`:**
+
+- Tag pushed to `cc638a5`; `release.yml` triggered (run 26589287125), both
+  `build-and-sign` and `create-release` jobs succeeded.
+- Draft release produced: `draft: true`, `prerelease: true` (hyphen in tag
+  → IS_PRERELEASE=true rule fired correctly), name `MyDeck Release v0.0.0-ci.test`.
+- Assets attached: signed APK (~5.2 MB) + `checksums.txt` (128 B). ✓
+- New `Remove keystore` step (`if: always()`) ran successfully. ✓
+- All SHA-pinned actions resolved (same runner-log pattern as snapshot). ✓
+- Draft release and tag deleted after inspection.
+
+**Open item for Phase 4 agent:** The draft release stored `tag_name:
+"refs/tags/v0.0.0-ci.test"` (the literal value of `${{ github.ref }}`) and
+the draft preview URL appeared as `releases/tag/untagged-...`. Published
+releases (e.g. v0.13.1) show a clean `tag_name: "v0.13.1"`, suggesting the
+prefix is stripped at publish time — but this was not directly verified. This
+is pre-existing behaviour (`tag: ${{ github.ref }}` was in the original
+workflow and was not changed in Phase 3). Before cutting the first RC, verify
+this is acceptable or replace `tag: ${{ github.ref }}` with
+`tag: ${{ github.ref_name }}` in `release.yml`'s `create-release` step.
+`github.ref_name` resolves to just the tag name (e.g. `v0.13.2-rc.1`) without
+the `refs/tags/` prefix.
+
+**Remaining validation (requires real tags):**
+
+- Final-release (no-hyphen) `prerelease: false` path — deferred to `v0.13.2` cut.
+- Scheduled nightly `latest-snapshot` source line — deferred to next nightly run.
 
 ## Resolved Decisions (2026-05-27)
 

--- a/docs/specs/github-actions-release-lanes-v0132-spec.md
+++ b/docs/specs/github-actions-release-lanes-v0132-spec.md
@@ -669,17 +669,12 @@ Phases 1–3 validated post-merge on `main` at commit `cc638a5`.
 - All SHA-pinned actions resolved (same runner-log pattern as snapshot). ✓
 - Draft release and tag deleted after inspection.
 
-**Open item for Phase 4 agent:** The draft release stored `tag_name:
-"refs/tags/v0.0.0-ci.test"` (the literal value of `${{ github.ref }}`) and
-the draft preview URL appeared as `releases/tag/untagged-...`. Published
-releases (e.g. v0.13.1) show a clean `tag_name: "v0.13.1"`, suggesting the
-prefix is stripped at publish time — but this was not directly verified. This
-is pre-existing behaviour (`tag: ${{ github.ref }}` was in the original
-workflow and was not changed in Phase 3). Before cutting the first RC, verify
-this is acceptable or replace `tag: ${{ github.ref }}` with
-`tag: ${{ github.ref_name }}` in `release.yml`'s `create-release` step.
-`github.ref_name` resolves to just the tag name (e.g. `v0.13.2-rc.1`) without
-the `refs/tags/` prefix.
+**Resolved in Phase 4:** The draft release stored `tag_name:
+"refs/tags/v0.0.0-ci.test"` (the literal value of `${{ github.ref }}`),
+causing a `releases/tag/untagged-...` preview URL on drafts. Fixed by
+replacing `tag: ${{ github.ref }}` with `tag: ${{ github.ref_name }}` in
+`release.yml`'s `create-release` step. `github.ref_name` resolves to just
+the tag name (e.g. `v0.13.2-rc.1`) without the `refs/tags/` prefix.
 
 **Remaining validation (requires real tags):**
 


### PR DESCRIPTION
## Summary

Implements Phase 4 of [docs/specs/github-actions-release-lanes-v0132-spec.md](docs/specs/github-actions-release-lanes-v0132-spec.md) (see [Branch Protection](docs/specs/github-actions-release-lanes-v0132-spec.md#branch-protection) subsection for the one step not covered here).

### Files changed

- **`.github/dependabot.yml`** — created; weekly Dependabot scan for GitHub Actions dependencies (spec §10)
- **`.github/workflows/release.yml`** — fixed `tag: ${{ github.ref }}` → `tag: ${{ github.ref_name }}` so draft releases get a clean tag name instead of `refs/tags/vX.Y.Z`
- **`docs/WORKFLOW.md`** — replaced the old CI/CD section (branch-prefix push triggers, signed PR builds) with the new trigger and artifact model; added full "CI/CD Scenarios" subsection covering all 10 common situations
- **`AGENTS.md`** — added "Triggering a snapshot build from a cloud environment" subsection with the AI-agent dispatch fallback convention (spec §2)
- **`CLAUDE.md`** — added matching CI/CD fallback section; added `gh` default-repo warning (upstream vs. fork confusion) under the existing GitHub Interactions section
- **`docs/specs/github-actions-release-lanes-v0132-spec.md`** — updated Status block (Phase 3 corrected, Phase 4 ticked, lead sentence updated to "Implementation complete."); folds in the Validation Results (2026-05-28) log for Phases 1–3 that was outstanding locally; open item for `github.ref_name` marked resolved

### What is NOT in this PR

Branch protection ruleset configuration — that must be done in GitHub's web UI. See spec §"Branch Protection" for the step-by-step.

## Next steps after merge

- [ ] Configure branch protection ruleset per spec §"Branch Protection": Settings → Rules → Rulesets → "Main branch protection" (restrict deletions, block force pushes, require PR, require `Quality Checks / verify` status check, require linear history).
- [ ] Within 1–2 days, confirm Dependabot has opened its first Actions dependency scan / PR.