### PR TITLE
Add HTTPS-only standard release packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,33 +35,20 @@ jobs:
         run: |
           echo "${{ secrets.SIGNING_KEY }}" | base64 --decode > ${{ github.workspace }}/keystore.jks
 
-      # Release APKs are intentionally secure by default:
-      # - HTTPS only
-      # - system CA trust only
-      #
-      # Self-hosters who need a custom less-secure release can opt in at build time
-      # by setting one or both environment variables below on the Gradle step.
-      #
-      # When you might need this:
-      # - ALLOW_INSECURE_HTTP_RELEASE=true
-      #   Example: your Readeck server is only reachable on a trusted local network
-      #   over plain HTTP, such as http://192.168.1.50:8000, and you do not have TLS
-      #   configured for that host.
-      #
-      # - ALLOW_USER_CA_RELEASE=true
-      #   Example: your Readeck server uses HTTPS, but its certificate chains to a
-      #   private or user-installed CA rather than a public system-trusted CA.
-      #
-      # To build such a custom release in GitHub Actions, add one or both of these
-      # env vars under the Gradle step:
-      #
-      #   ALLOW_INSECURE_HTTP_RELEASE: 'true'
-      #   ALLOW_USER_CA_RELEASE: 'true'
-      #
-      # Do not enable these for official/public releases unless you explicitly want
-      # the APK to trust weaker transport settings.
-      - name: Build and Sign Release APK
+      # Official release packaging produces two separately installable APKs:
+      # - Standard: HTTPS-only server URLs; system CA trust only.
+      # - HTTP-enabled: opt-in package for trusted private-network HTTP setups;
+      #   separate application ID and system + user CA trust.
+      - name: Build and Sign Standard Release APK
         run: ./gradlew assembleGithubReleaseRelease
