### PR TITLE
chore(release): bump version to 0.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.2] - 2026-05-29
+
+### Added
+
+- Reading time and word count filters in the bookmark list, including Min/Max ranges and an option to include bookmarks with no estimate
+
+### Fixed
+
+- Reader no longer shows stale extracted content for bookmarks opened immediately after adding, before server-side extraction completes
+
 ## [0.13.1] - 2026-05-20
 
 ### Fixed

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -48,8 +48,8 @@ android {
         applicationId = "com.mydeck.app"
         minSdk = 24
         targetSdk = 35
-        versionCode = 13001
-        versionName = "0.13.1"
+        versionCode = 13002
+        versionName = "0.13.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/metadata/en-US/changelogs/13002.txt
+++ b/metadata/en-US/changelogs/13002.txt
@@ -1,0 +1,5 @@
+<b>Added</b>
+- Reading time and word count filters: filter the bookmark list by length, with Min/Max ranges and an option to include items that have no estimate
+
+<b>Fixed</b>
+- Bookmarks opened right after adding no longer show stale extracted content; the reader now waits for server-side extraction to complete


### PR DESCRIPTION
- versionCode 13001 -> 13002
- versionName "0.13.1" -> "0.13.2"
- CHANGELOG.md: new [0.13.2] section covering reading time / word count filters (added) and stale-extracted-content fix (fixed)
- metadata/en-US/changelogs/13002.txt: store changelog mirror