+        env:
+          KEY_ALIAS: ${{ secrets.ALIAS }}
+          KEYSTORE_PASSWORD: ${{ secrets.KEY_STORE_PASSWORD }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          KEYSTORE: ${{ github.workspace }}/keystore.jks
+
+      - name: Build and Sign HTTP-enabled Release APK
+        run: ./gradlew assembleGithubReleaseHttpRelease
         env:
           KEY_ALIAS: ${{ secrets.ALIAS }}
           KEYSTORE_PASSWORD: ${{ secrets.KEY_STORE_PASSWORD }}
@@ -76,20 +63,35 @@ jobs:
         id: get_version
         run: echo "version=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_OUTPUT
 
-      - name: Create Checksum
-        id: create_checksum
+      - name: Create Standard Checksum
+        id: standard_checksum
         run: |
           FILENAME=$(echo app/build/outputs/apk/githubRelease/release/*.apk)
-          sha256sum "$FILENAME" > checksums.txt
+          sha256sum "$FILENAME" > checksums-standard.txt
           echo "ARTIFACT_FILENAME=$FILENAME" >> "$GITHUB_OUTPUT"
 
-      - name: Upload APK to GitHub Release Artifacts
+      - name: Create HTTP-enabled Checksum
+        id: http_checksum
+        run: |
+          FILENAME=$(echo app/build/outputs/apk/githubReleaseHttp/release/*.apk)
+          sha256sum "$FILENAME" > checksums-http-enabled.txt
+          echo "ARTIFACT_FILENAME=$FILENAME" >> "$GITHUB_OUTPUT"
+
+      - name: Upload Standard APK to GitHub Release Artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
-          name: app-release-${{ steps.get_version.outputs.version }}
+          name: app-release-standard-${{ steps.get_version.outputs.version }}
           path: |
-            ${{ steps.create_checksum.outputs.ARTIFACT_FILENAME }}
-            checksums.txt
+            ${{ steps.standard_checksum.outputs.ARTIFACT_FILENAME }}
+            checksums-standard.txt
+
+      - name: Upload HTTP-enabled APK to GitHub Release Artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: app-release-http-enabled-${{ steps.get_version.outputs.version }}
+          path: |
+            ${{ steps.http_checksum.outputs.ARTIFACT_FILENAME }}
+            checksums-http-enabled.txt
 
   create-release:
     needs: build-and-sign
@@ -115,11 +117,17 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "is_prerelease=$IS_PRERELEASE" >> "$GITHUB_OUTPUT"
 
-      - name: Download Release Artifact
+      - name: Download Standard Release Artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
-          name: app-release-${{ steps.get_version.outputs.version }}
-          path: ./artifacts
+          name: app-release-standard-${{ steps.get_version.outputs.version }}
+          path: ./artifacts/standard
+
+      - name: Download HTTP-enabled Release Artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        with:
+          name: app-release-http-enabled-${{ steps.get_version.outputs.version }}
+          path: ./artifacts/http-enabled
 
       - name: Create Release
         id: create_release
@@ -130,5 +138,13 @@ jobs:
           draft: true
           name: MyDeck Release v${{ steps.get_version.outputs.version }}
           tag: ${{ github.ref_name }}
-          artifacts: "./artifacts/**/*.apk,./artifacts/checksums.txt"
+          body: |
+            ## Recommended download
+
+            Download `MyDeck-${{ steps.get_version.outputs.version }}.apk` for the standard HTTPS-only MyDeck app.
+
+            ## Advanced: HTTP-enabled APK
+
+            Download `MyDeck-${{ steps.get_version.outputs.version }}-http-enabled.apk` only for trusted private-network setups that cannot use HTTPS. This is a separate package (`com.mydeck.app.permissive`) that can be installed beside the standard app and uses separate app data.
+          artifacts: "./artifacts/**/*.apk,./artifacts/**/*.txt"
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -63,11 +63,13 @@ jobs:
             BUILD_TYPE="${{ github.event.inputs.build_type || 'release' }}"
           fi
           if [ "$BUILD_TYPE" = "debug" ]; then
-            echo "GRADLE_TASK=assembleGithubSnapshotDebug" >> "$GITHUB_OUTPUT"
+            echo "STANDARD_GRADLE_TASK=assembleGithubSnapshotDebug" >> "$GITHUB_OUTPUT"
+            echo "HTTP_GRADLE_TASK=assembleGithubSnapshotHttpDebug" >> "$GITHUB_OUTPUT"
             echo "APK_DIR=debug" >> "$GITHUB_OUTPUT"
             echo "VERSION_SUFFIX=-debug" >> "$GITHUB_OUTPUT"
           else
-            echo "GRADLE_TASK=assembleGithubSnapshotRelease" >> "$GITHUB_OUTPUT"
+            echo "STANDARD_GRADLE_TASK=assembleGithubSnapshotRelease" >> "$GITHUB_OUTPUT"
+            echo "HTTP_GRADLE_TASK=assembleGithubSnapshotHttpRelease" >> "$GITHUB_OUTPUT"
             echo "APK_DIR=release" >> "$GITHUB_OUTPUT"
             echo "VERSION_SUFFIX=" >> "$GITHUB_OUTPUT"
           fi
@@ -83,17 +85,33 @@ jobs:
           echo "TIMESTAMP=$(date +%Y%m%dT%H%M%S)" >> "$GITHUB_OUTPUT"
           echo "COMMIT_SHA=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Build Snapshot APK (debug, no signing env)
+      - name: Build Standard Snapshot APK (debug, no signing env)
         if: github.event_name == 'pull_request' || steps.build_vars.outputs.APK_DIR == 'debug'
-        run: ./gradlew assembleGithubSnapshotDebug
+        run: ./gradlew ${{ steps.build_vars.outputs.STANDARD_GRADLE_TASK }}
         env:
-          SNAPSHOT_VERSION_NAME: ${{ steps.set_env.outputs.TIMESTAMP }}-${{ steps.set_env.outputs.COMMIT_SHA }}-debug
+          SNAPSHOT_VERSION_NAME: ${{ steps.set_env.outputs.TIMESTAMP }}-${{ steps.set_env.outputs.COMMIT_SHA }}-snapshot-debug
 
-      - name: Build Snapshot APK (signed release)
-        if: github.event_name != 'pull_request' && steps.build_vars.outputs.APK_DIR == 'release'
-        run: ./gradlew assembleGithubSnapshotRelease
+      - name: Build HTTP-enabled Snapshot APK (debug, no signing env)
+        if: github.event_name == 'pull_request' || steps.build_vars.outputs.APK_DIR == 'debug'
+        run: ./gradlew ${{ steps.build_vars.outputs.HTTP_GRADLE_TASK }}
         env:
-          SNAPSHOT_VERSION_NAME: ${{ steps.set_env.outputs.TIMESTAMP }}-${{ steps.set_env.outputs.COMMIT_SHA }}
+          SNAPSHOT_VERSION_NAME: ${{ steps.set_env.outputs.TIMESTAMP }}-${{ steps.set_env.outputs.COMMIT_SHA }}-snapshot-debug
+
+      - name: Build Standard Snapshot APK (signed release)
+        if: github.event_name != 'pull_request' && steps.build_vars.outputs.APK_DIR == 'release'
+        run: ./gradlew ${{ steps.build_vars.outputs.STANDARD_GRADLE_TASK }}
+        env:
+          SNAPSHOT_VERSION_NAME: ${{ steps.set_env.outputs.TIMESTAMP }}-${{ steps.set_env.outputs.COMMIT_SHA }}-snapshot
+          KEY_ALIAS: ${{ secrets.ALIAS }}
+          KEYSTORE_PASSWORD: ${{ secrets.KEY_STORE_PASSWORD }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          KEYSTORE: ${{ github.workspace }}/keystore.jks
+
+      - name: Build HTTP-enabled Snapshot APK (signed release)
+        if: github.event_name != 'pull_request' && steps.build_vars.outputs.APK_DIR == 'release'
+        run: ./gradlew ${{ steps.build_vars.outputs.HTTP_GRADLE_TASK }}
+        env:
+          SNAPSHOT_VERSION_NAME: ${{ steps.set_env.outputs.TIMESTAMP }}-${{ steps.set_env.outputs.COMMIT_SHA }}-snapshot
           KEY_ALIAS: ${{ secrets.ALIAS }}
           KEYSTORE_PASSWORD: ${{ secrets.KEY_STORE_PASSWORD }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
@@ -103,34 +121,61 @@ jobs:
         if: always() && github.event_name != 'pull_request' && steps.build_vars.outputs.APK_DIR == 'release'
         run: rm -f "${{ github.workspace }}/keystore.jks"
 
-      - name: Create Checksum
-        id: create_checksum
+      - name: Create Standard Checksum
+        id: standard_checksum
         run: |
           FILENAME=$(echo app/build/outputs/apk/githubSnapshot/${{ steps.build_vars.outputs.APK_DIR }}/*.apk)
-          sha256sum $FILENAME > checksums.txt
+          sha256sum "$FILENAME" > checksums-standard.txt
+          echo "ARTIFACT_FILENAME=$FILENAME" >> "$GITHUB_OUTPUT"
+
+      - name: Create HTTP-enabled Checksum
+        id: http_checksum
+        run: |
+          FILENAME=$(echo app/build/outputs/apk/githubSnapshotHttp/${{ steps.build_vars.outputs.APK_DIR }}/*.apk)
+          sha256sum "$FILENAME" > checksums-http-enabled.txt
           echo "ARTIFACT_FILENAME=$FILENAME" >> "$GITHUB_OUTPUT"
 
       # Every run produces a tester-downloadable snapshot artifact.
       # PR runs use 30-day retention so reviewers have time to install and test;
       # main / schedule / dispatch use 7-day retention.
-      - name: Upload PR Debug APK Artifact
+      - name: Upload PR Standard Debug APK Artifact
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
-          name: tester-snapshot-${{ steps.build_vars.outputs.APK_DIR }}
+          name: tester-snapshot-standard-${{ steps.build_vars.outputs.APK_DIR }}
           path: |
-            ${{ steps.create_checksum.outputs.ARTIFACT_FILENAME }}
-            checksums.txt
+            ${{ steps.standard_checksum.outputs.ARTIFACT_FILENAME }}
+            checksums-standard.txt
           retention-days: 30
 
-      - name: Upload Snapshot Artifact
+      - name: Upload PR HTTP-enabled Debug APK Artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: tester-snapshot-http-enabled-${{ steps.build_vars.outputs.APK_DIR }}
+          path: |
+            ${{ steps.http_checksum.outputs.ARTIFACT_FILENAME }}
+            checksums-http-enabled.txt
+          retention-days: 30
+
+      - name: Upload Standard Snapshot Artifact
         if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
-          name: tester-snapshot-${{ steps.build_vars.outputs.APK_DIR }}
+          name: tester-snapshot-standard-${{ steps.build_vars.outputs.APK_DIR }}
           path: |
-            ${{ steps.create_checksum.outputs.ARTIFACT_FILENAME }}
-            checksums.txt
+            ${{ steps.standard_checksum.outputs.ARTIFACT_FILENAME }}
+            checksums-standard.txt
+          retention-days: 7
+
+      - name: Upload HTTP-enabled Snapshot Artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: tester-snapshot-http-enabled-${{ steps.build_vars.outputs.APK_DIR }}
+          path: |
+            ${{ steps.http_checksum.outputs.ARTIFACT_FILENAME }}
+            checksums-http-enabled.txt
           retention-days: 7
 
   publish-latest-snapshot:
@@ -141,11 +186,17 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Download Snapshot Artifact
+      - name: Download Standard Snapshot Artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
-          name: tester-snapshot-release
-          path: ./artifacts
+          name: tester-snapshot-standard-release
+          path: ./artifacts/standard
+
+      - name: Download HTTP-enabled Snapshot Artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        with:
+          name: tester-snapshot-http-enabled-release
+          path: ./artifacts/http-enabled
 
       - name: Compute Source Line
         id: source
@@ -200,9 +251,17 @@ jobs:
             This is an automated snapshot build. It is a **Release-optimized** build but uses a separate package ID so it can be installed alongside your production version.
 
             ${{ steps.source.outputs.SOURCE_LINE }}
+
+            ## Recommended download
+
+            Download the standard snapshot APK for HTTPS-only Readeck server URLs.
+
+            ## Advanced: HTTP-enabled APK
+
+            Download the HTTP-enabled snapshot APK only for trusted private-network setups that cannot use HTTPS. It uses a separate package ID and separate app data.
           commit: ${{ github.sha }}
           tag: latest-snapshot
           removeArtifacts: true
           omitDraftDuringUpdate: true
-          artifacts: "./artifacts/**/*.apk,./artifacts/checksums.txt"
+          artifacts: "./artifacts/**/*.apk,./artifacts/**/*.txt"
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ It began as a fork of [ReadeckApp](https://github.com/jensomato/ReadeckApp) and 
 
 ## Download
 
+### Which APK do I want?
+
+- **Standard APK** (`MyDeck-<version>.apk`) is recommended. It accepts HTTPS Readeck server URLs only and uses system-trusted certificate authorities.
+- **HTTP-enabled APK** (`MyDeck-<version>-http-enabled.apk`) is for trusted private-network setups that cannot use HTTPS. It installs as a separate app (`com.mydeck.app.permissive`), keeps separate app data, and requires OAuth authorization again.
+
 - **GitHub Releases:** [Latest release](https://github.com/NateEaton/mydeck-android/releases/latest)
 
 ## Key Features
@@ -41,9 +46,9 @@ cd mydeck-android
 ./gradlew assembleDebug
 ```
 
-The debug APK will be at `app/build/outputs/apk/githubSnapshot/debug/`. Release builds require signing configuration — refer to the GitHub Actions workflow in `.github/workflows/release.yml`.
+The debug APKs will be at `app/build/outputs/apk/githubSnapshot/debug/` and `app/build/outputs/apk/githubSnapshotHttp/debug/`. Release builds require signing configuration — refer to the GitHub Actions workflow in `.github/workflows/release.yml`.
 
-Standard release builds permit `http://` server URLs (with an in-app warning). If you need to prohibit HTTP entirely in a custom build — for example, to enforce HTTPS in an organisational deployment — set `allowInsecureHttpRelease=false` as a Gradle property or `ALLOW_INSECURE_HTTP_RELEASE=false` as an environment variable. To trust HTTPS servers signed by a private CA, use `ALLOW_USER_CA_RELEASE=true`.
+Standard release builds are HTTPS-only by default. The HTTP-enabled flavors (`githubReleaseHttp`, `githubSnapshotHttp`) use separate application IDs and enable both cleartext HTTP and user-installed certificate authorities for users who explicitly need that package.
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,7 +29,7 @@ HTTP support uses two separate distribution paths:
 - **Standard APK**: HTTPS-only server URLs; system CA trust only.
 - **HTTP-enabled APK**: HTTP allowed; system + user CA trust. The URL-entry warning explains the cleartext-token risk and points users toward HTTPS alternatives such as Tailscale Serve or a reverse proxy.
 
-If a user installs the new standard APK over an older standard build that was already signed in to an `http://` server URL, MyDeck stops at startup on a migration screen. The screen offers switching to an HTTPS URL and signing in again, installing the separate HTTP-enabled APK, or signing out locally.
+If a user installs the new standard APK over an older standard build that was already signed in to an `http://` server URL, MyDeck stops at startup on a migration screen. The screen offers switching to an HTTPS URL and signing in again, or installing the separate HTTP-enabled APK.
 
 ### Self-hosted HTTP use case
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,33 +14,35 @@ MyDeck authenticates with the Readeck server using the **OAuth 2.0 Device Author
 
 ### Default configuration
 
-Release builds permit both `https://` and `http://` server URLs:
+The standard release APK accepts HTTPS Readeck server URLs only:
 
 - `https://` connections use system-trusted certificate authorities only
-- `http://` connections are permitted but trigger an in-app warning at the URL entry screen
-- OAuth operates over whatever scheme the user configures; no HTTPS is enforced at the protocol level
+- `http://` Readeck API requests are blocked before network I/O
+- OAuth bearer tokens are not sent over cleartext HTTP in the standard APK
 
-The inline warning is the primary user-facing safeguard for HTTP connections. It is displayed as soon as an `http://` URL is entered and remains visible until the URL is changed to `https://`.
+The HTTP-enabled APK is a separate opt-in package (`com.mydeck.app.permissive`). It can be installed beside the standard app, keeps separate encrypted credentials and local data, and is intended only for trusted private-network deployments that cannot use HTTPS.
 
-### Two-layer HTTP policy
+### HTTP policy
 
-HTTP support uses two independent controls with different audiences:
+HTTP support uses two separate distribution paths:
 
-- **Build gate** (`ALLOW_INSECURE_HTTP_RELEASE` / `allowInsecureHttpRelease`): a distribution-policy control. Defaults to `true` in standard release builds. Set to `false` to produce a binary that rejects `http://` URLs entirely — suitable for organisational deployments that mandate HTTPS. When set to `false`, no inline warning is shown because HTTP cannot be entered.
-- **Inline warning**: user-awareness in the distributed APK. Shown whenever a valid `http://` URL is entered; does not block login.
+- **Standard APK**: HTTPS-only server URLs; system CA trust only.
+- **HTTP-enabled APK**: HTTP allowed; system + user CA trust. The URL-entry warning explains the cleartext-token risk and points users toward HTTPS alternatives such as Tailscale Serve or a reverse proxy.
+
+If a user installs the new standard APK over an older standard build that was already signed in to an `http://` server URL, MyDeck stops at startup on a migration screen. The screen offers switching to an HTTPS URL and signing in again, installing the separate HTTP-enabled APK, or signing out locally.
 
 ### Self-hosted HTTP use case
 
-The primary supported scenario for HTTP is a self-hosted Readeck instance accessed over [Tailscale](https://tailscale.com/), which provides WireGuard-based network-layer encryption. Traffic over Tailscale is encrypted in transit even without TLS, making the confidentiality risk comparable to HTTPS on a private network.
+The primary remaining scenario for HTTP is a self-hosted Readeck instance accessed on a trusted private network that cannot expose HTTPS. Tailscale users should prefer [Tailscale Serve](https://tailscale.com/docs/features/tailscale-serve), which can present a private tailnet HTTPS URL while proxying to a local HTTP service.
 
-### Build flags
+### Build variants
 
-Two build flags control network policy in custom builds. Both are set via Gradle property or matching environment variable:
+Network policy is selected by build variant:
 
-- `ALLOW_INSECURE_HTTP_RELEASE` / `allowInsecureHttpRelease` — controls whether `http://` URLs are accepted (default: `true`)
-- `ALLOW_USER_CA_RELEASE` / `allowUserCaRelease` — trusts user-installed certificate authorities for HTTPS servers signed by a private CA (default: `false`)
+- Standard variants (`githubRelease`, `githubSnapshot`) are HTTPS-only and trust system certificate authorities.
+- HTTP-enabled variants (`githubReleaseHttp`, `githubSnapshotHttp`) allow `http://` server URLs and trust system + user certificate authorities.
 
-These flags are documented in `.github/workflows/release.yml`.
+Official release workflows publish the standard HTTPS-only APK and a separately labeled HTTP-enabled APK instead of changing the standard artifact policy.
 
 ## Credential Storage
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,30 +9,12 @@ plugins {
     alias(libs.plugins.aboutLibraries)
 }
 
-fun booleanBuildFlag(propertyName: String, envName: String, default: Boolean = false): Boolean {
-    val configuredValue = providers.gradleProperty(propertyName).orNull ?: System.getenv(envName)
-    return if (configuredValue == null) default
-    else configuredValue.equals("true", ignoreCase = true)
-}
-
 fun networkSecurityConfigRef(allowHttp: Boolean, allowUserCa: Boolean): String = when {
     allowHttp && allowUserCa -> "@xml/network_security_config_insecure"
     allowHttp -> "@xml/network_security_config_http"
     allowUserCa -> "@xml/network_security_config_user_ca"
     else -> "@xml/network_security_config"
 }
-
-// Release builds stay secure by default. Self-hosted users can opt into weaker
-// network policy in custom builds via Gradle properties or matching env vars.
-val allowInsecureHttpRelease = booleanBuildFlag(
-    propertyName = "allowInsecureHttpRelease",
-    envName = "ALLOW_INSECURE_HTTP_RELEASE",
-    default = true
-)
-val allowUserCaRelease = booleanBuildFlag(
-    propertyName = "allowUserCaRelease",
-    envName = "ALLOW_USER_CA_RELEASE"
-)
 
 android {
     namespace = "com.mydeck.app"
@@ -77,12 +59,6 @@ android {
             isMinifyEnabled = true
             isShrinkResources = true
             isDebuggable = false
-            manifestPlaceholders["networkSecurityConfig"] = networkSecurityConfigRef(
-                allowHttp = allowInsecureHttpRelease,
-                allowUserCa = allowUserCaRelease
-            )
-            buildConfigField("boolean", "ALLOW_INSECURE_HTTP", allowInsecureHttpRelease.toString())
-            buildConfigField("boolean", "ALLOW_USER_CA_CERTIFICATES", allowUserCaRelease.toString())
             buildConfigField("boolean", "SHOW_CARD_INDEX_OVERLAY", "false")
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
@@ -98,12 +74,6 @@ android {
             isMinifyEnabled = false
             isShrinkResources = false
             isDebuggable = true
-            manifestPlaceholders["networkSecurityConfig"] = networkSecurityConfigRef(
-                allowHttp = true,
-                allowUserCa = true
-            )
-            buildConfigField("boolean", "ALLOW_INSECURE_HTTP", "true")
-            buildConfigField("boolean", "ALLOW_USER_CA_CERTIFICATES", "true")
             buildConfigField("boolean", "SHOW_CARD_INDEX_OVERLAY", "false")
         }
     }
@@ -115,6 +85,31 @@ android {
             applicationIdSuffix = ".snapshot"
             versionName = System.getenv("SNAPSHOT_VERSION_NAME") ?: "${defaultConfig.versionName}-snapshot"
             versionCode = System.getenv("SNAPSHOT_VERSION_CODE")?.toInt() ?: defaultConfig.versionCode
+            manifestPlaceholders["appLabel"] = "MyDeck Snapshot"
+            manifestPlaceholders["networkSecurityConfig"] = networkSecurityConfigRef(
+                allowHttp = false,
+                allowUserCa = false
+            )
+            buildConfigField("boolean", "ALLOW_INSECURE_HTTP", "false")
+            buildConfigField("boolean", "ALLOW_USER_CA_CERTIFICATES", "false")
+            buildConfigField("boolean", "IS_HTTP_ENABLED_BUILD", "false")
+            if (signingConfigs.getByName("release").storeFile != null) {
+                signingConfig = signingConfigs.getByName("release")
+            }
+        }
+        create("githubSnapshotHttp") {
+            dimension = "version"
+            applicationIdSuffix = ".snapshot.permissive"
+            versionName = System.getenv("SNAPSHOT_VERSION_NAME") ?: "${defaultConfig.versionName}-snapshot"
+            versionCode = System.getenv("SNAPSHOT_VERSION_CODE")?.toInt() ?: defaultConfig.versionCode
+            manifestPlaceholders["appLabel"] = "MyDeck HTTP Snapshot"
+            manifestPlaceholders["networkSecurityConfig"] = networkSecurityConfigRef(
+                allowHttp = true,
+                allowUserCa = true
+            )
+            buildConfigField("boolean", "ALLOW_INSECURE_HTTP", "true")
+            buildConfigField("boolean", "ALLOW_USER_CA_CERTIFICATES", "true")
+            buildConfigField("boolean", "IS_HTTP_ENABLED_BUILD", "true")
             if (signingConfigs.getByName("release").storeFile != null) {
                 signingConfig = signingConfigs.getByName("release")
             }
@@ -123,6 +118,31 @@ android {
             dimension = "version"
             versionName = System.getenv("RELEASE_VERSION_NAME") ?: defaultConfig.versionName
             versionCode = System.getenv("RELEASE_VERSION_CODE")?.toInt() ?: defaultConfig.versionCode
+            manifestPlaceholders["appLabel"] = "MyDeck"
+            manifestPlaceholders["networkSecurityConfig"] = networkSecurityConfigRef(
+                allowHttp = false,
+                allowUserCa = false
+            )
+            buildConfigField("boolean", "ALLOW_INSECURE_HTTP", "false")
+            buildConfigField("boolean", "ALLOW_USER_CA_CERTIFICATES", "false")
+            buildConfigField("boolean", "IS_HTTP_ENABLED_BUILD", "false")
+            if (signingConfigs.getByName("release").storeFile != null) {
+                signingConfig = signingConfigs.getByName("release")
+            }
+        }
+        create("githubReleaseHttp") {
+            dimension = "version"
+            applicationIdSuffix = ".permissive"
+            versionName = System.getenv("RELEASE_VERSION_NAME") ?: defaultConfig.versionName
+            versionCode = System.getenv("RELEASE_VERSION_CODE")?.toInt() ?: defaultConfig.versionCode
+            manifestPlaceholders["appLabel"] = "MyDeck HTTP"
+            manifestPlaceholders["networkSecurityConfig"] = networkSecurityConfigRef(
+                allowHttp = true,
+                allowUserCa = true
+            )
+            buildConfigField("boolean", "ALLOW_INSECURE_HTTP", "true")
+            buildConfigField("boolean", "ALLOW_USER_CA_CERTIFICATES", "true")
+            buildConfigField("boolean", "IS_HTTP_ENABLED_BUILD", "true")
             if (signingConfigs.getByName("release").storeFile != null) {
                 signingConfig = signingConfigs.getByName("release")
             }
@@ -174,7 +194,12 @@ android {
         outputs.all {
             val output = this
             if (output is com.android.build.gradle.internal.api.ApkVariantOutputImpl) {
-                val newName = "MyDeck-${variant.versionName}.apk"
+                val httpSuffix = if (variant.productFlavors.any { it.name.endsWith("Http") }) {
+                    "-http-enabled"
+                } else {
+                    ""
+                }
+                val newName = "MyDeck-${variant.versionName}$httpSuffix.apk"
                 output.outputFileName = newName
             }
         }
@@ -284,7 +309,9 @@ tasks.register("assembleDebugAll") {
     description = "Assembles all debug flavor variants."
     dependsOn(
         ":app:assembleGithubReleaseDebug",
-        ":app:assembleGithubSnapshotDebug"
+        ":app:assembleGithubReleaseHttpDebug",
+        ":app:assembleGithubSnapshotDebug",
+        ":app:assembleGithubSnapshotHttpDebug"
     )
 }
 
@@ -293,7 +320,9 @@ tasks.register("testDebugUnitTestAll") {
     description = "Runs unit tests for all debug flavor variants."
     dependsOn(
         ":app:testGithubReleaseDebugUnitTest",
-        ":app:testGithubSnapshotDebugUnitTest"
+        ":app:testGithubReleaseHttpDebugUnitTest",
+        ":app:testGithubSnapshotDebugUnitTest",
+        ":app:testGithubSnapshotHttpDebugUnitTest"
     )
 }
 
@@ -302,7 +331,9 @@ tasks.register("lintDebugAll") {
     description = "Runs lint for all debug flavor variants."
     dependsOn(
         ":app:lintGithubReleaseDebug",
-        ":app:lintGithubSnapshotDebug"
+        ":app:lintGithubReleaseHttpDebug",
+        ":app:lintGithubSnapshotDebug",
+        ":app:lintGithubSnapshotHttpDebug"
     )
 }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
         android:fullBackupContent="@xml/backup_rules"
         android:networkSecurityConfig="${networkSecurityConfig}"
         android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name"
+        android:label="${appLabel}"
         android:supportsRtl="true"
         android:theme="@style/Theme.MyDeck"
         tools:targetApi="31">
@@ -23,7 +23,7 @@
             android:name=".MainActivity"
             android:configChanges="screenLayout|orientation|screenSize|keyboard|keyboardHidden|smallestScreenSize"
             android:exported="true"
-            android:label="@string/app_name"
+            android:label="${appLabel}"
             android:theme="@style/Theme.MyDeck.Starting">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/assets/guide/en/getting-started.md
+++ b/app/src/main/assets/guide/en/getting-started.md
@@ -8,7 +8,9 @@ To use MyDeck you need access to a running Readeck server.
 
 When you first open MyDeck, you'll see the welcome screen with a **Readeck URL** field pre-filled with `https://`. Enter the address of your Readeck server — for example, `https://readeck.example.com` — and tap **Connect**.
 
-`http://` URLs are also accepted. If you enter one, a warning will appear below the field noting that the connection is insecure. This is intended for self-hosted setups on a trusted private network — for example, accessing Readeck over [Tailscale](https://tailscale.com/), which encrypts traffic at the network layer even without HTTPS. You can still connect by tapping **Connect** after the warning appears.
+The standard MyDeck app accepts `https://` URLs only. If you enter an `http://` address, it is rejected — your OAuth token would otherwise travel over the network in cleartext. For self-hosted setups on a trusted private network, the recommended path is to put HTTPS in front of Readeck — for example, [Tailscale Serve](https://tailscale.com/docs/features/tailscale-serve) presents an HTTPS tailnet URL while proxying to a local HTTP service, or a reverse proxy can terminate TLS.
+
+A separate **HTTP-enabled APK** is published for setups that genuinely cannot use HTTPS (for example, connecting directly to a tailnet IP over HTTP). It installs alongside the standard app as its own package and shows an insecure-connection warning when you enter an `http://` URL.
 
 If the URL is invalid or the server cannot be reached, an error message will appear below the field. Double-check the address and make sure your device has network access to the server.
 

--- a/app/src/main/assets/guide/en/settings.md
+++ b/app/src/main/assets/guide/en/settings.md
@@ -13,7 +13,7 @@ The **Account** option in the drawer shows your username. Tapping it opens the *
 
 ## Server URL Security
 
-The standard MyDeck app accepts HTTPS Readeck server URLs only. If an older install was already signed in to an `http://` server URL, MyDeck shows a startup screen with three choices: change the saved server URL to HTTPS, install the separate HTTP-enabled APK, or sign out.
+The standard MyDeck app accepts HTTPS Readeck server URLs only. If an older install was already signed in to an `http://` server URL, MyDeck shows a startup screen with two choices: switch to an HTTPS URL and sign in again, or install the separate HTTP-enabled APK.
 
 The HTTP-enabled APK is for trusted private-network setups that cannot use HTTPS. It installs beside the standard app and keeps separate credentials and local data.
 

--- a/app/src/main/assets/guide/en/settings.md
+++ b/app/src/main/assets/guide/en/settings.md
@@ -11,6 +11,12 @@ The **Account** option in the drawer shows your username. Tapping it opens the *
 
 > **Note:** Signing out removes all local bookmark data. Everything is stored on the server so the data will still be available the next time you sign into the same server.
 
+## Server URL Security
+
+The standard MyDeck app accepts HTTPS Readeck server URLs only. If an older install was already signed in to an `http://` server URL, MyDeck shows a startup screen with three choices: change the saved server URL to HTTPS, install the separate HTTP-enabled APK, or sign out.
+
+The HTTP-enabled APK is for trusted private-network setups that cannot use HTTPS. It installs beside the standard app and keeps separate credentials and local data.
+
 ## Synchronization
 
 The **Synchronization Settings** screen controls how MyDeck keeps your bookmarks and their content in sync with the Readeck server.

--- a/app/src/main/java/com/mydeck/app/MainActivity.kt
+++ b/app/src/main/java/com/mydeck/app/MainActivity.kt
@@ -22,6 +22,7 @@ import com.mydeck.app.ui.navigation.BookmarkDetailRoute
 import com.mydeck.app.ui.shell.AppShell
 import com.mydeck.app.ui.theme.MyDeckTheme
 import com.mydeck.app.io.prefs.SettingsDataStore
+import com.mydeck.app.ui.migration.HttpUrlMigrationScreen
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -45,6 +46,7 @@ class MainActivity : ComponentActivity() {
             val theme = viewModel.theme.collectAsState()
             val lightAppearance = viewModel.lightAppearance.collectAsState()
             val darkAppearance = viewModel.darkAppearance.collectAsState()
+            val httpUrlMigrationState = viewModel.httpUrlMigrationState.collectAsState()
             val navController = rememberNavController()
             intentState = remember { mutableStateOf(intent) }
 
@@ -76,7 +78,11 @@ class MainActivity : ComponentActivity() {
             )
 
             MyDeckTheme(appearance = effectiveAppearance) {
-                AppShell(navController, settingsDataStore)
+                if (httpUrlMigrationState.value is MainViewModel.HttpUrlMigrationState.Required) {
+                    HttpUrlMigrationScreen()
+                } else {
+                    AppShell(navController, settingsDataStore)
+                }
             }
         }
     }

--- a/app/src/main/java/com/mydeck/app/MainViewModel.kt
+++ b/app/src/main/java/com/mydeck/app/MainViewModel.kt
@@ -7,6 +7,7 @@ import com.mydeck.app.domain.model.DarkAppearance
 import com.mydeck.app.domain.model.LightAppearance
 import com.mydeck.app.domain.model.Theme
 import com.mydeck.app.io.prefs.SettingsDataStore
+import com.mydeck.app.io.rest.ReadeckNetworkPolicy
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
@@ -18,11 +19,35 @@ import javax.inject.Inject
 class MainViewModel @Inject constructor(
     val settingsDataStore: SettingsDataStore
 ): ViewModel() {
+    sealed interface HttpUrlMigrationState {
+        data object Checking : HttpUrlMigrationState
+        data object NotRequired : HttpUrlMigrationState
+        data class Required(val savedUrl: String) : HttpUrlMigrationState
+    }
+
+    val httpUrlMigrationState: StateFlow<HttpUrlMigrationState> = combine(
+        settingsDataStore.tokenFlow,
+        settingsDataStore.urlFlow
+    ) { token, url ->
+        if (!token.isNullOrBlank() &&
+            ReadeckNetworkPolicy.isSavedHttpUrlBlocked(url, BuildConfig.ALLOW_INSECURE_HTTP)
+        ) {
+            HttpUrlMigrationState.Required(url.orEmpty())
+        } else {
+            HttpUrlMigrationState.NotRequired
+        }
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.Eagerly,
+        initialValue = HttpUrlMigrationState.Checking
+    )
+
     val isReady: StateFlow<Boolean> = combine(
         settingsDataStore.themeFlow,
         settingsDataStore.lightAppearanceFlow,
         settingsDataStore.darkAppearanceFlow,
-    ) { _, _, _ -> true }
+        httpUrlMigrationState,
+    ) { _, _, _, migrationState -> migrationState !is HttpUrlMigrationState.Checking }
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.Eagerly,

--- a/app/src/main/java/com/mydeck/app/domain/UserRepository.kt
+++ b/app/src/main/java/com/mydeck/app/domain/UserRepository.kt
@@ -29,6 +29,7 @@ interface UserRepository {
             val ex: Exception? = null
         ) : LoginResult()
         data class NetworkError(val errorMessage: String) : LoginResult()
+        data object HttpBlockedByBuildPolicy : LoginResult()
     }
 
     sealed class LogoutResult {

--- a/app/src/main/java/com/mydeck/app/domain/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/mydeck/app/domain/UserRepositoryImpl.kt
@@ -4,8 +4,11 @@ import com.mydeck.app.domain.model.AuthenticationDetails
 import com.mydeck.app.domain.model.CachedServerInfo
 import com.mydeck.app.domain.model.User
 import com.mydeck.app.domain.usecase.OAuthDeviceAuthorizationUseCase
+import com.mydeck.app.BuildConfig
 import com.mydeck.app.io.prefs.SettingsDataStore
 import com.mydeck.app.io.rest.ReadeckApi
+import com.mydeck.app.io.rest.ReadeckNetworkPolicy
+import com.mydeck.app.io.rest.isHttpBlockedByBuildPolicy
 import com.mydeck.app.io.rest.model.OAuthRevokeRequestDto
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -86,6 +89,10 @@ class UserRepositoryImpl @Inject constructor(
                         Timber.d("Device authorization required")
                         UserRepository.LoginResult.DeviceAuthorizationRequired(result.state)
                     }
+                    is OAuthDeviceAuthorizationUseCase.DeviceAuthResult.HttpBlockedByBuildPolicy -> {
+                        settingsDataStore.clearCredentials()
+                        UserRepository.LoginResult.HttpBlockedByBuildPolicy
+                    }
                     is OAuthDeviceAuthorizationUseCase.DeviceAuthResult.Error -> {
                         Timber.e("Device authorization failed: ${result.message}")
                         settingsDataStore.clearCredentials()
@@ -94,7 +101,11 @@ class UserRepositoryImpl @Inject constructor(
                 }
             } catch (e: IOException) {
                 settingsDataStore.clearCredentials()
-                UserRepository.LoginResult.NetworkError("Network error: ${e.message}")
+                if (e.isHttpBlockedByBuildPolicy()) {
+                    UserRepository.LoginResult.HttpBlockedByBuildPolicy
+                } else {
+                    UserRepository.LoginResult.NetworkError("Network error: ${e.message}")
+                }
             } catch (e: Exception) {
                 settingsDataStore.clearCredentials()
                 UserRepository.LoginResult.Error(
@@ -143,10 +154,14 @@ class UserRepositoryImpl @Inject constructor(
             } catch (e: Exception) {
                 Timber.e(e, "Failed to complete login")
                 settingsDataStore.clearCredentials()
-                UserRepository.LoginResult.Error(
-                    "Failed to complete login: ${e.message}",
-                    ex = e
-                )
+                if (e.isHttpBlockedByBuildPolicy()) {
+                    UserRepository.LoginResult.HttpBlockedByBuildPolicy
+                } else {
+                    UserRepository.LoginResult.Error(
+                        "Failed to complete login: ${e.message}",
+                        ex = e
+                    )
+                }
             }
         }
     }
@@ -159,8 +174,9 @@ class UserRepositoryImpl @Inject constructor(
         return withContext(Dispatchers.IO) {
             try {
                 val token = settingsDataStore.tokenFlow.first()
+                val url = settingsDataStore.urlFlow.first()
 
-                if (token != null) {
+                if (token != null && !ReadeckNetworkPolicy.isSavedHttpUrlBlocked(url, BuildConfig.ALLOW_INSECURE_HTTP)) {
                     try {
                         val response = readeckApi.revokeToken(
                             OAuthRevokeRequestDto(token = token)
@@ -174,6 +190,8 @@ class UserRepositoryImpl @Inject constructor(
                         Timber.e(e, "Failed to revoke token")
                         // Continue with local logout (fail open)
                     }
+                } else if (token != null) {
+                    Timber.i("Skipping token revocation because HTTP is blocked in this build")
                 }
 
                 settingsDataStore.clearCredentials()

--- a/app/src/main/java/com/mydeck/app/domain/usecase/OAuthDeviceAuthorizationUseCase.kt
+++ b/app/src/main/java/com/mydeck/app/domain/usecase/OAuthDeviceAuthorizationUseCase.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.os.Build
 import com.mydeck.app.domain.model.OAuthDeviceAuthorizationState
 import com.mydeck.app.io.rest.ReadeckApi
+import com.mydeck.app.io.rest.isHttpBlockedByBuildPolicy
 import com.mydeck.app.io.rest.model.*
 import com.mydeck.app.util.AppVersion
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -35,6 +36,7 @@ class OAuthDeviceAuthorizationUseCase @Inject constructor(
 
     sealed class DeviceAuthResult {
         data class AuthorizationRequired(val state: OAuthDeviceAuthorizationState) : DeviceAuthResult()
+        data object HttpBlockedByBuildPolicy : DeviceAuthResult()
         data class Error(val message: String, val exception: Exception? = null) : DeviceAuthResult()
     }
 
@@ -45,6 +47,7 @@ class OAuthDeviceAuthorizationUseCase @Inject constructor(
         data class Expired(val message: String) : TokenPollResult()
         data class SlowDown(val newInterval: Int) : TokenPollResult()
         data class NetworkError(val message: String, val exception: Exception? = null) : TokenPollResult()
+        data object HttpBlockedByBuildPolicy : TokenPollResult()
         data class Error(val message: String, val exception: Exception? = null) : TokenPollResult()
     }
 
@@ -113,6 +116,10 @@ class OAuthDeviceAuthorizationUseCase @Inject constructor(
             return DeviceAuthResult.AuthorizationRequired(state)
 
         } catch (e: IOException) {
+            if (e.isHttpBlockedByBuildPolicy()) {
+                Timber.w(e, "HTTP blocked during device authorization")
+                return DeviceAuthResult.HttpBlockedByBuildPolicy
+            }
             Timber.e(e, "Network error during device authorization")
             return DeviceAuthResult.Error("Network error: ${e.message}", e)
         } catch (e: SerializationException) {
@@ -208,6 +215,10 @@ class OAuthDeviceAuthorizationUseCase @Inject constructor(
             }
 
         } catch (e: IOException) {
+            if (e.isHttpBlockedByBuildPolicy()) {
+                Timber.w(e, "HTTP blocked while polling for token")
+                return TokenPollResult.HttpBlockedByBuildPolicy
+            }
             Timber.w(e, "Network error while polling for token (retryable)")
             return TokenPollResult.NetworkError("Network error: ${e.message}", e)
         } catch (e: SerializationException) {

--- a/app/src/main/java/com/mydeck/app/io/rest/NetworkModule.kt
+++ b/app/src/main/java/com/mydeck/app/io/rest/NetworkModule.kt
@@ -24,6 +24,7 @@ import retrofit2.converter.scalars.ScalarsConverterFactory
 import retrofit2.create
 import timber.log.Timber
 import java.io.File
+import javax.inject.Named
 import javax.inject.Singleton
 
 @Module
@@ -32,7 +33,8 @@ object NetworkModule {
 
     @Provides
     @Singleton
-    fun provideOkHttpClient(
+    @Named("readeckApi")
+    fun provideReadeckOkHttpClient(
         authInterceptor: AuthInterceptor,
         baseUrlInterceptor: UrlInterceptor
     ): OkHttpClient {
@@ -40,6 +42,7 @@ object NetworkModule {
             .connectTimeout(3, java.util.concurrent.TimeUnit.SECONDS)
             .addInterceptor(authInterceptor)
             .addInterceptor(baseUrlInterceptor)
+            .addInterceptor(ReadeckHttpPolicyInterceptor(BuildConfig.ALLOW_INSECURE_HTTP))
 
         if (BuildConfig.DEBUG) {
             // Route OkHttp wire logs through Timber so they land in the on-device
@@ -65,6 +68,7 @@ object NetworkModule {
     @Provides
     @Singleton
     fun provideRetrofit(
+        @Named("readeckApi")
         okHttpClient: OkHttpClient,
         json: Json
     ): Retrofit {

--- a/app/src/main/java/com/mydeck/app/io/rest/ReadeckHttpPolicyInterceptor.kt
+++ b/app/src/main/java/com/mydeck/app/io/rest/ReadeckHttpPolicyInterceptor.kt
@@ -1,0 +1,39 @@
+package com.mydeck.app.io.rest
+
+import okhttp3.HttpUrl
+import okhttp3.Interceptor
+import okhttp3.Response
+import java.io.IOException
+
+class ReadeckHttpPolicyInterceptor(
+    private val allowInsecureHttp: Boolean
+) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        if (!allowInsecureHttp && request.url.scheme.equals("http", ignoreCase = true)) {
+            throw HttpBlockedByBuildPolicyException(request.url)
+        }
+        return chain.proceed(request)
+    }
+}
+
+class HttpBlockedByBuildPolicyException(
+    url: HttpUrl
+) : IOException("HTTP Readeck server URLs are not allowed in this MyDeck build: ${url.host}")
+
+fun Throwable.isHttpBlockedByBuildPolicy(): Boolean {
+    var current: Throwable? = this
+    while (current != null) {
+        if (current is HttpBlockedByBuildPolicyException) {
+            return true
+        }
+        current = current.cause
+    }
+    return false
+}
+
+object ReadeckNetworkPolicy {
+    fun isSavedHttpUrlBlocked(url: String?, allowInsecureHttp: Boolean): Boolean {
+        return !allowInsecureHttp && url?.trimStart()?.startsWith("http://", ignoreCase = true) == true
+    }
+}

--- a/app/src/main/java/com/mydeck/app/ui/about/AboutScreen.kt
+++ b/app/src/main/java/com/mydeck/app/ui/about/AboutScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
+import com.mydeck.app.BuildConfig
 import com.mydeck.app.R
 import com.mydeck.app.util.AppVersion
 import com.mydeck.app.domain.model.CachedServerInfo
@@ -238,11 +239,23 @@ fun AboutScreenContent(
                 Build.MANUFACTURER,
                 Build.MODEL
             )
+            val serverUrlPolicy = if (BuildConfig.ALLOW_INSECURE_HTTP) {
+                stringResource(R.string.about_network_policy_server_urls_http_allowed)
+            } else {
+                stringResource(R.string.about_network_policy_server_urls_https_only)
+            }
+            val certificatePolicy = if (BuildConfig.ALLOW_USER_CA_CERTIFICATES) {
+                stringResource(R.string.about_network_policy_https_trust_system_user)
+            } else {
+                stringResource(R.string.about_network_policy_https_trust_system)
+            }
             val appDetailLines = listOf(
                 appInfoSummary,
                 stringResource(R.string.about_system_info_build_time, appBuildTime),
                 appAndroid,
-                appDevice
+                appDevice,
+                stringResource(R.string.about_network_policy_server_urls, serverUrlPolicy),
+                stringResource(R.string.about_network_policy_https_trust, certificatePolicy)
             )
 
             CollapsibleInfoCard(

--- a/app/src/main/java/com/mydeck/app/ui/list/BookmarkListViewModel.kt
+++ b/app/src/main/java/com/mydeck/app/ui/list/BookmarkListViewModel.kt
@@ -9,6 +9,7 @@ import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import com.mydeck.app.BuildConfig
 import com.mydeck.app.R
 import com.mydeck.app.domain.BookmarkRepository
 import com.mydeck.app.domain.model.Bookmark
@@ -25,6 +26,7 @@ import com.mydeck.app.domain.sync.OfflinePolicyEvaluator
 import com.mydeck.app.domain.usecase.FullSyncUseCase
 import com.mydeck.app.domain.usecase.UpdateBookmarkUseCase
 import com.mydeck.app.io.prefs.SettingsDataStore
+import com.mydeck.app.io.rest.ReadeckNetworkPolicy
 import com.mydeck.app.util.extractUrlAndTitle
 import com.mydeck.app.util.formatBookmarkShareText
 import com.mydeck.app.util.isValidUrl
@@ -137,6 +139,10 @@ class BookmarkListViewModel @Inject constructor(
         viewModelScope.launch {
             val url = settingsDataStore.urlFlow.first()
             val syncOnAppOpenEnabled = settingsDataStore.isSyncOnAppOpenEnabled()
+            if (ReadeckNetworkPolicy.isSavedHttpUrlBlocked(url, BuildConfig.ALLOW_INSECURE_HTTP)) {
+                Timber.i("Skipping app-open sync because HTTP is blocked in this build")
+                return@launch
+            }
             if (!url.isNullOrBlank() && syncOnAppOpenEnabled) {
                 loadBookmarks(LoadTrigger.APP_OPEN)
             }

--- a/app/src/main/java/com/mydeck/app/ui/migration/HttpUrlMigrationLoginCoordinator.kt
+++ b/app/src/main/java/com/mydeck/app/ui/migration/HttpUrlMigrationLoginCoordinator.kt
@@ -1,0 +1,20 @@
+package com.mydeck.app.ui.migration
+
+import java.util.concurrent.atomic.AtomicReference
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class HttpUrlMigrationLoginCoordinator @Inject constructor() {
+    private val pendingLoginUrl = AtomicReference<String?>()
+
+    fun requestLogin(normalizedUrl: String) {
+        pendingLoginUrl.set(normalizedUrl)
+    }
+
+    fun cancelLogin(normalizedUrl: String) {
+        pendingLoginUrl.compareAndSet(normalizedUrl, null)
+    }
+
+    fun consumePendingLoginUrl(): String? = pendingLoginUrl.getAndSet(null)
+}

--- a/app/src/main/java/com/mydeck/app/ui/migration/HttpUrlMigrationScreen.kt
+++ b/app/src/main/java/com/mydeck/app/ui/migration/HttpUrlMigrationScreen.kt
@@ -5,10 +5,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -54,7 +52,6 @@ fun HttpUrlMigrationScreen(
         onInstallHttpEnabled = { openUrlInCustomTab(context, MYDECK_RELEASES_URL) },
         onOpenTailscaleServe = { openUrlInCustomTab(context, TAILSCALE_SERVE_URL) },
         onOpenReadeckProxyDocs = { openUrlInCustomTab(context, READECK_PROXY_DOCS_URL) },
-        onLogOut = viewModel::logOut,
     )
 }
 
@@ -66,7 +63,6 @@ fun HttpUrlMigrationScreenContent(
     onInstallHttpEnabled: () -> Unit,
     onOpenTailscaleServe: () -> Unit,
     onOpenReadeckProxyDocs: () -> Unit,
-    onLogOut: () -> Unit,
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
 
@@ -142,21 +138,6 @@ fun HttpUrlMigrationScreenContent(
                         modifier = Modifier.fillMaxWidth()
                     ) {
                         Text(stringResource(R.string.http_migration_http_apk_action))
-                    }
-                }
-            }
-
-            item {
-                MigrationSection(
-                    title = stringResource(R.string.http_migration_logout_title),
-                    body = stringResource(R.string.http_migration_logout_body)
-                ) {
-                    OutlinedButton(
-                        onClick = onLogOut,
-                        enabled = !uiState.isBusy,
-                        modifier = Modifier.fillMaxWidth()
-                    ) {
-                        Text(stringResource(R.string.account_settings_sign_out))
                     }
                 }
             }

--- a/app/src/main/java/com/mydeck/app/ui/migration/HttpUrlMigrationScreen.kt
+++ b/app/src/main/java/com/mydeck/app/ui/migration/HttpUrlMigrationScreen.kt
@@ -1,0 +1,227 @@
+package com.mydeck.app.ui.migration
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.OpenInNew
+import androidx.compose.material3.Button
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.mydeck.app.R
+import com.mydeck.app.util.openUrlInCustomTab
+
+private const val TAILSCALE_SERVE_URL = "https://tailscale.com/docs/features/tailscale-serve"
+private const val READECK_PROXY_DOCS_URL = "https://readeck.org/en/docs/configuration"
+private const val MYDECK_RELEASES_URL = "https://github.com/NateEaton/mydeck-android/releases/latest"
+
+@Composable
+fun HttpUrlMigrationScreen(
+    viewModel: HttpUrlMigrationViewModel = hiltViewModel()
+) {
+    val uiState = viewModel.uiState.collectAsState().value
+    val context = LocalContext.current
+    HttpUrlMigrationScreenContent(
+        uiState = uiState,
+        onReplacementUrlChanged = viewModel::updateReplacementUrl,
+        onSaveReplacementUrl = viewModel::saveReplacementUrl,
+        onInstallHttpEnabled = { openUrlInCustomTab(context, MYDECK_RELEASES_URL) },
+        onOpenTailscaleServe = { openUrlInCustomTab(context, TAILSCALE_SERVE_URL) },
+        onOpenReadeckProxyDocs = { openUrlInCustomTab(context, READECK_PROXY_DOCS_URL) },
+        onLogOut = viewModel::logOut,
+    )
+}
+
+@Composable
+fun HttpUrlMigrationScreenContent(
+    uiState: HttpUrlMigrationViewModel.UiState,
+    onReplacementUrlChanged: (String) -> Unit,
+    onSaveReplacementUrl: () -> Unit,
+    onInstallHttpEnabled: () -> Unit,
+    onOpenTailscaleServe: () -> Unit,
+    onOpenReadeckProxyDocs: () -> Unit,
+    onLogOut: () -> Unit,
+) {
+    val keyboardController = LocalSoftwareKeyboardController.current
+
+    Scaffold { padding ->
+        LazyColumn(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize(),
+            contentPadding = PaddingValues(20.dp),
+            verticalArrangement = Arrangement.spacedBy(20.dp)
+        ) {
+            item {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(
+                        text = stringResource(R.string.http_migration_title),
+                        style = MaterialTheme.typography.headlineSmall
+                    )
+                    Text(
+                        text = stringResource(R.string.http_migration_body, uiState.savedUrl),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+
+            item {
+                MigrationSection(
+                    title = stringResource(R.string.http_migration_https_title),
+                    body = stringResource(R.string.http_migration_https_body)
+                ) {
+                    OutlinedTextField(
+                        value = uiState.replacementUrl,
+                        onValueChange = onReplacementUrlChanged,
+                        label = { Text(stringResource(R.string.account_settings_url_label)) },
+                        placeholder = { Text(stringResource(R.string.account_settings_url_placeholder)) },
+                        modifier = Modifier.fillMaxWidth(),
+                        singleLine = true,
+                        enabled = !uiState.isBusy,
+                        isError = uiState.urlError != null,
+                        supportingText = {
+                            uiState.urlError?.let { Text(stringResource(it)) }
+                        },
+                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                        keyboardActions = KeyboardActions(
+                            onDone = {
+                                keyboardController?.hide()
+                                onSaveReplacementUrl()
+                            }
+                        )
+                    )
+                    Button(
+                        onClick = onSaveReplacementUrl,
+                        enabled = !uiState.isBusy && uiState.urlError == null,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text(stringResource(R.string.http_migration_https_action))
+                    }
+                    LinkButtonRow(
+                        onOpenTailscaleServe = onOpenTailscaleServe,
+                        onOpenReadeckProxyDocs = onOpenReadeckProxyDocs
+                    )
+                }
+            }
+
+            item {
+                MigrationSection(
+                    title = stringResource(R.string.http_migration_http_apk_title),
+                    body = stringResource(R.string.http_migration_http_apk_body)
+                ) {
+                    OutlinedButton(
+                        onClick = onInstallHttpEnabled,
+                        enabled = !uiState.isBusy,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text(stringResource(R.string.http_migration_http_apk_action))
+                    }
+                }
+            }
+
+            item {
+                MigrationSection(
+                    title = stringResource(R.string.http_migration_logout_title),
+                    body = stringResource(R.string.http_migration_logout_body)
+                ) {
+                    OutlinedButton(
+                        onClick = onLogOut,
+                        enabled = !uiState.isBusy,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text(stringResource(R.string.account_settings_sign_out))
+                    }
+                }
+            }
+
+            if (uiState.actionError != null) {
+                item {
+                    Text(
+                        text = stringResource(uiState.actionError),
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MigrationSection(
+    title: String,
+    body: String,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        HorizontalDivider()
+        Text(text = title, style = MaterialTheme.typography.titleMedium)
+        Text(
+            text = body,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        content()
+    }
+}
+
+@Composable
+private fun LinkButtonRow(
+    onOpenTailscaleServe: () -> Unit,
+    onOpenReadeckProxyDocs: () -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        TextButton(onClick = onOpenTailscaleServe, contentPadding = PaddingValues(horizontal = 0.dp)) {
+            Row {
+                Text(stringResource(R.string.http_migration_tailscale_link))
+                Icon(
+                    Icons.Filled.OpenInNew,
+                    contentDescription = null,
+                    modifier = Modifier
+                        .padding(start = 6.dp)
+                        .size(18.dp)
+                )
+            }
+        }
+        TextButton(onClick = onOpenReadeckProxyDocs, contentPadding = PaddingValues(horizontal = 0.dp)) {
+            Row {
+                Text(stringResource(R.string.http_migration_readeck_proxy_link))
+                Icon(
+                    Icons.Filled.OpenInNew,
+                    contentDescription = null,
+                    modifier = Modifier
+                        .padding(start = 6.dp)
+                        .size(18.dp)
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/mydeck/app/ui/migration/HttpUrlMigrationViewModel.kt
+++ b/app/src/main/java/com/mydeck/app/ui/migration/HttpUrlMigrationViewModel.kt
@@ -56,27 +56,21 @@ class HttpUrlMigrationViewModel @Inject constructor(
             _uiState.update { it.copy(isBusy = true, actionError = null) }
             try {
                 val normalizedUrl = normalizeApiUrl(value)
-                settingsDataStore.clearCredentials()
+                val logoutResult = userRepository.logout()
+                if (logoutResult is UserRepository.LogoutResult.Error) {
+                    _uiState.update {
+                        it.copy(
+                            isBusy = false,
+                            actionError = R.string.http_migration_save_error
+                        )
+                    }
+                    return@launch
+                }
                 settingsDataStore.saveUrl(normalizedUrl)
             } catch (_: Exception) {
                 _uiState.update { it.copy(actionError = R.string.http_migration_save_error) }
             } finally {
                 _uiState.update { it.copy(isBusy = false) }
-            }
-        }
-    }
-
-    fun logOut() {
-        viewModelScope.launch {
-            _uiState.update { it.copy(isBusy = true, actionError = null) }
-            val result = userRepository.logout()
-            if (result is UserRepository.LogoutResult.Error) {
-                _uiState.update {
-                    it.copy(
-                        isBusy = false,
-                        actionError = R.string.http_migration_logout_error
-                    )
-                }
             }
         }
     }

--- a/app/src/main/java/com/mydeck/app/ui/migration/HttpUrlMigrationViewModel.kt
+++ b/app/src/main/java/com/mydeck/app/ui/migration/HttpUrlMigrationViewModel.kt
@@ -1,0 +1,103 @@
+package com.mydeck.app.ui.migration
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.mydeck.app.R
+import com.mydeck.app.domain.UserRepository
+import com.mydeck.app.io.prefs.SettingsDataStore
+import com.mydeck.app.util.isValidUrl
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class HttpUrlMigrationViewModel @Inject constructor(
+    private val settingsDataStore: SettingsDataStore,
+    private val userRepository: UserRepository,
+) : ViewModel() {
+    data class UiState(
+        val savedUrl: String = "",
+        val replacementUrl: String = "https://",
+        val urlError: Int? = null,
+        val actionError: Int? = null,
+        val isBusy: Boolean = false,
+    )
+
+    private val _uiState = MutableStateFlow(
+        UiState(
+            savedUrl = settingsDataStore.urlFlow.value.orEmpty(),
+            replacementUrl = toDisplayHttpsUrl(settingsDataStore.urlFlow.value)
+        )
+    )
+    val uiState: StateFlow<UiState> = _uiState.asStateFlow()
+
+    fun updateReplacementUrl(value: String) {
+        _uiState.update {
+            it.copy(
+                replacementUrl = value,
+                urlError = if (value.isValidUrl(allowHttp = false)) null else R.string.account_settings_url_error,
+                actionError = null
+            )
+        }
+    }
+
+    fun saveReplacementUrl() {
+        val value = _uiState.value.replacementUrl
+        if (!value.isValidUrl(allowHttp = false)) {
+            _uiState.update { it.copy(urlError = R.string.account_settings_url_error) }
+            return
+        }
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isBusy = true, actionError = null) }
+            try {
+                val normalizedUrl = normalizeApiUrl(value)
+                settingsDataStore.clearCredentials()
+                settingsDataStore.saveUrl(normalizedUrl)
+            } catch (_: Exception) {
+                _uiState.update { it.copy(actionError = R.string.http_migration_save_error) }
+            } finally {
+                _uiState.update { it.copy(isBusy = false) }
+            }
+        }
+    }
+
+    fun logOut() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isBusy = true, actionError = null) }
+            val result = userRepository.logout()
+            if (result is UserRepository.LogoutResult.Error) {
+                _uiState.update {
+                    it.copy(
+                        isBusy = false,
+                        actionError = R.string.http_migration_logout_error
+                    )
+                }
+            }
+        }
+    }
+
+    private fun normalizeApiUrl(rawUrl: String): String {
+        var url = rawUrl.trimEnd('/')
+        if (!url.endsWith("/api")) {
+            url = "$url/api"
+        }
+        return url
+    }
+
+    private fun toDisplayHttpsUrl(rawUrl: String?): String {
+        val display = rawUrl
+            ?.trimEnd('/')
+            ?.removeSuffix("/api")
+            .orEmpty()
+        return if (display.startsWith("http://", ignoreCase = true)) {
+            "https://" + display.substringAfter("://")
+        } else {
+            "https://"
+        }
+    }
+}

--- a/app/src/main/java/com/mydeck/app/ui/migration/HttpUrlMigrationViewModel.kt
+++ b/app/src/main/java/com/mydeck/app/ui/migration/HttpUrlMigrationViewModel.kt
@@ -18,6 +18,7 @@ import javax.inject.Inject
 class HttpUrlMigrationViewModel @Inject constructor(
     private val settingsDataStore: SettingsDataStore,
     private val userRepository: UserRepository,
+    private val loginCoordinator: HttpUrlMigrationLoginCoordinator,
 ) : ViewModel() {
     data class UiState(
         val savedUrl: String = "",
@@ -54,10 +55,12 @@ class HttpUrlMigrationViewModel @Inject constructor(
 
         viewModelScope.launch {
             _uiState.update { it.copy(isBusy = true, actionError = null) }
+            val normalizedUrl = normalizeApiUrl(value)
+            loginCoordinator.requestLogin(normalizedUrl)
             try {
-                val normalizedUrl = normalizeApiUrl(value)
                 val logoutResult = userRepository.logout()
                 if (logoutResult is UserRepository.LogoutResult.Error) {
+                    loginCoordinator.cancelLogin(normalizedUrl)
                     _uiState.update {
                         it.copy(
                             isBusy = false,
@@ -68,6 +71,7 @@ class HttpUrlMigrationViewModel @Inject constructor(
                 }
                 settingsDataStore.saveUrl(normalizedUrl)
             } catch (_: Exception) {
+                loginCoordinator.cancelLogin(normalizedUrl)
                 _uiState.update { it.copy(actionError = R.string.http_migration_save_error) }
             } finally {
                 _uiState.update { it.copy(isBusy = false) }

--- a/app/src/main/java/com/mydeck/app/ui/settings/AccountSettingsScreen.kt
+++ b/app/src/main/java/com/mydeck/app/ui/settings/AccountSettingsScreen.kt
@@ -97,7 +97,7 @@ fun AccountSettingsScreen(
                         settingsUiState.urlError != null ->
                             Text(text = stringResource(settingsUiState.urlError))
                         settingsUiState.urlWarning != null ->
-                            Text(text = stringResource(settingsUiState.urlWarning))
+                            HttpUrlWarningText()
                     }
                 }
             )

--- a/app/src/main/java/com/mydeck/app/ui/settings/AccountSettingsViewModel.kt
+++ b/app/src/main/java/com/mydeck/app/ui/settings/AccountSettingsViewModel.kt
@@ -10,6 +10,7 @@ import com.mydeck.app.domain.UserRepository
 import com.mydeck.app.domain.model.OAuthDeviceAuthorizationState
 import com.mydeck.app.domain.usecase.OAuthDeviceAuthorizationUseCase
 import com.mydeck.app.io.prefs.SettingsDataStore
+import com.mydeck.app.ui.migration.HttpUrlMigrationLoginCoordinator
 import com.mydeck.app.worker.LoadBookmarksWorker
 import com.mydeck.app.util.isValidUrl
 import com.mydeck.app.coroutine.ApplicationScope
@@ -45,7 +46,8 @@ class AccountSettingsViewModel @Inject constructor(
     private val oauthDeviceAuthUseCase: OAuthDeviceAuthorizationUseCase,
     private val workManager: WorkManager,
     @ApplicationContext private val context: Context,
-    @ApplicationScope private val applicationScope: CoroutineScope
+    @ApplicationScope private val applicationScope: CoroutineScope,
+    private val httpUrlMigrationLoginCoordinator: HttpUrlMigrationLoginCoordinator
 ) : ViewModel() {
 
     data class AccountSettingsUiState(
@@ -81,13 +83,17 @@ class AccountSettingsViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
+            val pendingMigrationLoginUrl = httpUrlMigrationLoginCoordinator.consumePendingLoginUrl()
             val token = settingsDataStore.tokenFlow.value
-            val url = settingsDataStore.urlFlow.value
+            val url = pendingMigrationLoginUrl ?: settingsDataStore.urlFlow.value
             _uiState.update {
                 it.copy(
                     isLoggedIn = !token.isNullOrBlank(),
                     url = toDisplayUrl(url)
                 )
+            }
+            if (pendingMigrationLoginUrl != null) {
+                startLogin(pendingMigrationLoginUrl)
             }
         }
     }
@@ -101,41 +107,45 @@ class AccountSettingsViewModel @Inject constructor(
         Timber.d("login() called with normalized URL: $url")
 
         viewModelScope.launch {
-            _uiState.update { it.copy(authStatus = AuthStatus.Loading) }
+            startLogin(url)
+        }
+    }
 
-            val result = userRepository.initiateLogin(url)
-            Timber.d("initiateLogin result: $result")
-            when (result) {
-                is UserRepository.LoginResult.DeviceAuthorizationRequired -> {
-                    val state = result.state
-                    _uiState.update {
-                        it.copy(
-                            authStatus = AuthStatus.WaitingForAuthorization,
-                            deviceAuthState = state
-                        )
-                    }
-                    startPolling(url, state)
-                }
+    private suspend fun startLogin(url: String) {
+        _uiState.update { it.copy(authStatus = AuthStatus.Loading) }
 
-                is UserRepository.LoginResult.Success -> {
-                    // Shouldn't happen from initiateLogin, but handle it
-                    onLoginSuccess()
+        val result = userRepository.initiateLogin(url)
+        Timber.d("initiateLogin result: $result")
+        when (result) {
+            is UserRepository.LoginResult.DeviceAuthorizationRequired -> {
+                val state = result.state
+                _uiState.update {
+                    it.copy(
+                        authStatus = AuthStatus.WaitingForAuthorization,
+                        deviceAuthState = state
+                    )
                 }
+                startPolling(url, state)
+            }
 
-                is UserRepository.LoginResult.Error -> {
-                    Timber.e("Login error (code=${result.code}): ${result.errorMessage}")
-                    _uiState.update { it.copy(authStatus = AuthStatus.Error(result.errorMessage)) }
-                }
+            is UserRepository.LoginResult.Success -> {
+                // Shouldn't happen from initiateLogin, but handle it
+                onLoginSuccess()
+            }
 
-                is UserRepository.LoginResult.NetworkError -> {
-                    Timber.e("Login network error: ${result.errorMessage}")
-                    _uiState.update { it.copy(authStatus = AuthStatus.Error(result.errorMessage)) }
-                }
+            is UserRepository.LoginResult.Error -> {
+                Timber.e("Login error (code=${result.code}): ${result.errorMessage}")
+                _uiState.update { it.copy(authStatus = AuthStatus.Error(result.errorMessage)) }
+            }
 
-                UserRepository.LoginResult.HttpBlockedByBuildPolicy -> {
-                    Timber.w("Login blocked because HTTP is disabled in this build")
-                    _uiState.update { it.copy(authStatus = AuthStatus.Error(context.getString(R.string.account_settings_http_blocked_error))) }
-                }
+            is UserRepository.LoginResult.NetworkError -> {
+                Timber.e("Login network error: ${result.errorMessage}")
+                _uiState.update { it.copy(authStatus = AuthStatus.Error(result.errorMessage)) }
+            }
+
+            UserRepository.LoginResult.HttpBlockedByBuildPolicy -> {
+                Timber.w("Login blocked because HTTP is disabled in this build")
+                _uiState.update { it.copy(authStatus = AuthStatus.Error(context.getString(R.string.account_settings_http_blocked_error))) }
             }
         }
     }

--- a/app/src/main/java/com/mydeck/app/ui/settings/AccountSettingsViewModel.kt
+++ b/app/src/main/java/com/mydeck/app/ui/settings/AccountSettingsViewModel.kt
@@ -131,6 +131,11 @@ class AccountSettingsViewModel @Inject constructor(
                     Timber.e("Login network error: ${result.errorMessage}")
                     _uiState.update { it.copy(authStatus = AuthStatus.Error(result.errorMessage)) }
                 }
+
+                UserRepository.LoginResult.HttpBlockedByBuildPolicy -> {
+                    Timber.w("Login blocked because HTTP is disabled in this build")
+                    _uiState.update { it.copy(authStatus = AuthStatus.Error(context.getString(R.string.account_settings_http_blocked_error))) }
+                }
             }
         }
     }
@@ -171,6 +176,9 @@ class AccountSettingsViewModel @Inject constructor(
                             is UserRepository.LoginResult.Error -> {
                                 _uiState.update { it.copy(authStatus = AuthStatus.Error(loginResult.errorMessage)) }
                             }
+                            UserRepository.LoginResult.HttpBlockedByBuildPolicy -> {
+                                _uiState.update { it.copy(authStatus = AuthStatus.Error(context.getString(R.string.account_settings_http_blocked_error))) }
+                            }
                             else -> {
                                 _uiState.update { it.copy(authStatus = AuthStatus.Error("Unexpected error")) }
                             }
@@ -204,6 +212,13 @@ class AccountSettingsViewModel @Inject constructor(
                     is OAuthDeviceAuthorizationUseCase.TokenPollResult.NetworkError -> {
                         Timber.w("Network error during polling, will retry: ${result.message}")
                         // Don't break — transient network errors are retryable
+                    }
+
+                    OAuthDeviceAuthorizationUseCase.TokenPollResult.HttpBlockedByBuildPolicy -> {
+                        _uiState.update {
+                            it.copy(authStatus = AuthStatus.Error(context.getString(R.string.account_settings_http_blocked_error)), deviceAuthState = null)
+                        }
+                        break
                     }
 
                     is OAuthDeviceAuthorizationUseCase.TokenPollResult.Error -> {

--- a/app/src/main/java/com/mydeck/app/ui/settings/HttpUrlWarningText.kt
+++ b/app/src/main/java/com/mydeck/app/ui/settings/HttpUrlWarningText.kt
@@ -1,0 +1,36 @@
+package com.mydeck.app.ui.settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.mydeck.app.R
+import com.mydeck.app.util.openUrlInCustomTab
+
+private const val TAILSCALE_SERVE_URL = "https://tailscale.com/docs/features/tailscale-serve"
+private const val READECK_PROXY_DOCS_URL = "https://readeck.org/en/docs/configuration"
+
+@Composable
+fun HttpUrlWarningText(modifier: Modifier = Modifier) {
+    val context = LocalContext.current
+    Column(modifier = modifier) {
+        Text(text = stringResource(R.string.account_settings_url_http_warning))
+        TextButton(
+            onClick = { openUrlInCustomTab(context, TAILSCALE_SERVE_URL) },
+            contentPadding = PaddingValues(0.dp)
+        ) {
+            Text(stringResource(R.string.http_migration_tailscale_link))
+        }
+        TextButton(
+            onClick = { openUrlInCustomTab(context, READECK_PROXY_DOCS_URL) },
+            contentPadding = PaddingValues(0.dp)
+        ) {
+            Text(stringResource(R.string.http_migration_readeck_proxy_link))
+        }
+    }
+}

--- a/app/src/main/java/com/mydeck/app/ui/welcome/WelcomeScreen.kt
+++ b/app/src/main/java/com/mydeck/app/ui/welcome/WelcomeScreen.kt
@@ -21,6 +21,7 @@ import com.mydeck.app.ui.login.DeviceAuthorizationScreen
 import com.mydeck.app.ui.navigation.BookmarkListRoute
 import com.mydeck.app.ui.navigation.WelcomeRoute
 import com.mydeck.app.ui.settings.AccountSettingsViewModel
+import com.mydeck.app.ui.settings.HttpUrlWarningText
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -103,7 +104,7 @@ fun WelcomeScreen(
                             settingsUiState.urlError != null ->
                                 Text(text = stringResource(settingsUiState.urlError))
                             settingsUiState.urlWarning != null ->
-                                Text(text = stringResource(settingsUiState.urlWarning))
+                                HttpUrlWarningText()
                         }
                     }
                 )

--- a/app/src/main/java/com/mydeck/app/worker/ActionSyncWorker.kt
+++ b/app/src/main/java/com/mydeck/app/worker/ActionSyncWorker.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.hilt.work.HiltWorker
 import androidx.work.*
 import com.mydeck.app.domain.BookmarkRepository
+import com.mydeck.app.io.rest.isHttpBlockedByBuildPolicy
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import javax.inject.Provider
@@ -17,9 +18,15 @@ class ActionSyncWorker @AssistedInject constructor(
 ) : CoroutineWorker(appContext, workerParams) {
 
     override suspend fun doWork(): Result {
-        return when (bookmarkRepositoryProvider.get().syncPendingActions()) {
+        return when (val result = bookmarkRepositoryProvider.get().syncPendingActions()) {
             is BookmarkRepository.UpdateResult.Success -> Result.success()
-            is BookmarkRepository.UpdateResult.NetworkError -> Result.retry()
+            is BookmarkRepository.UpdateResult.NetworkError -> {
+                if (result.ex?.isHttpBlockedByBuildPolicy() == true) {
+                    Result.failure()
+                } else {
+                    Result.retry()
+                }
+            }
             is BookmarkRepository.UpdateResult.Error -> Result.failure()
         }
     }

--- a/app/src/main/java/com/mydeck/app/worker/BatchArticleLoadWorker.kt
+++ b/app/src/main/java/com/mydeck/app/worker/BatchArticleLoadWorker.kt
@@ -17,6 +17,7 @@ import com.mydeck.app.domain.sync.OfflinePolicyEvaluator.Companion.avgArticleByt
 import com.mydeck.app.domain.usecase.LoadContentPackageUseCase
 import com.mydeck.app.io.db.dao.BookmarkDao
 import com.mydeck.app.io.prefs.SettingsDataStore
+import com.mydeck.app.io.rest.isHttpBlockedByBuildPolicy
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.async
@@ -215,7 +216,7 @@ class BatchArticleLoadWorker @AssistedInject constructor(
             return Result.success()
         } catch (e: Exception) {
             Timber.e(e, "BatchArticleLoadWorker failed")
-            return Result.retry()
+            return if (e.isHttpBlockedByBuildPolicy()) Result.failure() else Result.retry()
         }
     }
 
@@ -240,7 +241,7 @@ class BatchArticleLoadWorker @AssistedInject constructor(
             Result.success()
         } catch (e: Exception) {
             Timber.e(e, "BatchArticleLoadWorker: priority download failed for $bookmarkId")
-            Result.retry()
+            if (e.isHttpBlockedByBuildPolicy()) Result.failure() else Result.retry()
         }
     }
 

--- a/app/src/main/java/com/mydeck/app/worker/CreateBookmarkWorker.kt
+++ b/app/src/main/java/com/mydeck/app/worker/CreateBookmarkWorker.kt
@@ -12,6 +12,7 @@ import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import com.mydeck.app.domain.BookmarkRepository
 import com.mydeck.app.domain.model.Bookmark
+import com.mydeck.app.io.rest.isHttpBlockedByBuildPolicy
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.CancellationException
@@ -76,7 +77,9 @@ class CreateBookmarkWorker @AssistedInject constructor(
             throw e
         } catch (e: Exception) {
             Timber.e(e, "CreateBookmarkWorker: Failed to create bookmark")
-            if (runAttemptCount < 3) {
+            if (e.isHttpBlockedByBuildPolicy()) {
+                Result.failure()
+            } else if (runAttemptCount < 3) {
                 Result.retry()
             } else {
                 Result.failure()

--- a/app/src/main/java/com/mydeck/app/worker/DateRangeContentSyncWorker.kt
+++ b/app/src/main/java/com/mydeck/app/worker/DateRangeContentSyncWorker.kt
@@ -8,6 +8,7 @@ import com.mydeck.app.domain.sync.OfflinePolicyEvaluator
 import com.mydeck.app.domain.usecase.LoadContentPackageUseCase
 import com.mydeck.app.io.db.dao.BookmarkDao
 import com.mydeck.app.io.prefs.SettingsDataStore
+import com.mydeck.app.io.rest.isHttpBlockedByBuildPolicy
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import kotlinx.datetime.Clock
@@ -59,6 +60,10 @@ class DateRangeContentSyncWorker @AssistedInject constructor(
                     }
                 }
             } catch (e: Exception) {
+                if (e.isHttpBlockedByBuildPolicy()) {
+                    Timber.w(e, "Date range content sync blocked by HTTP policy")
+                    return Result.failure()
+                }
                 Timber.w(e, "Batch failed in date range sync; continuing with next batch")
             }
         }

--- a/app/src/main/java/com/mydeck/app/worker/FullSyncWorker.kt
+++ b/app/src/main/java/com/mydeck/app/worker/FullSyncWorker.kt
@@ -24,6 +24,7 @@ import com.mydeck.app.domain.sync.BookmarkMetadataSyncCoordinator
 import com.mydeck.app.domain.usecase.LoadBookmarksUseCase
 import com.mydeck.app.domain.usecase.FreshnessMarkerUseCase
 import com.mydeck.app.io.prefs.SettingsDataStore
+import com.mydeck.app.io.rest.isHttpBlockedByBuildPolicy
 import kotlinx.datetime.Clock
 import timber.log.Timber
 import kotlin.coroutines.cancellation.CancellationException
@@ -99,7 +100,14 @@ class FullSyncWorker @AssistedInject constructor(
 
     private suspend fun runMetadataSync(forceFullSync: Boolean): MetadataSyncOutcome {
         // Drain the action queue before starting sync to ensure local changes are sent first
-        bookmarkRepository.syncPendingActions()
+        when (val actionResult = bookmarkRepository.syncPendingActions()) {
+            is BookmarkRepository.UpdateResult.NetworkError -> {
+                if (actionResult.ex?.isHttpBlockedByBuildPolicy() == true) {
+                    return MetadataSyncOutcome(Result.failure())
+                }
+            }
+            else -> Unit
+        }
         val lastSyncTimestamp = settingsDataStore.getLastSyncTimestamp()
         val lastFullSyncTimestamp = settingsDataStore.getLastFullSyncTimestamp()
 
@@ -140,7 +148,7 @@ class FullSyncWorker @AssistedInject constructor(
                 return MetadataSyncOutcome(Result.failure())
             }
             is SyncResult.NetworkError -> {
-                return MetadataSyncOutcome(Result.retry())
+                return MetadataSyncOutcome(if (syncResult.ex?.isHttpBlockedByBuildPolicy() == true) Result.failure() else Result.retry())
             }
             is SyncResult.Success -> {
                 Timber.d("Deletion sync successful: ${syncResult.countDeleted} deleted")

--- a/app/src/main/java/com/mydeck/app/worker/LoadBookmarksWorker.kt
+++ b/app/src/main/java/com/mydeck/app/worker/LoadBookmarksWorker.kt
@@ -25,6 +25,7 @@ import com.mydeck.app.domain.SyncPriority
 import com.mydeck.app.domain.sync.BookmarkMetadataSyncCoordinator
 import com.mydeck.app.domain.usecase.LoadBookmarksUseCase
 import com.mydeck.app.io.prefs.SettingsDataStore
+import com.mydeck.app.io.rest.isHttpBlockedByBuildPolicy
 import com.mydeck.app.MainActivity
 import com.mydeck.app.R
 import kotlin.coroutines.cancellation.CancellationException
@@ -104,7 +105,7 @@ class LoadBookmarksWorker @AssistedInject constructor(
                 }
                 is BookmarkRepository.SyncResult.NetworkError -> {
                     Timber.e(result.ex, "Network error during initial full sync")
-                    MetadataSyncOutcome(Result.retry())
+                    MetadataSyncOutcome(if (result.ex?.isHttpBlockedByBuildPolicy() == true) Result.failure() else Result.retry())
                 }
                 is BookmarkRepository.SyncResult.Error -> {
                     Timber.e("Initial full sync failed: ${result.errorMessage}")
@@ -167,7 +168,7 @@ class LoadBookmarksWorker @AssistedInject constructor(
                 }
                 is BookmarkRepository.SyncResult.NetworkError -> {
                     Timber.e(result.ex, "Network error during full sync fallback")
-                    MetadataSyncOutcome(Result.retry())
+                    MetadataSyncOutcome(if (result.ex?.isHttpBlockedByBuildPolicy() == true) Result.failure() else Result.retry())
                 }
                 is BookmarkRepository.SyncResult.Error -> {
                     Timber.e("Full sync fallback failed: ${result.errorMessage}")
@@ -198,7 +199,9 @@ class LoadBookmarksWorker @AssistedInject constructor(
                     "Bookmark delta annotation checks skipped: metadata reload failed [updatedIds=%d path=LoadBookmarksWorker]",
                     deltaUpdatedIds.orEmpty().size
                 )
-                if (result.exception is IOException) {
+                if (result.exception.isHttpBlockedByBuildPolicy()) {
+                    MetadataSyncOutcome(Result.failure())
+                } else if (result.exception is IOException) {
                     MetadataSyncOutcome(Result.retry())
                 } else {
                     MetadataSyncOutcome(Result.failure())

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -17,7 +17,8 @@
     <string name="account_settings_password_placeholder">Passwort</string>
     <string name="account_settings_login">Einloggen</string>
     <string name="account_settings_url_error">Ungültige URL</string>
-    <string name="account_settings_url_http_warning">Insecure connection — only use on a trusted private network (e.g. Tailscale)</string>
+    <string name="account_settings_url_http_warning">This HTTP URL sends OAuth tokens without TLS. You are using the HTTP-enabled MyDeck build; prefer a Tailscale Serve HTTPS URL or a reverse proxy with HTTPS when possible.</string>
+    <string name="account_settings_http_blocked_error">HTTP Readeck server URLs are not allowed in this MyDeck build.</string>
     <string name="account_settings_username_error">Benutzername darf nicht leer sein</string>
     <string name="account_settings_password_error">Passwort darf nicht leer sein</string>
     <string name="account_settings_allow_unencrypted">Unverschlüsselte Verbindunge erlauben</string>
@@ -355,6 +356,20 @@ other{}
     <string name="welcome_title">Welcome to MyDeck</string>
     <string name="welcome_message">MyDeck is a read-later app for Readeck. Enter your Readeck server address below to get started. You\'ll be guided through a quick authorization process to connect your account.</string>
     <string name="welcome_connect_button">Connect</string>
+    <string name="http_migration_title">HTTP server URL blocked</string>
+    <string name="http_migration_body">This MyDeck build now allows HTTPS Readeck server URLs only. Your saved server URL is %1$s, so MyDeck has stopped before syncing.</string>
+    <string name="http_migration_https_title">1. Change the server URL to HTTPS</string>
+    <string name="http_migration_https_body">Enter the HTTPS URL you want to use. MyDeck will clear the old credentials first, then ask you to sign in again.</string>
+    <string name="http_migration_https_action">Use HTTPS and sign in again</string>
+    <string name="http_migration_tailscale_link">Tailscale Serve HTTPS docs</string>
+    <string name="http_migration_readeck_proxy_link">Readeck proxy configuration docs</string>
+    <string name="http_migration_http_apk_title">2. Install the HTTP-enabled APK</string>
+    <string name="http_migration_http_apk_body">Use this separate package only for trusted private-network setups that cannot use HTTPS. It installs beside this app and requires OAuth authorization again.</string>
+    <string name="http_migration_http_apk_action">Open latest release</string>
+    <string name="http_migration_logout_title">3. Sign out</string>
+    <string name="http_migration_logout_body">Use this only if you want to clear local credentials and configure MyDeck again from the welcome screen.</string>
+    <string name="http_migration_save_error">Could not switch to the HTTPS URL. Please try again.</string>
+    <string name="http_migration_logout_error">Could not finish sign out. Please try again.</string>
 
     <!-- Share Intent / Quick Save -->
     <string name="save_to_mydeck">In MyDeck speichern</string>
@@ -516,6 +531,12 @@ other{}
     <string name="about_system_info_server_loading">Loading…</string>
     <string name="about_system_info_server_error">Could not load server information</string>
     <string name="about_system_info_server_unavailable">No server information available</string>
+    <string name="about_network_policy_server_urls">Server URLs: %s</string>
+    <string name="about_network_policy_server_urls_https_only">HTTPS only</string>
+    <string name="about_network_policy_server_urls_http_allowed">HTTP allowed</string>
+    <string name="about_network_policy_https_trust">HTTPS trust: %s</string>
+    <string name="about_network_policy_https_trust_system">system certificate authorities</string>
+    <string name="about_network_policy_https_trust_system_user">system + user certificate authorities</string>
     <string name="highlight_offline_unavailable">Highlights can\'t be changed while offline</string>
     <string name="video_highlight_edit_not_supported">Editing video highlights isn\'t supported yet</string>
     <string name="video_embed_offline">Video unavailable while offline</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -358,18 +358,15 @@ other{}
     <string name="welcome_connect_button">Connect</string>
     <string name="http_migration_title">HTTP server URL blocked</string>
     <string name="http_migration_body">This MyDeck build now allows HTTPS Readeck server URLs only. Your saved server URL is %1$s, so MyDeck has stopped before syncing.</string>
-    <string name="http_migration_https_title">1. Change the server URL to HTTPS</string>
+    <string name="http_migration_https_title">Switch to HTTPS</string>
     <string name="http_migration_https_body">Enter the HTTPS URL you want to use. MyDeck will clear the old credentials first, then ask you to sign in again.</string>
     <string name="http_migration_https_action">Use HTTPS and sign in again</string>
     <string name="http_migration_tailscale_link">Tailscale Serve HTTPS docs</string>
     <string name="http_migration_readeck_proxy_link">Readeck proxy configuration docs</string>
-    <string name="http_migration_http_apk_title">2. Install the HTTP-enabled APK</string>
+    <string name="http_migration_http_apk_title">Install the HTTP-enabled APK</string>
     <string name="http_migration_http_apk_body">Use this separate package only for trusted private-network setups that cannot use HTTPS. It installs beside this app and requires OAuth authorization again.</string>
     <string name="http_migration_http_apk_action">Open latest release</string>
-    <string name="http_migration_logout_title">3. Sign out</string>
-    <string name="http_migration_logout_body">Use this only if you want to clear local credentials and configure MyDeck again from the welcome screen.</string>
     <string name="http_migration_save_error">Could not switch to the HTTPS URL. Please try again.</string>
-    <string name="http_migration_logout_error">Could not finish sign out. Please try again.</string>
 
     <!-- Share Intent / Quick Save -->
     <string name="save_to_mydeck">In MyDeck speichern</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -341,18 +341,15 @@ other{}
     <string name="welcome_connect_button">Conectar</string>
     <string name="http_migration_title">HTTP server URL blocked</string>
     <string name="http_migration_body">This MyDeck build now allows HTTPS Readeck server URLs only. Your saved server URL is %1$s, so MyDeck has stopped before syncing.</string>
-    <string name="http_migration_https_title">1. Change the server URL to HTTPS</string>
+    <string name="http_migration_https_title">Switch to HTTPS</string>
     <string name="http_migration_https_body">Enter the HTTPS URL you want to use. MyDeck will clear the old credentials first, then ask you to sign in again.</string>
     <string name="http_migration_https_action">Use HTTPS and sign in again</string>
     <string name="http_migration_tailscale_link">Tailscale Serve HTTPS docs</string>
     <string name="http_migration_readeck_proxy_link">Readeck proxy configuration docs</string>
-    <string name="http_migration_http_apk_title">2. Install the HTTP-enabled APK</string>
+    <string name="http_migration_http_apk_title">Install the HTTP-enabled APK</string>
     <string name="http_migration_http_apk_body">Use this separate package only for trusted private-network setups that cannot use HTTPS. It installs beside this app and requires OAuth authorization again.</string>
     <string name="http_migration_http_apk_action">Open latest release</string>
-    <string name="http_migration_logout_title">3. Sign out</string>
-    <string name="http_migration_logout_body">Use this only if you want to clear local credentials and configure MyDeck again from the welcome screen.</string>
     <string name="http_migration_save_error">Could not switch to the HTTPS URL. Please try again.</string>
-    <string name="http_migration_logout_error">Could not finish sign out. Please try again.</string>
 
     <!-- Share Intent / Quick Save -->
     <string name="save_to_mydeck">Guardar en MyDeck</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -17,7 +17,8 @@
     <string name="account_settings_password_placeholder">contraseña</string>
     <string name="account_settings_login">Iniciar sesión</string>
     <string name="account_settings_url_error">URL no válida</string>
-    <string name="account_settings_url_http_warning">Insecure connection — only use on a trusted private network (e.g. Tailscale)</string>
+    <string name="account_settings_url_http_warning">This HTTP URL sends OAuth tokens without TLS. You are using the HTTP-enabled MyDeck build; prefer a Tailscale Serve HTTPS URL or a reverse proxy with HTTPS when possible.</string>
+    <string name="account_settings_http_blocked_error">HTTP Readeck server URLs are not allowed in this MyDeck build.</string>
     <string name="account_settings_username_error">Debes escribir el identificador</string>
     <string name="account_settings_password_error">Debes escribir una contraseña</string>
     <string name="authors" translatable="true">
@@ -338,6 +339,20 @@ other{}
     <string name="welcome_title">Bienvenido a MyDeck</string>
     <string name="welcome_message">MyDeck es una aplicación de lectura posterior para Readeck. Ingresa la dirección del servidor de Readeck a continuación para comenzar. Serás guiado a través de un proceso de autorización rápido para conectar tu cuenta.</string>
     <string name="welcome_connect_button">Conectar</string>
+    <string name="http_migration_title">HTTP server URL blocked</string>
+    <string name="http_migration_body">This MyDeck build now allows HTTPS Readeck server URLs only. Your saved server URL is %1$s, so MyDeck has stopped before syncing.</string>
+    <string name="http_migration_https_title">1. Change the server URL to HTTPS</string>
+    <string name="http_migration_https_body">Enter the HTTPS URL you want to use. MyDeck will clear the old credentials first, then ask you to sign in again.</string>
+    <string name="http_migration_https_action">Use HTTPS and sign in again</string>
+    <string name="http_migration_tailscale_link">Tailscale Serve HTTPS docs</string>
+    <string name="http_migration_readeck_proxy_link">Readeck proxy configuration docs</string>
+    <string name="http_migration_http_apk_title">2. Install the HTTP-enabled APK</string>
+    <string name="http_migration_http_apk_body">Use this separate package only for trusted private-network setups that cannot use HTTPS. It installs beside this app and requires OAuth authorization again.</string>
+    <string name="http_migration_http_apk_action">Open latest release</string>
+    <string name="http_migration_logout_title">3. Sign out</string>
+    <string name="http_migration_logout_body">Use this only if you want to clear local credentials and configure MyDeck again from the welcome screen.</string>
+    <string name="http_migration_save_error">Could not switch to the HTTPS URL. Please try again.</string>
+    <string name="http_migration_logout_error">Could not finish sign out. Please try again.</string>
 
     <!-- Share Intent / Quick Save -->
     <string name="save_to_mydeck">Guardar en MyDeck</string>
@@ -520,6 +535,12 @@ other{}
     <string name="about_system_info_server_loading">Loading…</string>
     <string name="about_system_info_server_error">Could not load server information</string>
     <string name="about_system_info_server_unavailable">No server information available</string>
+    <string name="about_network_policy_server_urls">Server URLs: %s</string>
+    <string name="about_network_policy_server_urls_https_only">HTTPS only</string>
+    <string name="about_network_policy_server_urls_http_allowed">HTTP allowed</string>
+    <string name="about_network_policy_https_trust">HTTPS trust: %s</string>
+    <string name="about_network_policy_https_trust_system">system certificate authorities</string>
+    <string name="about_network_policy_https_trust_system_user">system + user certificate authorities</string>
     <string name="highlight_offline_unavailable">Highlights can\'t be changed while offline</string>
     <string name="video_highlight_edit_not_supported">Editing video highlights isn\'t supported yet</string>
     <string name="video_embed_offline">Video unavailable while offline</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -213,18 +213,15 @@
     <string name="welcome_connect_button">Connect</string>
     <string name="http_migration_title">HTTP server URL blocked</string>
     <string name="http_migration_body">This MyDeck build now allows HTTPS Readeck server URLs only. Your saved server URL is %1$s, so MyDeck has stopped before syncing.</string>
-    <string name="http_migration_https_title">1. Change the server URL to HTTPS</string>
+    <string name="http_migration_https_title">Switch to HTTPS</string>
     <string name="http_migration_https_body">Enter the HTTPS URL you want to use. MyDeck will clear the old credentials first, then ask you to sign in again.</string>
     <string name="http_migration_https_action">Use HTTPS and sign in again</string>
     <string name="http_migration_tailscale_link">Tailscale Serve HTTPS docs</string>
     <string name="http_migration_readeck_proxy_link">Readeck proxy configuration docs</string>
-    <string name="http_migration_http_apk_title">2. Install the HTTP-enabled APK</string>
+    <string name="http_migration_http_apk_title">Install the HTTP-enabled APK</string>
     <string name="http_migration_http_apk_body">Use this separate package only for trusted private-network setups that cannot use HTTPS. It installs beside this app and requires OAuth authorization again.</string>
     <string name="http_migration_http_apk_action">Open latest release</string>
-    <string name="http_migration_logout_title">3. Sign out</string>
-    <string name="http_migration_logout_body">Use this only if you want to clear local credentials and configure MyDeck again from the welcome screen.</string>
     <string name="http_migration_save_error">Could not switch to the HTTPS URL. Please try again.</string>
-    <string name="http_migration_logout_error">Could not finish sign out. Please try again.</string>
 
     <!-- Share Intent / Quick Save -->
     <string name="save_to_mydeck">Enregistrer dans MyDeck</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -211,6 +211,20 @@
     <string name="welcome_title">Welcome to MyDeck</string>
     <string name="welcome_message">MyDeck is a read-later app for Readeck. Enter your Readeck server address below to get started. You\'ll be guided through a quick authorization process to connect your account.</string>
     <string name="welcome_connect_button">Connect</string>
+    <string name="http_migration_title">HTTP server URL blocked</string>
+    <string name="http_migration_body">This MyDeck build now allows HTTPS Readeck server URLs only. Your saved server URL is %1$s, so MyDeck has stopped before syncing.</string>
+    <string name="http_migration_https_title">1. Change the server URL to HTTPS</string>
+    <string name="http_migration_https_body">Enter the HTTPS URL you want to use. MyDeck will clear the old credentials first, then ask you to sign in again.</string>
+    <string name="http_migration_https_action">Use HTTPS and sign in again</string>
+    <string name="http_migration_tailscale_link">Tailscale Serve HTTPS docs</string>
+    <string name="http_migration_readeck_proxy_link">Readeck proxy configuration docs</string>
+    <string name="http_migration_http_apk_title">2. Install the HTTP-enabled APK</string>
+    <string name="http_migration_http_apk_body">Use this separate package only for trusted private-network setups that cannot use HTTPS. It installs beside this app and requires OAuth authorization again.</string>
+    <string name="http_migration_http_apk_action">Open latest release</string>
+    <string name="http_migration_logout_title">3. Sign out</string>
+    <string name="http_migration_logout_body">Use this only if you want to clear local credentials and configure MyDeck again from the welcome screen.</string>
+    <string name="http_migration_save_error">Could not switch to the HTTPS URL. Please try again.</string>
+    <string name="http_migration_logout_error">Could not finish sign out. Please try again.</string>
 
     <!-- Share Intent / Quick Save -->
     <string name="save_to_mydeck">Enregistrer dans MyDeck</string>
@@ -422,6 +436,12 @@
     <string name="about_system_info_server_loading">Loading…</string>
     <string name="about_system_info_server_error">Could not load server information</string>
     <string name="about_system_info_server_unavailable">No server information available</string>
+    <string name="about_network_policy_server_urls">Server URLs: %s</string>
+    <string name="about_network_policy_server_urls_https_only">HTTPS only</string>
+    <string name="about_network_policy_server_urls_http_allowed">HTTP allowed</string>
+    <string name="about_network_policy_https_trust">HTTPS trust: %s</string>
+    <string name="about_network_policy_https_trust_system">system certificate authorities</string>
+    <string name="about_network_policy_https_trust_system_user">system + user certificate authorities</string>
     <string name="auto_sync_timeframe_15_minutes">Every 15 minutes</string>
     <string name="highlight_offline_unavailable">Highlights can\'t be changed while offline</string>
     <string name="video_highlight_edit_not_supported">Editing video highlights isn\'t supported yet</string>
@@ -470,7 +490,8 @@
     <string name="sync_status_last_content_sync_label">Last content sync</string>
     <string name="sync_status_next_sync">Next sync: %1$s</string>
     <string name="sync_status_favorites_label">Favorites</string>
-    <string name="account_settings_url_http_warning">Insecure connection — only use on a trusted private network (e.g. Tailscale)</string>
+    <string name="account_settings_url_http_warning">This HTTP URL sends OAuth tokens without TLS. You are using the HTTP-enabled MyDeck build; prefer a Tailscale Serve HTTPS URL or a reverse proxy with HTTPS when possible.</string>
+    <string name="account_settings_http_blocked_error">HTTP Readeck server URLs are not allowed in this MyDeck build.</string>
 
     <string name="app_name">MyDeck</string>
     <string name="back">Back</string>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -16,7 +16,8 @@
     <string name="account_settings_password_placeholder">contrasinal</string>
     <string name="account_settings_login">Acceder</string>
     <string name="account_settings_url_error">URL non válido</string>
-    <string name="account_settings_url_http_warning">Insecure connection — only use on a trusted private network (e.g. Tailscale)</string>
+    <string name="account_settings_url_http_warning">This HTTP URL sends OAuth tokens without TLS. You are using the HTTP-enabled MyDeck build; prefer a Tailscale Serve HTTPS URL or a reverse proxy with HTTPS when possible.</string>
+    <string name="account_settings_http_blocked_error">HTTP Readeck server URLs are not allowed in this MyDeck build.</string>
     <string name="account_settings_username_error">Tes que escribir o identificador</string>
     <string name="account_settings_password_error">Tes que escribir o contrasinal</string>
     <string name="authors" translatable="true">
@@ -278,6 +279,20 @@ other{}
     <string name="welcome_title">Welcome to MyDeck</string>
     <string name="welcome_message">MyDeck is a read-later app for Readeck. Enter your Readeck server address below to get started. You\'ll be guided through a quick authorization process to connect your account.</string>
     <string name="welcome_connect_button">Connect</string>
+    <string name="http_migration_title">HTTP server URL blocked</string>
+    <string name="http_migration_body">This MyDeck build now allows HTTPS Readeck server URLs only. Your saved server URL is %1$s, so MyDeck has stopped before syncing.</string>
+    <string name="http_migration_https_title">1. Change the server URL to HTTPS</string>
+    <string name="http_migration_https_body">Enter the HTTPS URL you want to use. MyDeck will clear the old credentials first, then ask you to sign in again.</string>
+    <string name="http_migration_https_action">Use HTTPS and sign in again</string>
+    <string name="http_migration_tailscale_link">Tailscale Serve HTTPS docs</string>
+    <string name="http_migration_readeck_proxy_link">Readeck proxy configuration docs</string>
+    <string name="http_migration_http_apk_title">2. Install the HTTP-enabled APK</string>
+    <string name="http_migration_http_apk_body">Use this separate package only for trusted private-network setups that cannot use HTTPS. It installs beside this app and requires OAuth authorization again.</string>
+    <string name="http_migration_http_apk_action">Open latest release</string>
+    <string name="http_migration_logout_title">3. Sign out</string>
+    <string name="http_migration_logout_body">Use this only if you want to clear local credentials and configure MyDeck again from the welcome screen.</string>
+    <string name="http_migration_save_error">Could not switch to the HTTPS URL. Please try again.</string>
+    <string name="http_migration_logout_error">Could not finish sign out. Please try again.</string>
 
     <!-- Share Intent / Quick Save -->
     <string name="save_to_mydeck">Gardar en MyDeck</string>
@@ -487,6 +502,12 @@ other{}
     <string name="about_system_info_server_loading">Loading…</string>
     <string name="about_system_info_server_error">Could not load server information</string>
     <string name="about_system_info_server_unavailable">No server information available</string>
+    <string name="about_network_policy_server_urls">Server URLs: %s</string>
+    <string name="about_network_policy_server_urls_https_only">HTTPS only</string>
+    <string name="about_network_policy_server_urls_http_allowed">HTTP allowed</string>
+    <string name="about_network_policy_https_trust">HTTPS trust: %s</string>
+    <string name="about_network_policy_https_trust_system">system certificate authorities</string>
+    <string name="about_network_policy_https_trust_system_user">system + user certificate authorities</string>
     <string name="auto_sync_timeframe_15_minutes">Every 15 minutes</string>
     <string name="highlight_offline_unavailable">Highlights can\'t be changed while offline</string>
     <string name="video_highlight_edit_not_supported">Editing video highlights isn\'t supported yet</string>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -281,18 +281,15 @@ other{}
     <string name="welcome_connect_button">Connect</string>
     <string name="http_migration_title">HTTP server URL blocked</string>
     <string name="http_migration_body">This MyDeck build now allows HTTPS Readeck server URLs only. Your saved server URL is %1$s, so MyDeck has stopped before syncing.</string>
-    <string name="http_migration_https_title">1. Change the server URL to HTTPS</string>
+    <string name="http_migration_https_title">Switch to HTTPS</string>
     <string name="http_migration_https_body">Enter the HTTPS URL you want to use. MyDeck will clear the old credentials first, then ask you to sign in again.</string>
     <string name="http_migration_https_action">Use HTTPS and sign in again</string>
     <string name="http_migration_tailscale_link">Tailscale Serve HTTPS docs</string>
     <string name="http_migration_readeck_proxy_link">Readeck proxy configuration docs</string>
-    <string name="http_migration_http_apk_title">2. Install the HTTP-enabled APK</string>
+    <string name="http_migration_http_apk_title">Install the HTTP-enabled APK</string>
     <string name="http_migration_http_apk_body">Use this separate package only for trusted private-network setups that cannot use HTTPS. It installs beside this app and requires OAuth authorization again.</string>
     <string name="http_migration_http_apk_action">Open latest release</string>
-    <string name="http_migration_logout_title">3. Sign out</string>
-    <string name="http_migration_logout_body">Use this only if you want to clear local credentials and configure MyDeck again from the welcome screen.</string>
     <string name="http_migration_save_error">Could not switch to the HTTPS URL. Please try again.</string>
-    <string name="http_migration_logout_error">Could not finish sign out. Please try again.</string>
 
     <!-- Share Intent / Quick Save -->
     <string name="save_to_mydeck">Gardar en MyDeck</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -213,18 +213,15 @@
     <string name="welcome_connect_button">Connect</string>
     <string name="http_migration_title">HTTP server URL blocked</string>
     <string name="http_migration_body">This MyDeck build now allows HTTPS Readeck server URLs only. Your saved server URL is %1$s, so MyDeck has stopped before syncing.</string>
-    <string name="http_migration_https_title">1. Change the server URL to HTTPS</string>
+    <string name="http_migration_https_title">Switch to HTTPS</string>
     <string name="http_migration_https_body">Enter the HTTPS URL you want to use. MyDeck will clear the old credentials first, then ask you to sign in again.</string>
     <string name="http_migration_https_action">Use HTTPS and sign in again</string>
     <string name="http_migration_tailscale_link">Tailscale Serve HTTPS docs</string>
     <string name="http_migration_readeck_proxy_link">Readeck proxy configuration docs</string>
-    <string name="http_migration_http_apk_title">2. Install the HTTP-enabled APK</string>
+    <string name="http_migration_http_apk_title">Install the HTTP-enabled APK</string>
     <string name="http_migration_http_apk_body">Use this separate package only for trusted private-network setups that cannot use HTTPS. It installs beside this app and requires OAuth authorization again.</string>
     <string name="http_migration_http_apk_action">Open latest release</string>
-    <string name="http_migration_logout_title">3. Sign out</string>
-    <string name="http_migration_logout_body">Use this only if you want to clear local credentials and configure MyDeck again from the welcome screen.</string>
     <string name="http_migration_save_error">Could not switch to the HTTPS URL. Please try again.</string>
-    <string name="http_migration_logout_error">Could not finish sign out. Please try again.</string>
 
     <!-- Share Intent / Quick Save -->
     <string name="save_to_mydeck">Zapisz w MyDeck</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -211,6 +211,20 @@
     <string name="welcome_title">Welcome to MyDeck</string>
     <string name="welcome_message">MyDeck is a read-later app for Readeck. Enter your Readeck server address below to get started. You\'ll be guided through a quick authorization process to connect your account.</string>
     <string name="welcome_connect_button">Connect</string>
+    <string name="http_migration_title">HTTP server URL blocked</string>
+    <string name="http_migration_body">This MyDeck build now allows HTTPS Readeck server URLs only. Your saved server URL is %1$s, so MyDeck has stopped before syncing.</string>
+    <string name="http_migration_https_title">1. Change the server URL to HTTPS</string>
+    <string name="http_migration_https_body">Enter the HTTPS URL you want to use. MyDeck will clear the old credentials first, then ask you to sign in again.</string>
+    <string name="http_migration_https_action">Use HTTPS and sign in again</string>
+    <string name="http_migration_tailscale_link">Tailscale Serve HTTPS docs</string>
+    <string name="http_migration_readeck_proxy_link">Readeck proxy configuration docs</string>
+    <string name="http_migration_http_apk_title">2. Install the HTTP-enabled APK</string>
+    <string name="http_migration_http_apk_body">Use this separate package only for trusted private-network setups that cannot use HTTPS. It installs beside this app and requires OAuth authorization again.</string>
+    <string name="http_migration_http_apk_action">Open latest release</string>
+    <string name="http_migration_logout_title">3. Sign out</string>
+    <string name="http_migration_logout_body">Use this only if you want to clear local credentials and configure MyDeck again from the welcome screen.</string>
+    <string name="http_migration_save_error">Could not switch to the HTTPS URL. Please try again.</string>
+    <string name="http_migration_logout_error">Could not finish sign out. Please try again.</string>
 
     <!-- Share Intent / Quick Save -->
     <string name="save_to_mydeck">Zapisz w MyDeck</string>
@@ -422,6 +436,12 @@
     <string name="about_system_info_server_loading">Loading…</string>
     <string name="about_system_info_server_error">Could not load server information</string>
     <string name="about_system_info_server_unavailable">No server information available</string>
+    <string name="about_network_policy_server_urls">Server URLs: %s</string>
+    <string name="about_network_policy_server_urls_https_only">HTTPS only</string>
+    <string name="about_network_policy_server_urls_http_allowed">HTTP allowed</string>
+    <string name="about_network_policy_https_trust">HTTPS trust: %s</string>
+    <string name="about_network_policy_https_trust_system">system certificate authorities</string>
+    <string name="about_network_policy_https_trust_system_user">system + user certificate authorities</string>
     <string name="auto_sync_timeframe_15_minutes">Every 15 minutes</string>
     <string name="highlight_offline_unavailable">Highlights can\'t be changed while offline</string>
     <string name="video_highlight_edit_not_supported">Editing video highlights isn\'t supported yet</string>
@@ -470,7 +490,8 @@
     <string name="sync_status_last_content_sync_label">Last content sync</string>
     <string name="sync_status_next_sync">Next sync: %1$s</string>
     <string name="sync_status_favorites_label">Favorites</string>
-    <string name="account_settings_url_http_warning">Insecure connection — only use on a trusted private network (e.g. Tailscale)</string>
+    <string name="account_settings_url_http_warning">This HTTP URL sends OAuth tokens without TLS. You are using the HTTP-enabled MyDeck build; prefer a Tailscale Serve HTTPS URL or a reverse proxy with HTTPS when possible.</string>
+    <string name="account_settings_http_blocked_error">HTTP Readeck server URLs are not allowed in this MyDeck build.</string>
 
     <string name="app_name">MyDeck</string>
     <string name="back">Back</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -211,6 +211,20 @@
     <string name="welcome_title">Welcome to MyDeck</string>
     <string name="welcome_message">MyDeck is a read-later app for Readeck. Enter your Readeck server address below to get started. You\'ll be guided through a quick authorization process to connect your account.</string>
     <string name="welcome_connect_button">Connect</string>
+    <string name="http_migration_title">HTTP server URL blocked</string>
+    <string name="http_migration_body">This MyDeck build now allows HTTPS Readeck server URLs only. Your saved server URL is %1$s, so MyDeck has stopped before syncing.</string>
+    <string name="http_migration_https_title">1. Change the server URL to HTTPS</string>
+    <string name="http_migration_https_body">Enter the HTTPS URL you want to use. MyDeck will clear the old credentials first, then ask you to sign in again.</string>
+    <string name="http_migration_https_action">Use HTTPS and sign in again</string>
+    <string name="http_migration_tailscale_link">Tailscale Serve HTTPS docs</string>
+    <string name="http_migration_readeck_proxy_link">Readeck proxy configuration docs</string>
+    <string name="http_migration_http_apk_title">2. Install the HTTP-enabled APK</string>
+    <string name="http_migration_http_apk_body">Use this separate package only for trusted private-network setups that cannot use HTTPS. It installs beside this app and requires OAuth authorization again.</string>
+    <string name="http_migration_http_apk_action">Open latest release</string>
+    <string name="http_migration_logout_title">3. Sign out</string>
+    <string name="http_migration_logout_body">Use this only if you want to clear local credentials and configure MyDeck again from the welcome screen.</string>
+    <string name="http_migration_save_error">Could not switch to the HTTPS URL. Please try again.</string>
+    <string name="http_migration_logout_error">Could not finish sign out. Please try again.</string>
 
     <!-- Share Intent / Quick Save -->
     <string name="save_to_mydeck">Guardar no MyDeck</string>
@@ -422,6 +436,12 @@
     <string name="about_system_info_server_loading">Loading…</string>
     <string name="about_system_info_server_error">Could not load server information</string>
     <string name="about_system_info_server_unavailable">No server information available</string>
+    <string name="about_network_policy_server_urls">Server URLs: %s</string>
+    <string name="about_network_policy_server_urls_https_only">HTTPS only</string>
+    <string name="about_network_policy_server_urls_http_allowed">HTTP allowed</string>
+    <string name="about_network_policy_https_trust">HTTPS trust: %s</string>
+    <string name="about_network_policy_https_trust_system">system certificate authorities</string>
+    <string name="about_network_policy_https_trust_system_user">system + user certificate authorities</string>
     <string name="auto_sync_timeframe_15_minutes">Every 15 minutes</string>
     <string name="highlight_offline_unavailable">Highlights can\'t be changed while offline</string>
     <string name="video_highlight_edit_not_supported">Editing video highlights isn\'t supported yet</string>
@@ -470,7 +490,8 @@
     <string name="sync_status_last_content_sync_label">Last content sync</string>
     <string name="sync_status_next_sync">Next sync: %1$s</string>
     <string name="sync_status_favorites_label">Favorites</string>
-    <string name="account_settings_url_http_warning">Insecure connection — only use on a trusted private network (e.g. Tailscale)</string>
+    <string name="account_settings_url_http_warning">This HTTP URL sends OAuth tokens without TLS. You are using the HTTP-enabled MyDeck build; prefer a Tailscale Serve HTTPS URL or a reverse proxy with HTTPS when possible.</string>
+    <string name="account_settings_http_blocked_error">HTTP Readeck server URLs are not allowed in this MyDeck build.</string>
 
     <string name="app_name">MyDeck</string>
     <string name="back">Back</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -213,18 +213,15 @@
     <string name="welcome_connect_button">Connect</string>
     <string name="http_migration_title">HTTP server URL blocked</string>
     <string name="http_migration_body">This MyDeck build now allows HTTPS Readeck server URLs only. Your saved server URL is %1$s, so MyDeck has stopped before syncing.</string>
-    <string name="http_migration_https_title">1. Change the server URL to HTTPS</string>
+    <string name="http_migration_https_title">Switch to HTTPS</string>
     <string name="http_migration_https_body">Enter the HTTPS URL you want to use. MyDeck will clear the old credentials first, then ask you to sign in again.</string>
     <string name="http_migration_https_action">Use HTTPS and sign in again</string>
     <string name="http_migration_tailscale_link">Tailscale Serve HTTPS docs</string>
     <string name="http_migration_readeck_proxy_link">Readeck proxy configuration docs</string>
-    <string name="http_migration_http_apk_title">2. Install the HTTP-enabled APK</string>
+    <string name="http_migration_http_apk_title">Install the HTTP-enabled APK</string>
     <string name="http_migration_http_apk_body">Use this separate package only for trusted private-network setups that cannot use HTTPS. It installs beside this app and requires OAuth authorization again.</string>
     <string name="http_migration_http_apk_action">Open latest release</string>
-    <string name="http_migration_logout_title">3. Sign out</string>
-    <string name="http_migration_logout_body">Use this only if you want to clear local credentials and configure MyDeck again from the welcome screen.</string>
     <string name="http_migration_save_error">Could not switch to the HTTPS URL. Please try again.</string>
-    <string name="http_migration_logout_error">Could not finish sign out. Please try again.</string>
 
     <!-- Share Intent / Quick Save -->
     <string name="save_to_mydeck">Guardar no MyDeck</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -211,6 +211,20 @@
     <string name="welcome_title">Welcome to MyDeck</string>
     <string name="welcome_message">MyDeck is a read-later app for Readeck. Enter your Readeck server address below to get started. You\'ll be guided through a quick authorization process to connect your account.</string>
     <string name="welcome_connect_button">Connect</string>
+    <string name="http_migration_title">HTTP server URL blocked</string>
+    <string name="http_migration_body">This MyDeck build now allows HTTPS Readeck server URLs only. Your saved server URL is %1$s, so MyDeck has stopped before syncing.</string>
+    <string name="http_migration_https_title">1. Change the server URL to HTTPS</string>
+    <string name="http_migration_https_body">Enter the HTTPS URL you want to use. MyDeck will clear the old credentials first, then ask you to sign in again.</string>
+    <string name="http_migration_https_action">Use HTTPS and sign in again</string>
+    <string name="http_migration_tailscale_link">Tailscale Serve HTTPS docs</string>
+    <string name="http_migration_readeck_proxy_link">Readeck proxy configuration docs</string>
+    <string name="http_migration_http_apk_title">2. Install the HTTP-enabled APK</string>
+    <string name="http_migration_http_apk_body">Use this separate package only for trusted private-network setups that cannot use HTTPS. It installs beside this app and requires OAuth authorization again.</string>
+    <string name="http_migration_http_apk_action">Open latest release</string>
+    <string name="http_migration_logout_title">3. Sign out</string>
+    <string name="http_migration_logout_body">Use this only if you want to clear local credentials and configure MyDeck again from the welcome screen.</string>
+    <string name="http_migration_save_error">Could not switch to the HTTPS URL. Please try again.</string>
+    <string name="http_migration_logout_error">Could not finish sign out. Please try again.</string>
 
     <!-- Share Intent / Quick Save -->
     <string name="save_to_mydeck">Сохранить в MyDeck</string>
@@ -422,6 +436,12 @@
     <string name="about_system_info_server_loading">Loading…</string>
     <string name="about_system_info_server_error">Could not load server information</string>
     <string name="about_system_info_server_unavailable">No server information available</string>
+    <string name="about_network_policy_server_urls">Server URLs: %s</string>
+    <string name="about_network_policy_server_urls_https_only">HTTPS only</string>
+    <string name="about_network_policy_server_urls_http_allowed">HTTP allowed</string>
+    <string name="about_network_policy_https_trust">HTTPS trust: %s</string>
+    <string name="about_network_policy_https_trust_system">system certificate authorities</string>
+    <string name="about_network_policy_https_trust_system_user">system + user certificate authorities</string>
     <string name="auto_sync_timeframe_15_minutes">Every 15 minutes</string>
     <string name="highlight_offline_unavailable">Highlights can\'t be changed while offline</string>
     <string name="video_highlight_edit_not_supported">Editing video highlights isn\'t supported yet</string>
@@ -470,7 +490,8 @@
     <string name="sync_status_last_content_sync_label">Last content sync</string>
     <string name="sync_status_next_sync">Next sync: %1$s</string>
     <string name="sync_status_favorites_label">Favorites</string>
-    <string name="account_settings_url_http_warning">Insecure connection — only use on a trusted private network (e.g. Tailscale)</string>
+    <string name="account_settings_url_http_warning">This HTTP URL sends OAuth tokens without TLS. You are using the HTTP-enabled MyDeck build; prefer a Tailscale Serve HTTPS URL or a reverse proxy with HTTPS when possible.</string>
+    <string name="account_settings_http_blocked_error">HTTP Readeck server URLs are not allowed in this MyDeck build.</string>
 
     <string name="app_name">MyDeck</string>
     <string name="back">Back</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -213,18 +213,15 @@
     <string name="welcome_connect_button">Connect</string>
     <string name="http_migration_title">HTTP server URL blocked</string>
     <string name="http_migration_body">This MyDeck build now allows HTTPS Readeck server URLs only. Your saved server URL is %1$s, so MyDeck has stopped before syncing.</string>
-    <string name="http_migration_https_title">1. Change the server URL to HTTPS</string>
+    <string name="http_migration_https_title">Switch to HTTPS</string>
     <string name="http_migration_https_body">Enter the HTTPS URL you want to use. MyDeck will clear the old credentials first, then ask you to sign in again.</string>
     <string name="http_migration_https_action">Use HTTPS and sign in again</string>
     <string name="http_migration_tailscale_link">Tailscale Serve HTTPS docs</string>
     <string name="http_migration_readeck_proxy_link">Readeck proxy configuration docs</string>
-    <string name="http_migration_http_apk_title">2. Install the HTTP-enabled APK</string>
+    <string name="http_migration_http_apk_title">Install the HTTP-enabled APK</string>
     <string name="http_migration_http_apk_body">Use this separate package only for trusted private-network setups that cannot use HTTPS. It installs beside this app and requires OAuth authorization again.</string>
     <string name="http_migration_http_apk_action">Open latest release</string>
-    <string name="http_migration_logout_title">3. Sign out</string>
-    <string name="http_migration_logout_body">Use this only if you want to clear local credentials and configure MyDeck again from the welcome screen.</string>
     <string name="http_migration_save_error">Could not switch to the HTTPS URL. Please try again.</string>
-    <string name="http_migration_logout_error">Could not finish sign out. Please try again.</string>
 
     <!-- Share Intent / Quick Save -->
     <string name="save_to_mydeck">Сохранить в MyDeck</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -211,6 +211,20 @@
     <string name="welcome_title">Welcome to MyDeck</string>
     <string name="welcome_message">MyDeck is a read-later app for Readeck. Enter your Readeck server address below to get started. You\'ll be guided through a quick authorization process to connect your account.</string>
     <string name="welcome_connect_button">Connect</string>
+    <string name="http_migration_title">HTTP server URL blocked</string>
+    <string name="http_migration_body">This MyDeck build now allows HTTPS Readeck server URLs only. Your saved server URL is %1$s, so MyDeck has stopped before syncing.</string>
+    <string name="http_migration_https_title">1. Change the server URL to HTTPS</string>
+    <string name="http_migration_https_body">Enter the HTTPS URL you want to use. MyDeck will clear the old credentials first, then ask you to sign in again.</string>
+    <string name="http_migration_https_action">Use HTTPS and sign in again</string>
+    <string name="http_migration_tailscale_link">Tailscale Serve HTTPS docs</string>
+    <string name="http_migration_readeck_proxy_link">Readeck proxy configuration docs</string>
+    <string name="http_migration_http_apk_title">2. Install the HTTP-enabled APK</string>
+    <string name="http_migration_http_apk_body">Use this separate package only for trusted private-network setups that cannot use HTTPS. It installs beside this app and requires OAuth authorization again.</string>
+    <string name="http_migration_http_apk_action">Open latest release</string>
+    <string name="http_migration_logout_title">3. Sign out</string>
+    <string name="http_migration_logout_body">Use this only if you want to clear local credentials and configure MyDeck again from the welcome screen.</string>
+    <string name="http_migration_save_error">Could not switch to the HTTPS URL. Please try again.</string>
+    <string name="http_migration_logout_error">Could not finish sign out. Please try again.</string>
 
     <!-- Share Intent / Quick Save -->
     <string name="save_to_mydeck">Зберегти в MyDeck</string>
@@ -422,6 +436,12 @@
     <string name="about_system_info_server_loading">Loading…</string>
     <string name="about_system_info_server_error">Could not load server information</string>
     <string name="about_system_info_server_unavailable">No server information available</string>
+    <string name="about_network_policy_server_urls">Server URLs: %s</string>
+    <string name="about_network_policy_server_urls_https_only">HTTPS only</string>
+    <string name="about_network_policy_server_urls_http_allowed">HTTP allowed</string>
+    <string name="about_network_policy_https_trust">HTTPS trust: %s</string>
+    <string name="about_network_policy_https_trust_system">system certificate authorities</string>
+    <string name="about_network_policy_https_trust_system_user">system + user certificate authorities</string>
     <string name="auto_sync_timeframe_15_minutes">Every 15 minutes</string>
     <string name="highlight_offline_unavailable">Highlights can\'t be changed while offline</string>
     <string name="video_highlight_edit_not_supported">Editing video highlights isn\'t supported yet</string>
@@ -470,7 +490,8 @@
     <string name="sync_status_last_content_sync_label">Last content sync</string>
     <string name="sync_status_next_sync">Next sync: %1$s</string>
     <string name="sync_status_favorites_label">Favorites</string>
-    <string name="account_settings_url_http_warning">Insecure connection — only use on a trusted private network (e.g. Tailscale)</string>
+    <string name="account_settings_url_http_warning">This HTTP URL sends OAuth tokens without TLS. You are using the HTTP-enabled MyDeck build; prefer a Tailscale Serve HTTPS URL or a reverse proxy with HTTPS when possible.</string>
+    <string name="account_settings_http_blocked_error">HTTP Readeck server URLs are not allowed in this MyDeck build.</string>
 
     <string name="app_name">MyDeck</string>
     <string name="back">Back</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -213,18 +213,15 @@
     <string name="welcome_connect_button">Connect</string>
     <string name="http_migration_title">HTTP server URL blocked</string>
     <string name="http_migration_body">This MyDeck build now allows HTTPS Readeck server URLs only. Your saved server URL is %1$s, so MyDeck has stopped before syncing.</string>
-    <string name="http_migration_https_title">1. Change the server URL to HTTPS</string>
+    <string name="http_migration_https_title">Switch to HTTPS</string>
     <string name="http_migration_https_body">Enter the HTTPS URL you want to use. MyDeck will clear the old credentials first, then ask you to sign in again.</string>
     <string name="http_migration_https_action">Use HTTPS and sign in again</string>
     <string name="http_migration_tailscale_link">Tailscale Serve HTTPS docs</string>
     <string name="http_migration_readeck_proxy_link">Readeck proxy configuration docs</string>
-    <string name="http_migration_http_apk_title">2. Install the HTTP-enabled APK</string>
+    <string name="http_migration_http_apk_title">Install the HTTP-enabled APK</string>
     <string name="http_migration_http_apk_body">Use this separate package only for trusted private-network setups that cannot use HTTPS. It installs beside this app and requires OAuth authorization again.</string>
     <string name="http_migration_http_apk_action">Open latest release</string>
-    <string name="http_migration_logout_title">3. Sign out</string>
-    <string name="http_migration_logout_body">Use this only if you want to clear local credentials and configure MyDeck again from the welcome screen.</string>
     <string name="http_migration_save_error">Could not switch to the HTTPS URL. Please try again.</string>
-    <string name="http_migration_logout_error">Could not finish sign out. Please try again.</string>
 
     <!-- Share Intent / Quick Save -->
     <string name="save_to_mydeck">Зберегти в MyDeck</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -334,18 +334,15 @@
     <string name="welcome_connect_button">Connect</string>
     <string name="http_migration_title">HTTP server URL blocked</string>
     <string name="http_migration_body">This MyDeck build now allows HTTPS Readeck server URLs only. Your saved server URL is %1$s, so MyDeck has stopped before syncing.</string>
-    <string name="http_migration_https_title">1. Change the server URL to HTTPS</string>
+    <string name="http_migration_https_title">Switch to HTTPS</string>
     <string name="http_migration_https_body">Enter the HTTPS URL you want to use. MyDeck will clear the old credentials first, then ask you to sign in again.</string>
     <string name="http_migration_https_action">Use HTTPS and sign in again</string>
     <string name="http_migration_tailscale_link">Tailscale Serve HTTPS docs</string>
     <string name="http_migration_readeck_proxy_link">Readeck proxy configuration docs</string>
-    <string name="http_migration_http_apk_title">2. Install the HTTP-enabled APK</string>
+    <string name="http_migration_http_apk_title">Install the HTTP-enabled APK</string>
     <string name="http_migration_http_apk_body">Use this separate package only for trusted private-network setups that cannot use HTTPS. It installs beside this app and requires OAuth authorization again.</string>
     <string name="http_migration_http_apk_action">Open latest release</string>
-    <string name="http_migration_logout_title">3. Sign out</string>
-    <string name="http_migration_logout_body">Use this only if you want to clear local credentials and configure MyDeck again from the welcome screen.</string>
     <string name="http_migration_save_error">Could not switch to the HTTPS URL. Please try again.</string>
-    <string name="http_migration_logout_error">Could not finish sign out. Please try again.</string>
 
     <!-- Share Intent / Quick Save -->
     <string name="save_to_mydeck">保存到 MyDeck</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -6,7 +6,8 @@
     <string name="account_settings_password_placeholder">密码</string>
     <string name="account_settings_login">登录</string>
     <string name="account_settings_url_error">无效的 URL</string>
-    <string name="account_settings_url_http_warning">Insecure connection — only use on a trusted private network (e.g. Tailscale)</string>
+    <string name="account_settings_url_http_warning">This HTTP URL sends OAuth tokens without TLS. You are using the HTTP-enabled MyDeck build; prefer a Tailscale Serve HTTPS URL or a reverse proxy with HTTPS when possible.</string>
+    <string name="account_settings_http_blocked_error">HTTP Readeck server URLs are not allowed in this MyDeck build.</string>
     <string name="favorites">收藏</string>
     <string name="url">URL</string>
     <string name="detail_view_no_content">未找到文章内容</string>
@@ -331,6 +332,20 @@
     <string name="welcome_title">Welcome to MyDeck</string>
     <string name="welcome_message">MyDeck is a read-later app for Readeck. Enter your Readeck server address below to get started. You\'ll be guided through a quick authorization process to connect your account.</string>
     <string name="welcome_connect_button">Connect</string>
+    <string name="http_migration_title">HTTP server URL blocked</string>
+    <string name="http_migration_body">This MyDeck build now allows HTTPS Readeck server URLs only. Your saved server URL is %1$s, so MyDeck has stopped before syncing.</string>
+    <string name="http_migration_https_title">1. Change the server URL to HTTPS</string>
+    <string name="http_migration_https_body">Enter the HTTPS URL you want to use. MyDeck will clear the old credentials first, then ask you to sign in again.</string>
+    <string name="http_migration_https_action">Use HTTPS and sign in again</string>
+    <string name="http_migration_tailscale_link">Tailscale Serve HTTPS docs</string>
+    <string name="http_migration_readeck_proxy_link">Readeck proxy configuration docs</string>
+    <string name="http_migration_http_apk_title">2. Install the HTTP-enabled APK</string>
+    <string name="http_migration_http_apk_body">Use this separate package only for trusted private-network setups that cannot use HTTPS. It installs beside this app and requires OAuth authorization again.</string>
+    <string name="http_migration_http_apk_action">Open latest release</string>
+    <string name="http_migration_logout_title">3. Sign out</string>
+    <string name="http_migration_logout_body">Use this only if you want to clear local credentials and configure MyDeck again from the welcome screen.</string>
+    <string name="http_migration_save_error">Could not switch to the HTTPS URL. Please try again.</string>
+    <string name="http_migration_logout_error">Could not finish sign out. Please try again.</string>
 
     <!-- Share Intent / Quick Save -->
     <string name="save_to_mydeck">保存到 MyDeck</string>
@@ -514,6 +529,12 @@
     <string name="about_system_info_server_loading">Loading…</string>
     <string name="about_system_info_server_error">Could not load server information</string>
     <string name="about_system_info_server_unavailable">No server information available</string>
+    <string name="about_network_policy_server_urls">Server URLs: %s</string>
+    <string name="about_network_policy_server_urls_https_only">HTTPS only</string>
+    <string name="about_network_policy_server_urls_http_allowed">HTTP allowed</string>
+    <string name="about_network_policy_https_trust">HTTPS trust: %s</string>
+    <string name="about_network_policy_https_trust_system">system certificate authorities</string>
+    <string name="about_network_policy_https_trust_system_user">system + user certificate authorities</string>
     <string name="highlight_offline_unavailable">Highlights can\'t be changed while offline</string>
     <string name="video_highlight_edit_not_supported">Editing video highlights isn\'t supported yet</string>
     <string name="video_embed_offline">Video unavailable while offline</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -530,18 +530,15 @@ other{}
     <!-- HTTP URL Migration -->
     <string name="http_migration_title">HTTP server URL blocked</string>
     <string name="http_migration_body">This MyDeck build now allows HTTPS Readeck server URLs only. Your saved server URL is %1$s, so MyDeck has stopped before syncing.</string>
-    <string name="http_migration_https_title">1. Change the server URL to HTTPS</string>
+    <string name="http_migration_https_title">Switch to HTTPS</string>
     <string name="http_migration_https_body">Enter the HTTPS URL you want to use. MyDeck will clear the old credentials first, then ask you to sign in again.</string>
     <string name="http_migration_https_action">Use HTTPS and sign in again</string>
     <string name="http_migration_tailscale_link">Tailscale Serve HTTPS docs</string>
     <string name="http_migration_readeck_proxy_link">Readeck proxy configuration docs</string>
-    <string name="http_migration_http_apk_title">2. Install the HTTP-enabled APK</string>
+    <string name="http_migration_http_apk_title">Install the HTTP-enabled APK</string>
     <string name="http_migration_http_apk_body">Use this separate package only for trusted private-network setups that cannot use HTTPS. It installs beside this app and requires OAuth authorization again.</string>
     <string name="http_migration_http_apk_action">Open latest release</string>
-    <string name="http_migration_logout_title">3. Sign out</string>
-    <string name="http_migration_logout_body">Use this only if you want to clear local credentials and configure MyDeck again from the welcome screen.</string>
     <string name="http_migration_save_error">Could not switch to the HTTPS URL. Please try again.</string>
-    <string name="http_migration_logout_error">Could not finish sign out. Please try again.</string>
 
     <!-- OAuth Device Code Authentication -->
     <string name="oauth_device_auth_title">Authorize MyDeck</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,7 +14,8 @@
     <string name="account_settings_password_placeholder">password</string>
     <string name="account_settings_login">Login</string>
     <string name="account_settings_url_error">Invalid URL</string>
-    <string name="account_settings_url_http_warning">Insecure connection — only use on a trusted private network (e.g. Tailscale)</string>
+    <string name="account_settings_url_http_warning">This HTTP URL sends OAuth tokens without TLS. You are using the HTTP-enabled MyDeck build; prefer a Tailscale Serve HTTPS URL or a reverse proxy with HTTPS when possible.</string>
+    <string name="account_settings_http_blocked_error">HTTP Readeck server URLs are not allowed in this MyDeck build.</string>
     <string name="account_settings_initial_sync_failed">Initial sync failed. Please check your connection and try again.</string>
     <string name="account_settings_username_error">Email address cannot be empty</string>
     <string name="account_settings_password_error">Password cannot be empty</string>
@@ -287,6 +288,12 @@ other{}
     <string name="about_system_info_server_loading">Loading…</string>
     <string name="about_system_info_server_error">Could not load server information</string>
     <string name="about_system_info_server_unavailable">No server information available</string>
+    <string name="about_network_policy_server_urls">Server URLs: %s</string>
+    <string name="about_network_policy_server_urls_https_only">HTTPS only</string>
+    <string name="about_network_policy_server_urls_http_allowed">HTTP allowed</string>
+    <string name="about_network_policy_https_trust">HTTPS trust: %s</string>
+    <string name="about_network_policy_https_trust_system">system certificate authorities</string>
+    <string name="about_network_policy_https_trust_system_user">system + user certificate authorities</string>
     <string name="about_project_title">Project</string>
     <string name="about_project_this_repo">MyDeck Repository (Fork)</string>
     <string name="about_project_original_repo">Original ReadeckApp Repository</string>
@@ -519,6 +526,22 @@ other{}
     <string name="welcome_title">Welcome to MyDeck</string>
     <string name="welcome_message">MyDeck is a read-later app for Readeck. Enter your Readeck server address below to get started. You\'ll be guided through a quick authorization process to connect your account.</string>
     <string name="welcome_connect_button">Connect</string>
+
+    <!-- HTTP URL Migration -->
+    <string name="http_migration_title">HTTP server URL blocked</string>
+    <string name="http_migration_body">This MyDeck build now allows HTTPS Readeck server URLs only. Your saved server URL is %1$s, so MyDeck has stopped before syncing.</string>
+    <string name="http_migration_https_title">1. Change the server URL to HTTPS</string>
+    <string name="http_migration_https_body">Enter the HTTPS URL you want to use. MyDeck will clear the old credentials first, then ask you to sign in again.</string>
+    <string name="http_migration_https_action">Use HTTPS and sign in again</string>
+    <string name="http_migration_tailscale_link">Tailscale Serve HTTPS docs</string>
+    <string name="http_migration_readeck_proxy_link">Readeck proxy configuration docs</string>
+    <string name="http_migration_http_apk_title">2. Install the HTTP-enabled APK</string>
+    <string name="http_migration_http_apk_body">Use this separate package only for trusted private-network setups that cannot use HTTPS. It installs beside this app and requires OAuth authorization again.</string>
+    <string name="http_migration_http_apk_action">Open latest release</string>
+    <string name="http_migration_logout_title">3. Sign out</string>
+    <string name="http_migration_logout_body">Use this only if you want to clear local credentials and configure MyDeck again from the welcome screen.</string>
+    <string name="http_migration_save_error">Could not switch to the HTTPS URL. Please try again.</string>
+    <string name="http_migration_logout_error">Could not finish sign out. Please try again.</string>
 
     <!-- OAuth Device Code Authentication -->
     <string name="oauth_device_auth_title">Authorize MyDeck</string>

--- a/app/src/test/java/com/mydeck/app/io/rest/ReadeckHttpPolicyInterceptorTest.kt
+++ b/app/src/test/java/com/mydeck/app/io/rest/ReadeckHttpPolicyInterceptorTest.kt
@@ -1,0 +1,59 @@
+package com.mydeck.app.io.rest
+
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ReadeckHttpPolicyInterceptorTest {
+    @Test
+    fun `blocks http requests when insecure http is disabled`() {
+        val server = MockWebServer()
+        server.start()
+        try {
+            val client = OkHttpClient.Builder()
+                .addInterceptor(ReadeckHttpPolicyInterceptor(allowInsecureHttp = false))
+                .build()
+            val request = Request.Builder()
+                .url(server.url("/api/info"))
+                .build()
+
+            try {
+                client.newCall(request).execute()
+                error("Expected HTTP policy block")
+            } catch (e: HttpBlockedByBuildPolicyException) {
+                assertTrue(e.isHttpBlockedByBuildPolicy())
+            }
+
+            assertEquals(0, server.requestCount)
+        } finally {
+            server.shutdown()
+        }
+    }
+
+    @Test
+    fun `allows http requests when insecure http is enabled`() {
+        val server = MockWebServer()
+        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+        server.start()
+        try {
+            val client = OkHttpClient.Builder()
+                .addInterceptor(ReadeckHttpPolicyInterceptor(allowInsecureHttp = true))
+                .build()
+            val request = Request.Builder()
+                .url(server.url("/api/info"))
+                .build()
+
+            client.newCall(request).execute().use { response ->
+                assertTrue(response.isSuccessful)
+            }
+
+            assertEquals(1, server.requestCount)
+        } finally {
+            server.shutdown()
+        }
+    }
+}

--- a/app/src/test/java/com/mydeck/app/ui/migration/HttpUrlMigrationViewModelTest.kt
+++ b/app/src/test/java/com/mydeck/app/ui/migration/HttpUrlMigrationViewModelTest.kt
@@ -34,8 +34,9 @@ class HttpUrlMigrationViewModelTest {
         userRepository = mockk()
 
         every { settingsDataStore.urlFlow } returns MutableStateFlow("http://192.168.1.10/api")
-        coEvery { settingsDataStore.clearCredentials() } coAnswers {
-            calls += "clearCredentials"
+        coEvery { userRepository.logout() } coAnswers {
+            calls += "revokeThenClearCredentials"
+            UserRepository.LogoutResult.Success
         }
         every { settingsDataStore.saveUrl(any()) } answers {
             calls += "saveUrl:${firstArg<String>()}"
@@ -48,7 +49,7 @@ class HttpUrlMigrationViewModelTest {
     }
 
     @Test
-    fun `saveReplacementUrl clears credentials before saving HTTPS URL`() = runTest {
+    fun `saveReplacementUrl logs out before saving HTTPS URL`() = runTest {
         val viewModel = HttpUrlMigrationViewModel(
             settingsDataStore = settingsDataStore,
             userRepository = userRepository
@@ -60,7 +61,7 @@ class HttpUrlMigrationViewModelTest {
 
         assertEquals(
             listOf(
-                "clearCredentials",
+                "revokeThenClearCredentials",
                 "saveUrl:https://readeck.example/api"
             ),
             calls

--- a/app/src/test/java/com/mydeck/app/ui/migration/HttpUrlMigrationViewModelTest.kt
+++ b/app/src/test/java/com/mydeck/app/ui/migration/HttpUrlMigrationViewModelTest.kt
@@ -5,6 +5,7 @@ import com.mydeck.app.io.prefs.SettingsDataStore
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -24,6 +25,7 @@ class HttpUrlMigrationViewModelTest {
     private val testDispatcher = StandardTestDispatcher()
     private lateinit var settingsDataStore: SettingsDataStore
     private lateinit var userRepository: UserRepository
+    private lateinit var loginCoordinator: HttpUrlMigrationLoginCoordinator
     private lateinit var calls: MutableList<String>
 
     @Before
@@ -32,6 +34,7 @@ class HttpUrlMigrationViewModelTest {
         calls = mutableListOf()
         settingsDataStore = mockk()
         userRepository = mockk()
+        loginCoordinator = mockk(relaxed = true)
 
         every { settingsDataStore.urlFlow } returns MutableStateFlow("http://192.168.1.10/api")
         coEvery { userRepository.logout() } coAnswers {
@@ -52,7 +55,8 @@ class HttpUrlMigrationViewModelTest {
     fun `saveReplacementUrl logs out before saving HTTPS URL`() = runTest {
         val viewModel = HttpUrlMigrationViewModel(
             settingsDataStore = settingsDataStore,
-            userRepository = userRepository
+            userRepository = userRepository,
+            loginCoordinator = loginCoordinator
         )
 
         viewModel.updateReplacementUrl("https://readeck.example")
@@ -66,5 +70,6 @@ class HttpUrlMigrationViewModelTest {
             ),
             calls
         )
+        verify { loginCoordinator.requestLogin("https://readeck.example/api") }
     }
 }

--- a/app/src/test/java/com/mydeck/app/ui/migration/HttpUrlMigrationViewModelTest.kt
+++ b/app/src/test/java/com/mydeck/app/ui/migration/HttpUrlMigrationViewModelTest.kt
@@ -1,0 +1,69 @@
+package com.mydeck.app.ui.migration
+
+import com.mydeck.app.domain.UserRepository
+import com.mydeck.app.io.prefs.SettingsDataStore
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class HttpUrlMigrationViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var settingsDataStore: SettingsDataStore
+    private lateinit var userRepository: UserRepository
+    private lateinit var calls: MutableList<String>
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        calls = mutableListOf()
+        settingsDataStore = mockk()
+        userRepository = mockk()
+
+        every { settingsDataStore.urlFlow } returns MutableStateFlow("http://192.168.1.10/api")
+        coEvery { settingsDataStore.clearCredentials() } coAnswers {
+            calls += "clearCredentials"
+        }
+        every { settingsDataStore.saveUrl(any()) } answers {
+            calls += "saveUrl:${firstArg<String>()}"
+        }
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `saveReplacementUrl clears credentials before saving HTTPS URL`() = runTest {
+        val viewModel = HttpUrlMigrationViewModel(
+            settingsDataStore = settingsDataStore,
+            userRepository = userRepository
+        )
+
+        viewModel.updateReplacementUrl("https://readeck.example")
+        viewModel.saveReplacementUrl()
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf(
+                "clearCredentials",
+                "saveUrl:https://readeck.example/api"
+            ),
+            calls
+        )
+    }
+}

--- a/app/src/test/java/com/mydeck/app/ui/settings/AccountSettingsViewModelTest.kt
+++ b/app/src/test/java/com/mydeck/app/ui/settings/AccountSettingsViewModelTest.kt
@@ -7,6 +7,7 @@ import com.mydeck.app.domain.UserRepository
 import com.mydeck.app.domain.model.OAuthDeviceAuthorizationState
 import com.mydeck.app.domain.usecase.OAuthDeviceAuthorizationUseCase
 import com.mydeck.app.io.prefs.SettingsDataStore
+import com.mydeck.app.ui.migration.HttpUrlMigrationLoginCoordinator
 import com.mydeck.app.worker.LoadBookmarksWorker
 import android.content.Context
 import androidx.work.WorkInfo
@@ -54,6 +55,7 @@ class AccountSettingsViewModelTest {
     private lateinit var workManager: WorkManager
     private lateinit var context: Context
     private lateinit var applicationScope: CoroutineScope
+    private lateinit var httpUrlMigrationLoginCoordinator: HttpUrlMigrationLoginCoordinator
     private lateinit var viewModel: AccountSettingsViewModel
 
     @Before
@@ -67,6 +69,7 @@ class AccountSettingsViewModelTest {
         workManager = mockk()
         context = mockk()
         applicationScope = TestScope(testDispatcher)
+        httpUrlMigrationLoginCoordinator = HttpUrlMigrationLoginCoordinator()
         mockkObject(LoadBookmarksWorker.Companion)
         
         every { settingsDataStore.urlFlow } returns MutableStateFlow("")
@@ -88,7 +91,8 @@ class AccountSettingsViewModelTest {
             oauthDeviceAuthUseCase = oauthDeviceAuthUseCase,
             workManager = workManager,
             context = context,
-            applicationScope = applicationScope
+            applicationScope = applicationScope,
+            httpUrlMigrationLoginCoordinator = httpUrlMigrationLoginCoordinator
         )
     }
 
@@ -109,7 +113,8 @@ class AccountSettingsViewModelTest {
             oauthDeviceAuthUseCase = oauthDeviceAuthUseCase,
             workManager = workManager,
             context = context,
-            applicationScope = applicationScope
+            applicationScope = applicationScope,
+            httpUrlMigrationLoginCoordinator = httpUrlMigrationLoginCoordinator
         )
         
         advanceUntilIdle() // Wait for init block to complete
@@ -132,12 +137,59 @@ class AccountSettingsViewModelTest {
             oauthDeviceAuthUseCase = oauthDeviceAuthUseCase,
             workManager = workManager,
             context = context,
-            applicationScope = applicationScope
+            applicationScope = applicationScope,
+            httpUrlMigrationLoginCoordinator = httpUrlMigrationLoginCoordinator
         )
 
         advanceUntilIdle()
 
         assertEquals("https://example.com", viewModel.uiState.value.url)
+    }
+
+    @Test
+    fun `pending HTTP migration login prepopulates URL and starts OAuth`() = runTest {
+        httpUrlMigrationLoginCoordinator.requestLogin("https://example.com/api")
+        coEvery { userRepository.initiateLogin("https://example.com/api") } returns
+            UserRepository.LoginResult.DeviceAuthorizationRequired(
+                OAuthDeviceAuthorizationState(
+                    clientId = "test-client",
+                    deviceCode = "TEST-CODE",
+                    userCode = "TEST-USER-CODE",
+                    verificationUri = "https://example.com/auth",
+                    verificationUriComplete = "https://example.com/auth?code=TEST-USER-CODE",
+                    expiresAt = System.currentTimeMillis() + 1800_000,
+                    pollingInterval = 5
+                )
+            )
+        coEvery {
+            oauthDeviceAuthUseCase.pollForToken(
+                clientId = any(),
+                deviceCode = any(),
+                currentInterval = any()
+            )
+        } returns OAuthDeviceAuthorizationUseCase.TokenPollResult.StillPending
+
+        viewModel = AccountSettingsViewModel(
+            settingsDataStore = settingsDataStore,
+            bookmarkRepository = bookmarkRepository,
+            userRepository = userRepository,
+            oauthDeviceAuthUseCase = oauthDeviceAuthUseCase,
+            workManager = workManager,
+            context = context,
+            applicationScope = applicationScope,
+            httpUrlMigrationLoginCoordinator = httpUrlMigrationLoginCoordinator
+        )
+
+        runCurrent()
+
+        val uiState = viewModel.uiState.value
+        assertEquals("https://example.com", uiState.url)
+        assertEquals(AccountSettingsViewModel.AuthStatus.WaitingForAuthorization, uiState.authStatus)
+        assertNotNull(uiState.deviceAuthState)
+        coVerify { userRepository.initiateLogin("https://example.com/api") }
+
+        viewModel.cancelAuthorization()
+        runCurrent()
     }
 
     private fun assertInitialUiState(settingsUiState: AccountSettingsViewModel.AccountSettingsUiState) {

--- a/app/src/test/java/com/mydeck/app/ui/settings/AccountSettingsViewModelTest.kt
+++ b/app/src/test/java/com/mydeck/app/ui/settings/AccountSettingsViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.mydeck.app.ui.settings
 
 import com.mydeck.app.R
+import com.mydeck.app.BuildConfig
 import com.mydeck.app.domain.BookmarkRepository
 import com.mydeck.app.domain.UserRepository
 import com.mydeck.app.domain.model.OAuthDeviceAuthorizationState
@@ -374,17 +375,21 @@ class AccountSettingsViewModelTest {
     }
 
     @Test
-    fun `updateUrl with http URL should not set urlError`() = runTest {
+    fun `updateUrl with http URL should follow build policy`() = runTest {
         viewModel.updateUrl("http://validurl.com")
         advanceUntilIdle()
         val uiState = viewModel.uiState.first()
-        assertNull(uiState.urlError)
+        if (BuildConfig.ALLOW_INSECURE_HTTP) {
+            assertNull(uiState.urlError)
+        } else {
+            assertEquals(R.string.account_settings_url_error, uiState.urlError)
+        }
     }
 
     @Test
-    fun `loginEnabled should be true when url is http`() = runTest {
+    fun `loginEnabled should follow build policy when url is http`() = runTest {
         viewModel.updateUrl("http://validurl.com")
         advanceUntilIdle()
-        assertTrue(viewModel.uiState.first().loginEnabled)
+        assertEquals(BuildConfig.ALLOW_INSECURE_HTTP, viewModel.uiState.first().loginEnabled)
     }
 }

--- a/docs/specs/release-default-https-only-spec.md
+++ b/docs/specs/release-default-https-only-spec.md
@@ -2,7 +2,41 @@
 
 ## Status
 
-Proposal — not yet scheduled for implementation.
+Implemented in v0.14 (branch `feat/https-only-release-default`). The default flip,
+dual-package build/workflow split, network-boundary enforcement, migration screen,
+and About-screen policy display all shipped. Two designs diverged from this spec
+during implementation — see **Implementation notes** below. Archive to
+`docs/archive/` at v0.14 release time.
+
+## Implementation notes
+
+Two designs diverged from the description below during implementation. They are the
+authoritative record of what shipped:
+
+1. **Central network-boundary interceptor, not a per-call-site guard.** The
+   §Migration and §Code touch points sections describe a guard "shared by foreground
+   API calls and background workers," implying an enumerated list of call sites that
+   each short-circuit before OkHttp. That named list proved incomplete (it missed the
+   annotation flows, `HighlightsViewModel`/repository, `AboutViewModel`, the logout
+   token revoke, and `getBookmarkLog(@Url)`). Instead a single
+   `ReadeckHttpPolicyInterceptor` sits on the ReadeckApi OkHttp client and keys on the
+   actual outbound request scheme — which also resolves the Retrofit `@Url`
+   relative/absolute ambiguity and the login request that has no saved URL yet. The
+   interceptor is scoped to the ReadeckApi client only, deliberately not installed
+   globally, so it never blocks Coil image traffic. It returns a typed result that the
+   UI can distinguish from a generic network failure. Local logout always succeeds; the
+   remote token revoke is best-effort and skipped when HTTP-blocked.
+
+2. **Migration UX collapsed three options to two.** §Migration lists three paths:
+   change the URL to HTTPS, install the HTTP-enabled APK, and log out. Options 1 and 3
+   functionally converged — the app cannot verify that a new HTTPS URL points at the
+   same Readeck instance, and a base-URL change cannot preserve the existing session —
+   so both end in "clear credentials and re-authenticate." They were merged into a
+   single **"Use HTTPS and sign in again"** action: best-effort token revoke → clear
+   credentials → save the normalized HTTPS URL → return to the account/login screen with
+   the HTTPS URL prefilled and OAuth device authorization started automatically. The
+   standalone "Sign out" section (and its `http_migration_logout_*` strings across all
+   locales) was removed. "Install the HTTP-enabled APK" remains as the second path.
 
 ## Context
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. For more details, visit
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects


### PR DESCRIPTION
## Summary

- Make the standard MyDeck package HTTPS-only with system CA trust.
- Add separate HTTP-enabled release and snapshot packages with `.permissive` application IDs and separate app data.
- Add a startup migration screen for existing standard installs with saved `http://` Readeck URLs.
- Add a ReadeckApi-only OkHttp interceptor that blocks HTTP before network I/O in standard builds.
- Update release and snapshot workflows to publish standard and HTTP-enabled APKs while preserving SHA-pinned actions, RC handling, and fail-closed `latest-snapshot` behavior.
- Update docs to match: HTTPS-only spec status + divergences, getting-started guide, SECURITY.md, README.

## Migration UX

When a standard build upgrades over an existing `http://` Readeck URL, MyDeck stops at startup before sync and shows a migration screen with two options:

1. **Use HTTPS and sign in again.** MyDeck best-effort revokes the old token, clears credentials, saves the normalized HTTPS URL, then returns to the account screen with the URL prefilled and OAuth device authorization started automatically. Clearing credentials first avoids token reuse across server origins (an HTTPS URL may point at a different instance).
2. **Install the separate HTTP-enabled APK.**

A standalone "sign out" option was intentionally dropped — it was functionally identical to option 1 (both end in clear-credentials-and-re-authenticate).

## Packaging

Published APK families:

- Standard release: `com.mydeck.app`, `MyDeck-<version>.apk`
- HTTP-enabled release: `com.mydeck.app.permissive`, `MyDeck-<version>-http-enabled.apk`
- Standard snapshot: `com.mydeck.app.snapshot`, `MyDeck-<version>-snapshot.apk`
- HTTP-enabled snapshot: `com.mydeck.app.snapshot.permissive`, `MyDeck-<version>-snapshot-http-enabled.apk`

The HTTP-enabled package can be installed beside the standard package and keeps separate app data.

## Verification

Gradle daemon heap raised to 4096m in `gradle.properties` so the `*All` quality checks no longer OOM.

- `./gradlew :app:assembleDebugAll`
- `./gradlew :app:testDebugUnitTestAll`
- `./gradlew :app:lintDebugAll`
- `./gradlew :app:assembleGithubReleaseRelease`
- `./gradlew :app:assembleGithubReleaseHttpRelease`
- `./gradlew :app:assembleGithubSnapshotHttpRelease`
- Security review: no findings

## Manual Testing

- Fresh standard install rejects `http://` server URLs.
- Upgrade over a prior standard install with saved `http://` URL shows the migration screen before sync.
- "Use HTTPS and sign in again" revokes/clears credentials, saves the HTTPS URL, and auto-starts OAuth sign-in with the URL prefilled.
- HTTP-enabled package installs alongside standard package with separate data.
- About screen shows independent server URL and CA trust policy facts per variant.