### PR TITLE
Feat/multi select 

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,12 @@ Do not fail silently — surface the request in the PR description so the mainta
 
 ---
 
+## Providing Copyable Deliverables (prompts, PR descriptions, discussion posts)
+
+When asked to produce an artifact the user will copy elsewhere — an implementation prompt for another agent, a PR/issue description, a discussion/release post, a commit message, etc. — **always present it as raw markdown inside a fenced code block** so it can be copied verbatim without rendering. Do not render it as normal prose. If the artifact itself contains fenced code blocks, use a longer outer fence (e.g. four backticks) so nesting is preserved.
+
+---
+
 ## Other Guidelines
 
 - Follow existing code style and patterns

--- a/app/src/androidTest/java/com/mydeck/app/ui/list/BookmarkListTopBarOverflowTest.kt
+++ b/app/src/androidTest/java/com/mydeck/app/ui/list/BookmarkListTopBarOverflowTest.kt
@@ -1,0 +1,215 @@
+package com.mydeck.app.ui.list
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.mydeck.app.domain.model.LayoutMode
+import com.mydeck.app.domain.model.SortOption
+import com.mydeck.app.ui.theme.MyDeckTheme
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class BookmarkListTopBarOverflowTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private fun launchNormalMode(
+        onOpenFilterSheet: () -> Unit = {},
+        onEnterMultiSelectMode: () -> Unit = {},
+    ) {
+        composeTestRule.setContent {
+            MyDeckTheme {
+                BookmarkListBarActions(
+                    isLabelMode = false,
+                    layoutMode = LayoutMode.MOSAIC,
+                    sortOption = SortOption.ADDED_NEWEST,
+                    onLayoutModeSelected = {},
+                    onSortOptionSelected = {},
+                    onOpenFilterSheet = onOpenFilterSheet,
+                    onEnterMultiSelectMode = onEnterMultiSelectMode,
+                    onRequestRenameLabel = {},
+                    onRequestDeleteLabel = {},
+                )
+            }
+        }
+    }
+
+    private fun launchLabelMode(
+        onEnterMultiSelectMode: () -> Unit = {},
+        onRequestRenameLabel: () -> Unit = {},
+        onRequestDeleteLabel: () -> Unit = {},
+    ) {
+        composeTestRule.setContent {
+            MyDeckTheme {
+                BookmarkListBarActions(
+                    isLabelMode = true,
+                    layoutMode = LayoutMode.MOSAIC,
+                    sortOption = SortOption.ADDED_NEWEST,
+                    onLayoutModeSelected = {},
+                    onSortOptionSelected = {},
+                    onOpenFilterSheet = {},
+                    onEnterMultiSelectMode = onEnterMultiSelectMode,
+                    onRequestRenameLabel = onRequestRenameLabel,
+                    onRequestDeleteLabel = onRequestDeleteLabel,
+                )
+            }
+        }
+    }
+
+    private fun openOverflow() {
+        composeTestRule.onNodeWithContentDescription("More options").performClick()
+    }
+
+    // -------------------------------------------------------------------------
+    // §8 — Normal mode
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun normalMode_barShowsLayoutSortAndOverflow() {
+        launchNormalMode()
+
+        composeTestRule.onNodeWithContentDescription("Layout").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Sort").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("More options").assertIsDisplayed()
+    }
+
+    @Test
+    fun normalMode_overflowContains_FilterThenSelectBookmarks_inOrder() {
+        launchNormalMode()
+        openOverflow()
+
+        // Both items appear
+        composeTestRule.onNodeWithText("Filter bookmarks").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Select bookmarks").assertIsDisplayed()
+
+        // Filter comes before Select bookmarks in the semantic tree (positional ordering)
+        val filterNode = composeTestRule.onNodeWithText("Filter bookmarks")
+            .fetchSemanticsNode()
+        val selectNode = composeTestRule.onNodeWithText("Select bookmarks")
+            .fetchSemanticsNode()
+        assertTrue(
+            "Filter bookmarks must appear above Select bookmarks",
+            filterNode.positionInRoot.y < selectNode.positionInRoot.y
+        )
+    }
+
+    @Test
+    fun normalMode_overflowDoesNotContain_RenameLabel_OrDeleteLabel() {
+        launchNormalMode()
+        openOverflow()
+
+        composeTestRule.onNodeWithText("Rename label").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Delete label").assertDoesNotExist()
+    }
+
+    @Test
+    fun normalMode_tapFilter_callsOnOpenFilterSheet() {
+        var called = false
+        launchNormalMode(onOpenFilterSheet = { called = true })
+        openOverflow()
+
+        composeTestRule.onNodeWithText("Filter bookmarks").performClick()
+
+        assertTrue("onOpenFilterSheet should have been called", called)
+    }
+
+    @Test
+    fun normalMode_tapSelectBookmarks_callsOnEnterMultiSelectMode() {
+        var called = false
+        launchNormalMode(onEnterMultiSelectMode = { called = true })
+        openOverflow()
+
+        composeTestRule.onNodeWithText("Select bookmarks").performClick()
+
+        assertTrue("onEnterMultiSelectMode should have been called", called)
+    }
+
+    // -------------------------------------------------------------------------
+    // §8 — Label mode
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun labelMode_barShowsLayoutSortAndOverflow() {
+        launchLabelMode()
+
+        composeTestRule.onNodeWithContentDescription("Layout").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Sort").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("More options").assertIsDisplayed()
+    }
+
+    @Test
+    fun labelMode_overflowContains_RenameThenDeleteThenSelectBookmarks() {
+        launchLabelMode()
+        openOverflow()
+
+        composeTestRule.onNodeWithText("Rename label").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Delete label").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Select bookmarks").assertIsDisplayed()
+
+        val renameNode = composeTestRule.onNodeWithText("Rename label").fetchSemanticsNode()
+        val deleteNode = composeTestRule.onNodeWithText("Delete label").fetchSemanticsNode()
+        val selectNode = composeTestRule.onNodeWithText("Select bookmarks").fetchSemanticsNode()
+
+        assertTrue(
+            "Rename label must appear above Delete label",
+            renameNode.positionInRoot.y < deleteNode.positionInRoot.y
+        )
+        assertTrue(
+            "Delete label must appear above Select bookmarks",
+            deleteNode.positionInRoot.y < selectNode.positionInRoot.y
+        )
+    }
+
+    @Test
+    fun labelMode_overflowDoesNotContain_FilterBookmarks() {
+        launchLabelMode()
+        openOverflow()
+
+        composeTestRule.onNodeWithText("Filter bookmarks").assertDoesNotExist()
+    }
+
+    @Test
+    fun labelMode_tapRenameLabel_callsOnRequestRenameLabel() {
+        var called = false
+        launchLabelMode(onRequestRenameLabel = { called = true })
+        openOverflow()
+
+        composeTestRule.onNodeWithText("Rename label").performClick()
+
+        assertTrue("onRequestRenameLabel should have been called", called)
+    }
+
+    @Test
+    fun labelMode_tapDeleteLabel_callsOnRequestDeleteLabel() {
+        var called = false
+        launchLabelMode(onRequestDeleteLabel = { called = true })
+        openOverflow()
+
+        composeTestRule.onNodeWithText("Delete label").performClick()
+
+        assertTrue("onRequestDeleteLabel should have been called", called)
+    }
+
+    @Test
+    fun labelMode_tapSelectBookmarks_callsOnEnterMultiSelectMode() {
+        var called = false
+        launchLabelMode(onEnterMultiSelectMode = { called = true })
+        openOverflow()
+
+        composeTestRule.onNodeWithText("Select bookmarks").performClick()
+
+        assertTrue("onEnterMultiSelectMode should have been called", called)
+    }
+}

--- a/app/src/main/assets/guide/en/organizing.md
+++ b/app/src/main/assets/guide/en/organizing.md
@@ -39,7 +39,7 @@ There are two ways to access these actions:
 
 Tap the **❤️** button on any bookmark card in a list view to mark a bookmark as a favorite. Tap again to remove it. The heart fills when a bookmark is a favorite.
 
-To favorite or unfavorite several bookmarks at once, tap **⋮ → Select bookmarks**, choose the cards you want (or **⋮ → Select all**), then use the favorite action on the bar. If any selected bookmark isn't yet a favorite, the bar offers **Add favorite**; once they all are, it flips to **Remove favorite**, with the opposite action in the overflow. A snackbar confirms the result (e.g. "3 set as favorites") with an **Undo** that reverts only the bookmarks that actually changed. See [Selecting Multiple Bookmarks](./your-bookmarks.md) for the full multi-select flow.
+To favorite or unfavorite several bookmarks at once, tap **⋮ → Select bookmarks**, choose the cards you want (or **⋮ → Select all**), then use the favorite action on the bar. If any selected bookmark isn't yet a favorite, the bar offers **Add favorite**; once they all are, it flips to **Remove favorite**. The selection stays put after the action, so you can keep working with it. A snackbar confirms the result (e.g. "3 set as favorites") with an **Undo** that reverts only the bookmarks that actually changed. See [Selecting Multiple Bookmarks](./your-bookmarks.md) for the full multi-select flow.
 
 In the reading view, you can toggle favorites using:
 - The **❤️ Favorite / Remove favorite** button at the end of the content
@@ -54,7 +54,7 @@ Archiving moves a bookmark out of **My List** into the **Archive**. Archived boo
 You can archive a bookmark from several places:
 
 - **Card action** — tap the Archive button on a bookmark card in any list view
-- **Multi-select** — tap **⋮ → Select bookmarks**, choose the cards you want (or **⋮ → Select all**), then use the archive action on the bar. It offers **Archive** when any selected bookmark isn't yet archived, and flips to **Unarchive** once they all are, with the opposite action in the overflow. A snackbar confirms the result (e.g. "5 set as archived") with an **Undo** that reverts only the bookmarks that actually changed.
+- **Multi-select** — tap **⋮ → Select bookmarks**, choose the cards you want (or **⋮ → Select all**), then use the archive action on the bar. It offers **Archive** when any selected bookmark isn't yet archived, and flips to **Unarchive** once they all are. A snackbar confirms the result (e.g. "5 set as archived") with an **Undo** that reverts only the bookmarks that actually changed. Because archiving removes items from My List, selection mode exits automatically once the last selected card leaves the view.
 - **Reading view** — use the **📦 Archive / Unarchive** button at the end of the content or **⋮** → **Archive / Unarchive**
 - **Add Link sheet** — tap **Archive** to save a new bookmark directly to the Archive
 
@@ -72,4 +72,4 @@ To delete a bookmark, tap the **🗑️** button on its card in a list view, or 
 
 When deleting from a list view, the card is greyed out and a **"Deleting bookmark \"Title...\""** bar appears at the bottom of the screen with a short title snippet so you can tell which queued delete **Undo** will restore. Tap **Undo** to restore it, or tap anywhere else (including the greyed-out card) to confirm deletion. When deleting from the reading view, you are returned to the list and the same undo bar appears.
 
-To delete several bookmarks at once, tap **⋮ → Select bookmarks**, choose the cards you want, then tap the **🗑️ Delete** icon in the top bar. Selection mode exits and a **"N bookmarks deleted"** snackbar appears with an **Undo** action. The staged bookmarks stay greyed out until you tap **Undo** to restore them all, or let the snackbar go (or interact elsewhere) to confirm the deletion.
+To delete several bookmarks at once, tap **⋮ → Select bookmarks**, choose the cards you want, then open the **⋮ overflow** and tap **🗑️ Delete**. Selection mode exits and a **"N bookmarks deleted"** snackbar appears with an **Undo** action. The staged bookmarks stay greyed out until you tap **Undo** to restore them all, or let the snackbar go (or interact elsewhere) to confirm the deletion.

--- a/app/src/main/assets/guide/en/organizing.md
+++ b/app/src/main/assets/guide/en/organizing.md
@@ -39,12 +39,7 @@ There are two ways to access these actions:
 
 Tap the **❤️** button on any bookmark card in a list view to mark a bookmark as a favorite. Tap again to remove it. The heart fills when a bookmark is a favorite.
 
-To favorite or unfavorite several bookmarks at once, tap the **select icon** in the bookmark list top bar and choose the cards you want (or tap **⋮ → Select all** to choose every bookmark in the current view). The top bar exposes the most useful favorite action for your current selection:
-
-- If any selected bookmark is **not** yet a favorite, the bar shows **❤️ Add favorite**. The overflow has **Remove favorite**.
-- If **all** selected bookmarks are already favorites, the bar promotes **Remove favorite** for one-tap reversal; the overflow's **Add favorite** is greyed out.
-
-A snackbar confirms the post-state of the selection (e.g. "3 set as favorites", "3 unset as favorites").
+To favorite or unfavorite several bookmarks at once, tap **⋮ → Select bookmarks**, choose the cards you want (or **⋮ → Select all**), then use the favorite action on the bar. If any selected bookmark isn't yet a favorite, the bar offers **Add favorite**; once they all are, it flips to **Remove favorite**, with the opposite action in the overflow. A snackbar confirms the result (e.g. "3 set as favorites") with an **Undo** that reverts only the bookmarks that actually changed. See [Selecting Multiple Bookmarks](./your-bookmarks.md) for the full multi-select flow.
 
 In the reading view, you can toggle favorites using:
 - The **❤️ Favorite / Remove favorite** button at the end of the content
@@ -59,7 +54,7 @@ Archiving moves a bookmark out of **My List** into the **Archive**. Archived boo
 You can archive a bookmark from several places:
 
 - **Card action** — tap the Archive button on a bookmark card in any list view
-- **Multi-select** — tap the **select icon** in the bookmark list top bar, choose the cards you want (or tap **⋮ → Select all**). The top bar exposes whichever archive action is most useful: **Archive** when any selected bookmark is not yet archived (overflow holds **Unarchive**), or **Unarchive** promoted to the bar when all selected bookmarks are already archived (overflow's Archive is greyed out). A snackbar confirms the post-state of the selection (e.g. "5 set as archived", "5 unset as archived").
+- **Multi-select** — tap **⋮ → Select bookmarks**, choose the cards you want (or **⋮ → Select all**), then use the archive action on the bar. It offers **Archive** when any selected bookmark isn't yet archived, and flips to **Unarchive** once they all are, with the opposite action in the overflow. A snackbar confirms the result (e.g. "5 set as archived") with an **Undo** that reverts only the bookmarks that actually changed.
 - **Reading view** — use the **📦 Archive / Unarchive** button at the end of the content or **⋮** → **Archive / Unarchive**
 - **Add Link sheet** — tap **Archive** to save a new bookmark directly to the Archive
 
@@ -76,3 +71,5 @@ Highlights let you mark passages in articles and transcripts with a color and an
 To delete a bookmark, tap the **🗑️** button on its card in a list view, or tap **⋮** → **Delete** in the reading view.
 
 When deleting from a list view, the card is greyed out and a **"Deleting bookmark \"Title...\""** bar appears at the bottom of the screen with a short title snippet so you can tell which queued delete **Undo** will restore. Tap **Undo** to restore it, or tap anywhere else (including the greyed-out card) to confirm deletion. When deleting from the reading view, you are returned to the list and the same undo bar appears.
+
+To delete several bookmarks at once, tap **⋮ → Select bookmarks**, choose the cards you want, then tap the **🗑️ Delete** icon in the top bar. Selection mode exits and a **"N bookmarks deleted"** snackbar appears with an **Undo** action. The staged bookmarks stay greyed out until you tap **Undo** to restore them all, or let the snackbar go (or interact elsewhere) to confirm the deletion.

--- a/app/src/main/assets/guide/en/organizing.md
+++ b/app/src/main/assets/guide/en/organizing.md
@@ -39,6 +39,8 @@ There are two ways to access these actions:
 
 Tap the **❤️** button on any bookmark card in a list view to mark a bookmark as a favorite. Tap again to remove it. The heart fills when a bookmark is a favorite.
 
+To favorite or unfavorite several bookmarks at once, tap the **select icon** in the bookmark list top bar, select the cards you want, then tap the **Favorite** action in the top bar. Each selected bookmark toggles from its current favorite state.
+
 In the reading view, you can toggle favorites using:
 - The **❤️ Favorite / Remove favorite** button at the end of the content
 - The **⋮** overflow menu → **Add to favorites / Remove favorite**
@@ -52,6 +54,7 @@ Archiving moves a bookmark out of **My List** into the **Archive**. Archived boo
 You can archive a bookmark from several places:
 
 - **Card action** — tap the Archive button on a bookmark card in any list view
+- **Multi-select** — tap the **select icon** in the bookmark list top bar, choose several cards, then tap the **Archive** action. Each selected bookmark toggles from its current archive state.
 - **Reading view** — use the **📦 Archive / Unarchive** button at the end of the content or **⋮** → **Archive / Unarchive**
 - **Add Link sheet** — tap **Archive** to save a new bookmark directly to the Archive
 

--- a/app/src/main/assets/guide/en/organizing.md
+++ b/app/src/main/assets/guide/en/organizing.md
@@ -8,11 +8,13 @@ Labels let you categorize your bookmarks with any words, phrases, or emojis you 
 
 ### Adding Labels to a Bookmark
 
-You can add labels in two places:
+You can add labels in three places:
 
 - **When saving a bookmark** — the Add Link sheet (opened from the **+** button or the Android share sheet) shows a **Labels** section with chips for current labels and an **Add labels** / **Edit labels** row. Tap that row to open a label picker, select one or more labels, then tap **Done** to save label changes.
 
 - **From Bookmark Details** — open any bookmark and tap **⋮** → **Details**. The Labels section shows existing labels with **×** buttons to remove them, plus an **Add labels** / **Edit labels** row that opens the same multi-select label picker.
+
+- **For several bookmarks at once** — tap **⋮ → Select bookmarks**, choose the cards you want (or **⋮ → Select all**), then open the **⋮ overflow** and tap **Add labels**. Pick one or more labels (or create a new one) and tap **Done** to add them to every selected bookmark. Existing labels are kept, and any bookmark that already has all the chosen labels is left unchanged. The selection stays active afterward, so you can keep working with it. A snackbar confirms the result (e.g. "Labels added to 3 bookmarks") with an **Undo** that restores the prior labels on the bookmarks that changed. Batch *removing* labels isn't supported yet.
 
 ### Browsing by Label
 

--- a/app/src/main/assets/guide/en/organizing.md
+++ b/app/src/main/assets/guide/en/organizing.md
@@ -39,11 +39,16 @@ There are two ways to access these actions:
 
 Tap the **❤️** button on any bookmark card in a list view to mark a bookmark as a favorite. Tap again to remove it. The heart fills when a bookmark is a favorite.
 
-To favorite or unfavorite several bookmarks at once, tap the **select icon** in the bookmark list top bar, select the cards you want, then tap the **Favorite** action in the top bar. Each selected bookmark toggles from its current favorite state.
+To favorite or unfavorite several bookmarks at once, tap the **select icon** in the bookmark list top bar and choose the cards you want (or tap **⋮ → Select all** to choose every bookmark in the current view). The top bar exposes the most useful favorite action for your current selection:
+
+- If any selected bookmark is **not** yet a favorite, the bar shows **❤️ Add favorite**. The overflow has **Remove favorite**.
+- If **all** selected bookmarks are already favorites, the bar promotes **Remove favorite** for one-tap reversal; the overflow's **Add favorite** is greyed out.
+
+A snackbar confirms the post-state of the selection (e.g. "3 set as favorites", "3 unset as favorites").
 
 In the reading view, you can toggle favorites using:
 - The **❤️ Favorite / Remove favorite** button at the end of the content
-- The **⋮** overflow menu → **Add to favorites / Remove favorite**
+- The **⋮** overflow menu → **Add favorite / Remove favorite**
 
 Favorites are independent of My List and Archive — a favorite can be in either. To see all your favorites in one place, open the navigation drawer and tap **Favorites**.
 
@@ -54,7 +59,7 @@ Archiving moves a bookmark out of **My List** into the **Archive**. Archived boo
 You can archive a bookmark from several places:
 
 - **Card action** — tap the Archive button on a bookmark card in any list view
-- **Multi-select** — tap the **select icon** in the bookmark list top bar, choose several cards, then tap the **Archive** action. Each selected bookmark toggles from its current archive state.
+- **Multi-select** — tap the **select icon** in the bookmark list top bar, choose the cards you want (or tap **⋮ → Select all**). The top bar exposes whichever archive action is most useful: **Archive** when any selected bookmark is not yet archived (overflow holds **Unarchive**), or **Unarchive** promoted to the bar when all selected bookmarks are already archived (overflow's Archive is greyed out). A snackbar confirms the post-state of the selection (e.g. "5 set as archived", "5 unset as archived").
 - **Reading view** — use the **📦 Archive / Unarchive** button at the end of the content or **⋮** → **Archive / Unarchive**
 - **Add Link sheet** — tap **Archive** to save a new bookmark directly to the Archive
 

--- a/app/src/main/assets/guide/en/your-bookmarks.md
+++ b/app/src/main/assets/guide/en/your-bookmarks.md
@@ -18,6 +18,26 @@ Tap the **menu icon** (☰) in the top-left corner to open the navigation drawer
 Each item shows a count of how many bookmarks it contains.
 Tap outside the drawer or swipe it closed to dismiss it without changing sections.
 
+The top bar shows the **☰ menu**, the current section title, a **layout icon**, a **sort icon**, and a **⋮ overflow menu**. The overflow holds **Filter** and **Select bookmarks**. (When you're viewing a single label, the overflow instead offers **Rename label**, **Delete label**, and **Select bookmarks**.)
+
+## Adding Bookmarks
+
+### From within MyDeck
+
+Tap the **+** button at the bottom-right of the list to open the **Add Link** sheet. Enter the URL of the page you want to save, and optionally a title, labels, and mark it as a favorite (❤️), then tap **Add**.
+
+For labels, use the **Add labels** / **Edit labels** row in the Labels section. This opens a picker where you can select multiple labels (and create a new label from search text). When you pick a label from search results, the search clears, and your selected labels stay pinned below the search field while you continue choosing more. Tap **Done** to apply picker changes, or tap **Back** to cancel picker changes.
+
+- **Add** — saves the bookmark and closes the sheet
+- **View** — saves the bookmark and immediately opens it to read
+- **Archive** — saves the bookmark directly to the archive
+
+### From another app
+
+You can save any link to MyDeck using Android's share sheet. In a browser or another app, tap **Share** and choose **Save to MyDeck**. A sheet appears with the URL (and title, if the app shared one) pre-filled. You can add or edit the title, pick labels, mark it as a favorite (❤️), and choose **Add**, **View**, or **Archive**.
+
+When opened via the share sheet, a 5-second countdown starts and the bookmark is added automatically when it reaches zero. Tap anywhere on the sheet to stop the countdown and take your time.
+
 ## Bookmark Cards
 
 Each item in the list is a bookmark card. Every card shows the bookmark's **title**, **site name**, estimated **reading time**, and any **labels** assigned to it. If a bookmark has more labels than fit on one line, you can scroll the label row horizontally.
@@ -35,10 +55,6 @@ A denser view that uses the site's **favicon** instead of a full thumbnail. A fi
 ### Mosaic Layout
 
 Each card is a large tile with the thumbnail filling the entire card and the title overlaid at the bottom. Labels are not shown in mosaic layout.
-
-### Switching Layouts
-
-Tap the **layout icon** in the top bar to choose between Grid, Compact, and Mosaic. The icon updates to reflect your current choice.
 
 ### Bookmark Types
 
@@ -77,25 +93,6 @@ Each card has four action buttons:
 
 See [Organizing](./organizing.md) for more on how favorites, archive, labels, and deletion work across your whole collection.
 
-## Selecting Multiple Bookmarks
-
-Tap the **select icon** (empty circle) on the right side of the top bar to enter selection mode. The top bar changes to show an **X** button on the left, the number of selected bookmarks as the title, and a **⋮ overflow** button on the right.
-
-While selection mode is active, tap any bookmark card to select or deselect it. The card's interactive action buttons are replaced by dimmed status icons that show each bookmark's current **favorite** and **archive** state, and the far-right action area shows a circular selection indicator. Tapping the **X** exits selection mode and clears the current selection.
-
-Tap the **⋮ overflow** button to open the selection menu, which always offers:
-
-- **Select all / Deselect all** — selects every bookmark in the current view. If all visible bookmarks are already selected, the same item becomes **Deselect all** and clears the selection.
-
-Once you have at least one bookmark selected, two action icons appear in the top bar (one for favorite, one for archive) and two corresponding items appear in the overflow. Each axis works independently and the bar promotes the most useful action based on what you've selected:
-
-- **Favorite**:
-  - If any selected bookmark is **not** yet a favorite, the bar shows **❤️ Add favorite** (filled heart). Tapping it favorites the whole selection. The overflow has **Remove favorite** as the inverse.
-  - If **all** selected bookmarks are already favorites, the bar promotes **Remove favorite** (outline heart) for a one-tap reversal. The overflow's **Add favorite** is greyed out since there's nothing left to favorite.
-- **Archive**: same pattern with **Archive** (filled box) and **Unarchive** (outline box).
-
-After the action runs, a snackbar at the bottom confirms the post-state of the selection — for example "3 set as favorites", "3 unset as favorites", "5 set as archived", "5 unset as archived" — and selection mode exits automatically.
-
 ## Swipe Actions on Cards
 
 In single-column layouts you can swipe a bookmark card left or right to archive or delete it without tapping the icon buttons.
@@ -129,27 +126,25 @@ Long-pressing on a bookmark card opens a context menu dialog. The dialog header 
 - Download image
 - Share image
 
-## Adding Bookmarks
+## Switching Layouts
 
-### From within MyDeck
+Tap the **layout icon** in the top bar to choose between Grid, Compact, and Mosaic. The icon updates to reflect your current choice.
 
-Tap the **+** button at the bottom-right of the list to open the **Add Link** sheet. Enter the URL of the page you want to save, and optionally a title, labels, and mark it as a favorite (❤️), then tap **Add**.
+## Sorting
 
-For labels, use the **Add labels** / **Edit labels** row in the Labels section. This opens a picker where you can select multiple labels (and create a new label from search text). When you pick a label from search results, the search clears, and your selected labels stay pinned below the search field while you continue choosing more. Tap **Done** to apply picker changes, or tap **Back** to cancel picker changes.
+Tap the **sort icon** (↕) in the top bar to change the sort order. Options are:
 
-- **Add** — saves the bookmark and closes the sheet
-- **View** — saves the bookmark and immediately opens it to read
-- **Archive** — saves the bookmark directly to the archive
+- **Added** — date the bookmark was saved to Readeck
+- **Published** — date the original article was published
+- **Title** — alphabetical by title
+- **Site Name** — alphabetical by site
+- **Duration** — by estimated reading time
 
-### From another app
-
-You can save any link to MyDeck using Android's share sheet. In a browser or another app, tap **Share** and choose **Save to MyDeck**. A sheet appears with the URL (and title, if the app shared one) pre-filled. You can add or edit the title, pick labels, mark it as a favorite (❤️), and choose **Add**, **View**, or **Archive**.
-
-When opened via the share sheet, a 5-second countdown starts and the bookmark is added automatically when it reaches zero. Tap anywhere on the sheet to stop the countdown and take your time.
+An arrow on the selected option shows the current direction. Tap the same option again to toggle between ascending and descending.
 
 ## Searching and Filtering
 
-Tap the **filter icon** (≡) in the top bar to open the filter sheet. The sheet opens showing the top half of the options. Scroll down within the sheet to see all options.
+Open the **⋮ overflow menu** in the top bar and tap **Filter** to open the filter sheet. The sheet opens showing the top half of the options. Scroll down within the sheet to see all options.
 
 Active filters are shown as chips below the top bar. Tap the **×** on a chip to clear that filter.
 
@@ -193,17 +188,16 @@ To return to a standard view you can:
 
 Tap **Search** to apply, or **Reset** to clear all filters.
 
-## Sorting
+## Selecting Multiple Bookmarks
 
-Tap the **sort icon** (↕) in the top bar to change the sort order. Options are:
+Open the **⋮ overflow menu** and tap **Select bookmarks** to enter selection mode. The top bar switches to an **✕** (exit), the number of selected bookmarks as the title, and a **⋮ overflow** that offers **Select all / Deselect all**. Tap any card to select or deselect it — each card's action buttons become dimmed icons showing its current favorite and archive state, with a selection indicator on the right. Tap **✕** to exit and clear the selection.
 
-- **Added** — date the bookmark was saved to Readeck
-- **Published** — date the original article was published
-- **Title** — alphabetical by title
-- **Site Name** — alphabetical by site
-- **Duration** — by estimated reading time
+Once at least one bookmark is selected, three actions on the bar apply to the **whole selection** — **Favorite**, **Archive**, and **🗑️ Delete**:
 
-An arrow on the selected option shows the current direction. Tap the same option again to toggle between ascending and descending.
+- **Favorite** and **Archive** each show the most useful action for what you've selected. If any selected bookmark isn't yet favorited (or archived), the bar offers **Add favorite** (or **Archive**); once they all already are, it flips to **Remove favorite** (or **Unarchive**). The opposite action sits in the overflow, greyed out when it would do nothing.
+- **Delete** removes every selected bookmark.
+
+Running any of the three exits selection mode and shows a snackbar confirming what happened — for example "3 set as favorites", "5 set as archived", or "4 bookmarks deleted" — each with an **Undo** action. Favorite and archive apply immediately, and Undo reverts only the bookmarks that actually changed. Delete is held until the snackbar goes away: the bookmarks stay greyed out while it's showing, so you can tap **Undo** to keep them, or dismiss the snackbar (or tap elsewhere) to confirm the deletion.
 
 ## Refreshing
 

--- a/app/src/main/assets/guide/en/your-bookmarks.md
+++ b/app/src/main/assets/guide/en/your-bookmarks.md
@@ -190,14 +190,16 @@ Tap **Search** to apply, or **Reset** to clear all filters.
 
 ## Selecting Multiple Bookmarks
 
-Open the **⋮ overflow menu** and tap **Select bookmarks** to enter selection mode. The top bar switches to an **✕** (exit), the number of selected bookmarks as the title, and a **⋮ overflow** that offers **Select all / Deselect all**. Tap any card to select or deselect it — each card's action buttons become dimmed icons showing its current favorite and archive state, with a selection indicator on the right. Tap **✕** to exit and clear the selection.
+Open the **⋮ overflow menu** and tap **Select bookmarks** to enter selection mode. The top bar switches to an **✕** (exit), the number of selected bookmarks as the title, an **Archive** and a **Favorite** action, and a **⋮ overflow**. Tap any card to select or deselect it — each card's action buttons become dimmed icons showing its current favorite and archive state, with a selection indicator on the right. Tap **✕** to exit and clear the selection.
 
-Once at least one bookmark is selected, three actions on the bar apply to the **whole selection** — **Favorite**, **Archive**, and **🗑️ Delete**:
+Once at least one bookmark is selected, the bar's two actions apply to the **whole selection**:
 
-- **Favorite** and **Archive** each show the most useful action for what you've selected. If any selected bookmark isn't yet favorited (or archived), the bar offers **Add favorite** (or **Archive**); once they all already are, it flips to **Remove favorite** (or **Unarchive**). The opposite action sits in the overflow, greyed out when it would do nothing.
-- **Delete** removes every selected bookmark.
+- **Archive** and **Favorite** each show the most useful action for what you've selected. If any selected bookmark isn't yet archived (or favorited), the bar offers **Archive** (or **Add favorite**); once they all already are, it flips to **Unarchive** (or **Remove favorite**).
+- The **⋮ overflow** holds **🗑️ Delete** (removes every selected bookmark) and **Select all / Deselect all**.
 
-Running any of the three exits selection mode and shows a snackbar confirming what happened — for example "3 set as favorites", "5 set as archived", or "4 bookmarks deleted" — each with an **Undo** action. Favorite and archive apply immediately, and Undo reverts only the bookmarks that actually changed. Delete is held until the snackbar goes away: the bookmarks stay greyed out while it's showing, so you can tap **Undo** to keep them, or dismiss the snackbar (or tap elsewhere) to confirm the deletion.
+Archive and Favorite apply immediately and **keep you in selection mode**, so you can run several actions on the same selection in a row. Each shows a snackbar confirming what happened — for example "3 set as favorites" or "5 set as archived" — with an **Undo** action that reverts only the bookmarks that actually changed. Selection mode ends when you tap **✕**, or automatically once an action leaves nothing selected (for example, archiving the last item in My List removes it from the view).
+
+**Delete** is held until the snackbar goes away: the bookmarks stay greyed out while it's showing, so you can tap **Undo** to keep them, or dismiss the snackbar (or tap elsewhere) to confirm the deletion.
 
 ## Refreshing
 

--- a/app/src/main/assets/guide/en/your-bookmarks.md
+++ b/app/src/main/assets/guide/en/your-bookmarks.md
@@ -77,6 +77,14 @@ Each card has four action buttons:
 
 See [Organizing](./organizing.md) for more on how favorites, archive, labels, and deletion work across your whole collection.
 
+## Selecting Multiple Bookmarks
+
+Tap the **select icon** (empty circle) on the right side of the top bar to enter selection mode. The top bar changes to show an **X** button and the number of selected bookmarks.
+
+While selection mode is active, tap any bookmark card to select or deselect it. The card's usual action buttons are hidden, and the far-right action area shows a circular selection indicator instead. Tapping the **X** exits selection mode and clears the current selection.
+
+After selecting one or more bookmarks, use the top-bar **Favorite** or **Archive** buttons to apply that action to all selected cards. Each selected bookmark is toggled from its current state: favorites become not favorite, non-favorites become favorite, archived bookmarks become unarchived, and unarchived bookmarks become archived.
+
 ## Swipe Actions on Cards
 
 In single-column layouts you can swipe a bookmark card left or right to archive or delete it without tapping the icon buttons.

--- a/app/src/main/assets/guide/en/your-bookmarks.md
+++ b/app/src/main/assets/guide/en/your-bookmarks.md
@@ -195,7 +195,9 @@ Open the **⋮ overflow menu** and tap **Select bookmarks** to enter selection m
 Once at least one bookmark is selected, the bar's two actions apply to the **whole selection**:
 
 - **Archive** and **Favorite** each show the most useful action for what you've selected. If any selected bookmark isn't yet archived (or favorited), the bar offers **Archive** (or **Add favorite**); once they all already are, it flips to **Unarchive** (or **Remove favorite**).
-- The **⋮ overflow** holds **🗑️ Delete** (removes every selected bookmark) and **Select all / Deselect all**.
+- The **⋮ overflow** holds **🗑️ Delete** (removes every selected bookmark), **Add labels**, and **Select all / Deselect all**.
+
+**Add labels** opens the label picker. Pick one or more existing labels (or create a new one from the search box) and tap **Done** to add them to every selected bookmark — labels already present are kept, and bookmarks that already have all the chosen labels are left untouched. Like Archive and Favorite, this **keeps you in selection mode** so you can keep working with the same set. A snackbar confirms "Labels added to N bookmarks" with an **Undo** that restores the prior labels on the bookmarks that changed.
 
 Archive and Favorite apply immediately and **keep you in selection mode**, so you can run several actions on the same selection in a row. Each shows a snackbar confirming what happened — for example "3 set as favorites" or "5 set as archived" — with an **Undo** action that reverts only the bookmarks that actually changed. Selection mode ends when you tap **✕**, or automatically once an action leaves nothing selected (for example, archiving the last item in My List removes it from the view).
 

--- a/app/src/main/assets/guide/en/your-bookmarks.md
+++ b/app/src/main/assets/guide/en/your-bookmarks.md
@@ -79,11 +79,22 @@ See [Organizing](./organizing.md) for more on how favorites, archive, labels, an
 
 ## Selecting Multiple Bookmarks
 
-Tap the **select icon** (empty circle) on the right side of the top bar to enter selection mode. The top bar changes to show an **X** button and the number of selected bookmarks.
+Tap the **select icon** (empty circle) on the right side of the top bar to enter selection mode. The top bar changes to show an **X** button on the left, the number of selected bookmarks as the title, and a **⋮ overflow** button on the right.
 
-While selection mode is active, tap any bookmark card to select or deselect it. The card's usual action buttons are hidden, and the far-right action area shows a circular selection indicator instead. Tapping the **X** exits selection mode and clears the current selection.
+While selection mode is active, tap any bookmark card to select or deselect it. The card's interactive action buttons are replaced by dimmed status icons that show each bookmark's current **favorite** and **archive** state, and the far-right action area shows a circular selection indicator. Tapping the **X** exits selection mode and clears the current selection.
 
-After selecting one or more bookmarks, use the top-bar **Favorite** or **Archive** buttons to apply that action to all selected cards. Each selected bookmark is toggled from its current state: favorites become not favorite, non-favorites become favorite, archived bookmarks become unarchived, and unarchived bookmarks become archived.
+Tap the **⋮ overflow** button to open the selection menu, which always offers:
+
+- **Select all / Deselect all** — selects every bookmark in the current view. If all visible bookmarks are already selected, the same item becomes **Deselect all** and clears the selection.
+
+Once you have at least one bookmark selected, two action icons appear in the top bar (one for favorite, one for archive) and two corresponding items appear in the overflow. Each axis works independently and the bar promotes the most useful action based on what you've selected:
+
+- **Favorite**:
+  - If any selected bookmark is **not** yet a favorite, the bar shows **❤️ Add favorite** (filled heart). Tapping it favorites the whole selection. The overflow has **Remove favorite** as the inverse.
+  - If **all** selected bookmarks are already favorites, the bar promotes **Remove favorite** (outline heart) for a one-tap reversal. The overflow's **Add favorite** is greyed out since there's nothing left to favorite.
+- **Archive**: same pattern with **Archive** (filled box) and **Unarchive** (outline box).
+
+After the action runs, a snackbar at the bottom confirms the post-state of the selection — for example "3 set as favorites", "3 unset as favorites", "5 set as archived", "5 unset as archived" — and selection mode exits automatically.
 
 ## Swipe Actions on Cards
 

--- a/app/src/main/java/com/mydeck/app/domain/BookmarkRepository.kt
+++ b/app/src/main/java/com/mydeck/app/domain/BookmarkRepository.kt
@@ -46,6 +46,7 @@ interface BookmarkRepository {
     fun observeBookmark(id: String): Flow<Bookmark?>
     suspend fun deleteAllBookmarks()
     suspend fun deleteBookmark(id: String): UpdateResult
+    suspend fun deleteBookmarks(ids: List<String>): UpdateResult
     suspend fun createBookmark(
         title: String,
         url: String,

--- a/app/src/main/java/com/mydeck/app/domain/BookmarkRepository.kt
+++ b/app/src/main/java/com/mydeck/app/domain/BookmarkRepository.kt
@@ -103,6 +103,16 @@ interface BookmarkRepository {
     suspend fun updateMetadata(bookmarkId: String, metadata: BookmarkMetadataUpdate): UpdateResult
     suspend fun renameLabel(oldLabel: String, newLabel: String): UpdateResult
     suspend fun deleteLabel(label: String): UpdateResult
+
+    /**
+     * Adds [labels] to each bookmark in [ids] (additive union per bookmark).
+     * Returns the prior label list of every bookmark that actually changed,
+     * keyed by bookmark id, so the change can be undone.
+     */
+    suspend fun addLabelsToBookmarks(ids: List<String>, labels: List<String>): Map<String, List<String>>
+
+    /** Restores the captured prior label lists (Undo for [addLabelsToBookmarks]). */
+    suspend fun restoreBookmarkLabels(priorByBookmark: Map<String, List<String>>)
     suspend fun fetchRawBookmarkJson(bookmarkId: String): String?
     suspend fun refreshBookmarkMetadata(bookmarkId: String)
     suspend fun fetchExtractionLog(bookmarkId: String): ExtractionLogResult

--- a/app/src/main/java/com/mydeck/app/domain/BookmarkRepository.kt
+++ b/app/src/main/java/com/mydeck/app/domain/BookmarkRepository.kt
@@ -8,6 +8,13 @@ import com.mydeck.app.domain.model.ProgressFilter
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 
+data class BookmarkBatchUpdate(
+    val bookmarkId: String,
+    val isFavorite: Boolean? = null,
+    val isArchived: Boolean? = null,
+    val isRead: Boolean? = null
+)
+
 interface BookmarkRepository {
     fun observeBookmarks(
         type: Bookmark.Type? = null,
@@ -45,6 +52,7 @@ interface BookmarkRepository {
         labels: List<String> = emptyList()
     ): String
     suspend fun updateBookmark(bookmarkId: String, isFavorite: Boolean?, isArchived: Boolean?, isRead: Boolean?): UpdateResult
+    suspend fun updateBookmarks(updates: List<BookmarkBatchUpdate>): UpdateResult
     suspend fun updateReadProgress(bookmarkId: String, progress: Int): UpdateResult
     suspend fun updateLabels(bookmarkId: String, labels: List<String>): UpdateResult
     val syncProgress: StateFlow<BookmarkSyncProgress>

--- a/app/src/main/java/com/mydeck/app/domain/BookmarkRepositoryImpl.kt
+++ b/app/src/main/java/com/mydeck/app/domain/BookmarkRepositoryImpl.kt
@@ -525,37 +525,66 @@ class BookmarkRepositoryImpl @Inject constructor(
     ): BookmarkRepository.UpdateResult {
         withContext(dispatcher) {
             database.performTransaction {
-                isFavorite?.let {
-                    bookmarkDao.updateIsMarked(bookmarkId, it)
-                    upsertPendingAction(bookmarkId, ActionType.TOGGLE_FAVORITE, TogglePayload(it))
-                }
-                isArchived?.let {
-                    bookmarkDao.updateIsArchived(bookmarkId, it)
-                    upsertPendingAction(bookmarkId, ActionType.TOGGLE_ARCHIVE, TogglePayload(it))
-                    if (it) {
-                        applicationScope.launch {
-                            try {
-                                val scope = settingsDataStore.getOfflineContentScope()
-                                if (scope == OfflineContentScope.MY_LIST &&
-                                    contentPackageManager.hasResources(bookmarkId) == true
-                                ) {
-                                    contentPackageManager.deletePackage(bookmarkId)
-                                    Timber.d("Purged managed offline content on archive for $bookmarkId")
-                                }
-                            } catch (e: Exception) {
-                                Timber.w(e, "Failed to purge managed offline content on archive for $bookmarkId")
-                            }
-                        }
-                    }
-                }
-                isRead?.let {
-                    bookmarkDao.updateReadProgress(bookmarkId, if (it) 100 else 0)
-                    upsertPendingAction(bookmarkId, ActionType.TOGGLE_READ, TogglePayload(it))
-                }
+                applyBookmarkUpdate(
+                    BookmarkBatchUpdate(
+                        bookmarkId = bookmarkId,
+                        isFavorite = isFavorite,
+                        isArchived = isArchived,
+                        isRead = isRead
+                    )
+                )
             }
             syncScheduler.scheduleActionSync()
         }
         return BookmarkRepository.UpdateResult.Success
+    }
+
+    override suspend fun updateBookmarks(
+        updates: List<BookmarkBatchUpdate>
+    ): BookmarkRepository.UpdateResult {
+        if (updates.isEmpty()) return BookmarkRepository.UpdateResult.Success
+
+        withContext(dispatcher) {
+            database.performTransaction {
+                updates.forEach { applyBookmarkUpdate(it) }
+            }
+            syncScheduler.scheduleActionSync()
+        }
+        return BookmarkRepository.UpdateResult.Success
+    }
+
+    private suspend fun applyBookmarkUpdate(update: BookmarkBatchUpdate) {
+        update.isFavorite?.let {
+            bookmarkDao.updateIsMarked(update.bookmarkId, it)
+            upsertPendingAction(update.bookmarkId, ActionType.TOGGLE_FAVORITE, TogglePayload(it))
+        }
+        update.isArchived?.let {
+            bookmarkDao.updateIsArchived(update.bookmarkId, it)
+            upsertPendingAction(update.bookmarkId, ActionType.TOGGLE_ARCHIVE, TogglePayload(it))
+            if (it) {
+                purgeManagedOfflineContentOnArchive(update.bookmarkId)
+            }
+        }
+        update.isRead?.let {
+            bookmarkDao.updateReadProgress(update.bookmarkId, if (it) 100 else 0)
+            upsertPendingAction(update.bookmarkId, ActionType.TOGGLE_READ, TogglePayload(it))
+        }
+    }
+
+    private fun purgeManagedOfflineContentOnArchive(bookmarkId: String) {
+        applicationScope.launch {
+            try {
+                val scope = settingsDataStore.getOfflineContentScope()
+                if (scope == OfflineContentScope.MY_LIST &&
+                    contentPackageManager.hasResources(bookmarkId) == true
+                ) {
+                    contentPackageManager.deletePackage(bookmarkId)
+                    Timber.d("Purged managed offline content on archive for $bookmarkId")
+                }
+            } catch (e: Exception) {
+                Timber.w(e, "Failed to purge managed offline content on archive for $bookmarkId")
+            }
+        }
     }
 
     override suspend fun deleteBookmark(id: String): BookmarkRepository.UpdateResult {

--- a/app/src/main/java/com/mydeck/app/domain/BookmarkRepositoryImpl.kt
+++ b/app/src/main/java/com/mydeck/app/domain/BookmarkRepositoryImpl.kt
@@ -611,6 +611,34 @@ class BookmarkRepositoryImpl @Inject constructor(
         return BookmarkRepository.UpdateResult.Success
     }
 
+    override suspend fun deleteBookmarks(ids: List<String>): BookmarkRepository.UpdateResult {
+        if (ids.isEmpty()) return BookmarkRepository.UpdateResult.Success
+
+        withContext(dispatcher) {
+            database.performTransaction {
+                ids.forEach { id ->
+                    // 1. Optimistic Soft Delete
+                    bookmarkDao.softDeleteBookmark(id)
+
+                    // 2. Delete Supremacy: remove other actions for this bookmark
+                    pendingActionDao.deleteAllForBookmark(id)
+
+                    // 3. Queue Delete Action
+                    pendingActionDao.insert(
+                        PendingActionEntity(
+                            bookmarkId = id,
+                            actionType = ActionType.DELETE,
+                            payload = null,
+                            createdAt = Clock.System.now()
+                        )
+                    )
+                }
+            }
+            syncScheduler.scheduleActionSync()
+        }
+        return BookmarkRepository.UpdateResult.Success
+    }
+
     private suspend fun upsertPendingAction(
         bookmarkId: String,
         type: ActionType,

--- a/app/src/main/java/com/mydeck/app/domain/BookmarkRepositoryImpl.kt
+++ b/app/src/main/java/com/mydeck/app/domain/BookmarkRepositoryImpl.kt
@@ -1180,6 +1180,49 @@ class BookmarkRepositoryImpl @Inject constructor(
             }
         }
 
+    override suspend fun addLabelsToBookmarks(
+        ids: List<String>,
+        labels: List<String>
+    ): Map<String, List<String>> = withContext(dispatcher) {
+        if (ids.isEmpty() || labels.isEmpty()) return@withContext emptyMap()
+
+        val idSet = ids.toSet()
+        val targets = bookmarkDao.getAllBookmarksWithContent()
+            .filter { it.bookmark.id in idSet }
+
+        val priorByBookmark = mutableMapOf<String, List<String>>()
+        database.performTransaction {
+            for (bookmarkWithContent in targets) {
+                val bookmark = bookmarkWithContent.bookmark
+                val prior = bookmark.labels
+                val merged = (prior + labels).distinct()
+                if (merged.size == prior.size) continue
+
+                priorByBookmark[bookmark.id] = prior
+                val labelsJson = json.encodeToString(merged)
+                bookmarkDao.updateLabels(bookmark.id, labelsJson)
+                upsertPendingAction(bookmark.id, ActionType.UPDATE_LABELS, LabelsPayload(merged))
+            }
+        }
+        if (priorByBookmark.isNotEmpty()) {
+            syncScheduler.scheduleActionSync()
+        }
+        priorByBookmark
+    }
+
+    override suspend fun restoreBookmarkLabels(priorByBookmark: Map<String, List<String>>) =
+        withContext(dispatcher) {
+            if (priorByBookmark.isEmpty()) return@withContext
+            database.performTransaction {
+                for ((id, priorLabels) in priorByBookmark) {
+                    val labelsJson = json.encodeToString(priorLabels)
+                    bookmarkDao.updateLabels(id, labelsJson)
+                    upsertPendingAction(id, ActionType.UPDATE_LABELS, LabelsPayload(priorLabels))
+                }
+            }
+            syncScheduler.scheduleActionSync()
+        }
+
     override suspend fun refreshBookmarkMetadata(bookmarkId: String) = withContext(dispatcher) {
         try {
             val response = readeckApi.getBookmarkById(bookmarkId)

--- a/app/src/main/java/com/mydeck/app/domain/usecase/UpdateBookmarkUseCase.kt
+++ b/app/src/main/java/com/mydeck/app/domain/usecase/UpdateBookmarkUseCase.kt
@@ -42,6 +42,10 @@ class UpdateBookmarkUseCase @Inject constructor(
         return handleResult(bookmarkRepository.deleteBookmark(bookmarkId))
     }
 
+    suspend fun deleteBookmarks(bookmarkIds: List<String>): Result {
+        return handleResult(bookmarkRepository.deleteBookmarks(bookmarkIds))
+    }
+
     private fun handleResult(result: BookmarkRepository.UpdateResult): Result {
         return when(result) {
             is BookmarkRepository.UpdateResult.Success -> Result.Success

--- a/app/src/main/java/com/mydeck/app/domain/usecase/UpdateBookmarkUseCase.kt
+++ b/app/src/main/java/com/mydeck/app/domain/usecase/UpdateBookmarkUseCase.kt
@@ -1,5 +1,6 @@
 package com.mydeck.app.domain.usecase
 
+import com.mydeck.app.domain.BookmarkBatchUpdate
 import com.mydeck.app.domain.BookmarkRepository
 import javax.inject.Inject
 
@@ -31,6 +32,10 @@ class UpdateBookmarkUseCase @Inject constructor(
             isArchived = null,
             isRead = isRead
         ))
+    }
+
+    suspend fun updateBookmarks(updates: List<BookmarkBatchUpdate>): Result {
+        return handleResult(bookmarkRepository.updateBookmarks(updates))
     }
 
     suspend fun deleteBookmark(bookmarkId: String): Result {

--- a/app/src/main/java/com/mydeck/app/domain/usecase/UpdateBookmarkUseCase.kt
+++ b/app/src/main/java/com/mydeck/app/domain/usecase/UpdateBookmarkUseCase.kt
@@ -46,6 +46,14 @@ class UpdateBookmarkUseCase @Inject constructor(
         return handleResult(bookmarkRepository.deleteBookmarks(bookmarkIds))
     }
 
+    suspend fun addLabelsToBookmarks(ids: List<String>, labels: List<String>): Map<String, List<String>> {
+        return bookmarkRepository.addLabelsToBookmarks(ids, labels)
+    }
+
+    suspend fun restoreBookmarkLabels(priorByBookmark: Map<String, List<String>>) {
+        bookmarkRepository.restoreBookmarkLabels(priorByBookmark)
+    }
+
     private fun handleResult(result: BookmarkRepository.UpdateResult): Result {
         return when(result) {
             is BookmarkRepository.UpdateResult.Success -> Result.Success

--- a/app/src/main/java/com/mydeck/app/ui/list/BookmarkCard.kt
+++ b/app/src/main/java/com/mydeck/app/ui/list/BookmarkCard.kt
@@ -59,6 +59,7 @@ import androidx.compose.material3.CardDefaults.outlinedCardBorder
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SuggestionChip
 import androidx.compose.material3.Text
@@ -81,9 +82,11 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
@@ -375,6 +378,29 @@ private fun BookmarkSelectionIndicator(
     }
 }
 
+@Composable
+private fun BookmarkSelectStateIcon(
+    imageVector: ImageVector,
+    contentDescription: String,
+    tint: Color = LocalContentColor.current,
+    boxSize: Dp = 36.dp,
+    iconSize: Dp = 20.dp,
+) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier.size(boxSize)
+    ) {
+        Icon(
+            imageVector = imageVector,
+            contentDescription = contentDescription,
+            tint = tint,
+            modifier = Modifier
+                .size(iconSize)
+                .alpha(0.38f)
+        )
+    }
+}
+
 @OptIn(ExperimentalLayoutApi::class, ExperimentalFoundationApi::class)
 @Composable
 fun BookmarkMosaicCard(
@@ -570,7 +596,24 @@ fun BookmarkMosaicCard(
                             }
                         }
                         } else {
-                            Spacer(Modifier.width(1.dp))
+                            Row(horizontalArrangement = Arrangement.Start) {
+                                BookmarkSelectStateIcon(
+                                    imageVector = if (bookmark.isMarked) Icons.Filled.Favorite else Icons.Outlined.FavoriteBorder,
+                                    contentDescription = stringResource(
+                                        if (bookmark.isMarked) R.string.bookmark_state_favorited
+                                        else R.string.bookmark_state_not_favorited
+                                    ),
+                                    tint = Color.White
+                                )
+                                BookmarkSelectStateIcon(
+                                    imageVector = if (bookmark.isArchived) Icons.Filled.Inventory2 else Icons.Outlined.Inventory2,
+                                    contentDescription = stringResource(
+                                        if (bookmark.isArchived) R.string.bookmark_state_archived
+                                        else R.string.bookmark_state_not_archived
+                                    ),
+                                    tint = Color.White
+                                )
+                            }
                         }
                         if (isSelectionMode) {
                             BookmarkSelectionIndicator(
@@ -1013,7 +1056,26 @@ private fun BookmarkGridCardMobilePortrait(
                             }
                         }
                         } else {
-                            Spacer(Modifier.width(1.dp))
+                            Row(horizontalArrangement = Arrangement.Start) {
+                                BookmarkSelectStateIcon(
+                                    imageVector = if (bookmark.isMarked) Icons.Filled.Favorite else Icons.Outlined.FavoriteBorder,
+                                    contentDescription = stringResource(
+                                        if (bookmark.isMarked) R.string.bookmark_state_favorited
+                                        else R.string.bookmark_state_not_favorited
+                                    ),
+                                    boxSize = 48.dp,
+                                    iconSize = 24.dp
+                                )
+                                BookmarkSelectStateIcon(
+                                    imageVector = if (bookmark.isArchived) Icons.Filled.Inventory2 else Icons.Outlined.Inventory2,
+                                    contentDescription = stringResource(
+                                        if (bookmark.isArchived) R.string.bookmark_state_archived
+                                        else R.string.bookmark_state_not_archived
+                                    ),
+                                    boxSize = 48.dp,
+                                    iconSize = 24.dp
+                                )
+                            }
                         }
                         if (isSelectionMode) {
                             BookmarkSelectionIndicator(
@@ -1337,7 +1399,22 @@ private fun BookmarkGridCardNarrow(
                         }
                     }
                     } else {
-                        Spacer(Modifier.width(1.dp))
+                        Row(horizontalArrangement = Arrangement.Start) {
+                            BookmarkSelectStateIcon(
+                                imageVector = if (bookmark.isMarked) Icons.Filled.Favorite else Icons.Outlined.FavoriteBorder,
+                                contentDescription = stringResource(
+                                    if (bookmark.isMarked) R.string.bookmark_state_favorited
+                                    else R.string.bookmark_state_not_favorited
+                                )
+                            )
+                            BookmarkSelectStateIcon(
+                                imageVector = if (bookmark.isArchived) Icons.Filled.Inventory2 else Icons.Outlined.Inventory2,
+                                contentDescription = stringResource(
+                                    if (bookmark.isArchived) R.string.bookmark_state_archived
+                                    else R.string.bookmark_state_not_archived
+                                )
+                            )
+                        }
                     }
                     if (isSelectionMode) {
                         BookmarkSelectionIndicator(
@@ -1667,7 +1744,22 @@ private fun BookmarkGridCardWide(
                         }
                     }
                     } else {
-                        Spacer(Modifier.width(1.dp))
+                        Row(horizontalArrangement = Arrangement.Start) {
+                            BookmarkSelectStateIcon(
+                                imageVector = if (bookmark.isMarked) Icons.Filled.Favorite else Icons.Outlined.FavoriteBorder,
+                                contentDescription = stringResource(
+                                    if (bookmark.isMarked) R.string.bookmark_state_favorited
+                                    else R.string.bookmark_state_not_favorited
+                                )
+                            )
+                            BookmarkSelectStateIcon(
+                                imageVector = if (bookmark.isArchived) Icons.Filled.Inventory2 else Icons.Outlined.Inventory2,
+                                contentDescription = stringResource(
+                                    if (bookmark.isArchived) R.string.bookmark_state_archived
+                                    else R.string.bookmark_state_not_archived
+                                )
+                            )
+                        }
                     }
                     if (isSelectionMode) {
                         BookmarkSelectionIndicator(
@@ -2025,7 +2117,24 @@ private fun BookmarkCompactCardNarrow(
                 }
             }
             } else {
-                Spacer(Modifier.width(1.dp))
+                Row(horizontalArrangement = Arrangement.Start) {
+                    BookmarkSelectStateIcon(
+                        imageVector = if (bookmark.isMarked) Icons.Filled.Favorite else Icons.Outlined.FavoriteBorder,
+                        contentDescription = stringResource(
+                            if (bookmark.isMarked) R.string.bookmark_state_favorited
+                            else R.string.bookmark_state_not_favorited
+                        ),
+                        boxSize = 32.dp,
+                        iconSize = 18.dp
+                    )
+                    BookmarkSelectStateIcon(
+                        imageVector = if (bookmark.isArchived) Icons.Filled.Inventory2 else Icons.Outlined.Inventory2,
+                        contentDescription = stringResource(
+                            if (bookmark.isArchived) R.string.bookmark_state_archived
+                            else R.string.bookmark_state_not_archived
+                        )
+                    )
+                }
             }
             if (isSelectionMode) {
                 BookmarkSelectionIndicator(
@@ -2178,6 +2287,20 @@ private fun BookmarkCompactCardWide(
                 Spacer(Modifier.width(4.dp))
 
                 if (isSelectionMode) {
+                    BookmarkSelectStateIcon(
+                        imageVector = if (bookmark.isMarked) Icons.Filled.Favorite else Icons.Outlined.FavoriteBorder,
+                        contentDescription = stringResource(
+                            if (bookmark.isMarked) R.string.bookmark_state_favorited
+                            else R.string.bookmark_state_not_favorited
+                        )
+                    )
+                    BookmarkSelectStateIcon(
+                        imageVector = if (bookmark.isArchived) Icons.Filled.Inventory2 else Icons.Outlined.Inventory2,
+                        contentDescription = stringResource(
+                            if (bookmark.isArchived) R.string.bookmark_state_archived
+                            else R.string.bookmark_state_not_archived
+                        )
+                    )
                     BookmarkSelectionIndicator(
                         isSelected = isSelected,
                         onClick = { onToggleSelection(bookmark.id) }

--- a/app/src/main/java/com/mydeck/app/ui/list/BookmarkCard.kt
+++ b/app/src/main/java/com/mydeck/app/ui/list/BookmarkCard.kt
@@ -84,6 +84,9 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
@@ -322,6 +325,56 @@ private fun CompactStatusRail(
 
 val LocalIsWideLayout = compositionLocalOf { false }
 
+private fun Modifier.selectionSemantics(
+    isSelectionMode: Boolean,
+    isSelected: Boolean
+): Modifier = if (isSelectionMode) {
+    this.semantics { selected = isSelected }
+} else {
+    this
+}
+
+@Composable
+private fun BookmarkSelectionIndicator(
+    isSelected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    outlineColor: Color = MaterialTheme.colorScheme.outline
+) {
+    val description = stringResource(
+        if (isSelected) R.string.action_deselect_bookmark else R.string.action_select_bookmark
+    )
+    IconButton(
+        onClick = onClick,
+        modifier = modifier
+            .size(36.dp)
+            .semantics { contentDescription = description }
+    ) {
+        if (isSelected) {
+            Box(
+                modifier = Modifier
+                    .size(24.dp)
+                    .background(MaterialTheme.colorScheme.primary, CircleShape),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Check,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onPrimary,
+                    modifier = Modifier.size(18.dp)
+                )
+            }
+        } else {
+            Canvas(modifier = Modifier.size(24.dp)) {
+                drawCircle(
+                    color = outlineColor,
+                    style = Stroke(width = 2.dp.toPx())
+                )
+            }
+        }
+    }
+}
+
 @OptIn(ExperimentalLayoutApi::class, ExperimentalFoundationApi::class)
 @Composable
 fun BookmarkMosaicCard(
@@ -342,6 +395,9 @@ fun BookmarkMosaicCard(
     onClickDownloadImage: (String) -> Unit = {},
     onClickShareImage: (String) -> Unit = {},
     isWideLayout: Boolean = LocalIsWideLayout.current,
+    isSelectionMode: Boolean = false,
+    isSelected: Boolean = false,
+    onToggleSelection: (String) -> Unit = {},
     index: Int? = null
 ) {
     var showBodyContextMenu by remember { mutableStateOf(false) }
@@ -353,7 +409,10 @@ fun BookmarkMosaicCard(
                 .fillMaxWidth()
                 .padding(if (isWideLayout) 1.dp else 8.dp)
                 .height(200.dp)
-                .clickable { onClickCard(bookmark.id) },
+                .selectionSemantics(isSelectionMode, isSelected)
+                .clickable {
+                    if (isSelectionMode) onToggleSelection(bookmark.id) else onClickCard(bookmark.id)
+                },
             elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
             border = outlinedCardBorder().copy(
                 brush = androidx.compose.ui.graphics.SolidColor(
@@ -377,9 +436,13 @@ fun BookmarkMosaicCard(
                         .fillMaxWidth()
                         .height(200.dp)
                         .combinedClickable(
-                            onClick = { onClickCard(bookmark.id) },
-                            onLongClick = { showImageContextMenu = true },
-                            onLongClickLabel = stringResource(R.string.long_press_for_options)
+                            onClick = {
+                                if (isSelectionMode) onToggleSelection(bookmark.id) else onClickCard(bookmark.id)
+                            },
+                            onLongClick = if (isSelectionMode) ({}) else {
+                                { showImageContextMenu = true }
+                            },
+                            onLongClickLabel = if (isSelectionMode) null else stringResource(R.string.long_press_for_options)
                         )
                 )
 
@@ -432,9 +495,13 @@ fun BookmarkMosaicCard(
                         .align(Alignment.BottomStart)
                         .fillMaxWidth()
                         .combinedClickable(
-                            onClick = { onClickCard(bookmark.id) },
-                            onLongClick = { showBodyContextMenu = true },
-                            onLongClickLabel = stringResource(R.string.long_press_for_options)
+                            onClick = {
+                                if (isSelectionMode) onToggleSelection(bookmark.id) else onClickCard(bookmark.id)
+                            },
+                            onLongClick = if (isSelectionMode) ({}) else {
+                                { showBodyContextMenu = true }
+                            },
+                            onLongClickLabel = if (isSelectionMode) null else stringResource(R.string.long_press_for_options)
                         )
                         .padding(horizontal = 12.dp, vertical = 8.dp),
                     verticalArrangement = Arrangement.spacedBy(4.dp)
@@ -466,6 +533,7 @@ fun BookmarkMosaicCard(
                         horizontalArrangement = Arrangement.SpaceBetween,
                         verticalAlignment = Alignment.CenterVertically
                     ) {
+                        if (!isSelectionMode) {
                         Row(horizontalArrangement = Arrangement.Start) {
                             IconButton(
                                 onClick = { onClickFavorite(bookmark.id, !bookmark.isMarked) },
@@ -501,16 +569,27 @@ fun BookmarkMosaicCard(
                                 )
                             }
                         }
-                        IconButton(
-                            onClick = { onClickDelete(bookmark.id) },
-                            modifier = Modifier.size(36.dp)
-                        ) {
-                            Icon(
-                                imageVector = Icons.Filled.Delete,
-                                contentDescription = stringResource(R.string.action_delete),
-                                tint = Color.White,
-                                modifier = Modifier.size(20.dp)
+                        } else {
+                            Spacer(Modifier.width(1.dp))
+                        }
+                        if (isSelectionMode) {
+                            BookmarkSelectionIndicator(
+                                isSelected = isSelected,
+                                onClick = { onToggleSelection(bookmark.id) },
+                                outlineColor = Color.White
                             )
+                        } else {
+                            IconButton(
+                                onClick = { onClickDelete(bookmark.id) },
+                                modifier = Modifier.size(36.dp)
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Filled.Delete,
+                                    contentDescription = stringResource(R.string.action_delete),
+                                    tint = Color.White,
+                                    modifier = Modifier.size(20.dp)
+                                )
+                            }
                         }
                     }
                 }
@@ -537,7 +616,7 @@ fun BookmarkMosaicCard(
             }
         }
         }
-        if (showBodyContextMenu) {
+        if (showBodyContextMenu && !isSelectionMode) {
             LongPressContextMenuDialog(
                 headerImageUrl = bookmark.iconSrc,
                 title = bookmark.title,
@@ -572,7 +651,7 @@ fun BookmarkMosaicCard(
 
             }
         }
-        if (showImageContextMenu && bookmark.imageSrc.isNotBlank()) {
+        if (showImageContextMenu && !isSelectionMode && bookmark.imageSrc.isNotBlank()) {
             LongPressContextMenuDialog(
                 headerImageUrl = bookmark.imageSrc,
                 title = bookmark.title,
@@ -621,6 +700,9 @@ fun BookmarkGridCard(
     isWideLayout: Boolean = LocalIsWideLayout.current,
     isInGrid: Boolean = false,
     useMobilePortraitLayout: Boolean = false,
+    isSelectionMode: Boolean = false,
+    isSelected: Boolean = false,
+    onToggleSelection: (String) -> Unit = {},
     index: Int? = null,
 ) {
     if (useMobilePortraitLayout) {
@@ -640,6 +722,9 @@ fun BookmarkGridCard(
             onClickCopyImage = onClickCopyImage,
             onClickDownloadImage = onClickDownloadImage,
             onClickShareImage = onClickShareImage,
+            isSelectionMode = isSelectionMode,
+            isSelected = isSelected,
+            onToggleSelection = onToggleSelection,
             index = index,
         )
     } else if (isWideLayout) {
@@ -660,6 +745,9 @@ fun BookmarkGridCard(
             onClickDownloadImage = onClickDownloadImage,
             onClickShareImage = onClickShareImage,
             isInGrid = isInGrid,
+            isSelectionMode = isSelectionMode,
+            isSelected = isSelected,
+            onToggleSelection = onToggleSelection,
             index = index,
         )
     } else {
@@ -679,6 +767,9 @@ fun BookmarkGridCard(
             onClickCopyImage = onClickCopyImage,
             onClickDownloadImage = onClickDownloadImage,
             onClickShareImage = onClickShareImage,
+            isSelectionMode = isSelectionMode,
+            isSelected = isSelected,
+            onToggleSelection = onToggleSelection,
             index = index,
         )
     }
@@ -715,6 +806,9 @@ private fun BookmarkGridCardMobilePortrait(
     onClickCopyImage: (String) -> Unit = {},
     onClickDownloadImage: (String) -> Unit = {},
     onClickShareImage: (String) -> Unit = {},
+    isSelectionMode: Boolean = false,
+    isSelected: Boolean = false,
+    onToggleSelection: (String) -> Unit = {},
     index: Int? = null,
 ) {
     var showBodyContextMenu by remember { mutableStateOf(false) }
@@ -727,10 +821,15 @@ private fun BookmarkGridCardMobilePortrait(
                 .fillMaxWidth()
                 .padding(horizontal = 12.dp, vertical = 8.dp)
                 .height(MobilePortraitGridCardHeight)
+                .selectionSemantics(isSelectionMode, isSelected)
                 .combinedClickable(
-                    onClick = { onClickCard(bookmark.id) },
-                    onLongClick = { showBodyContextMenu = true },
-                    onLongClickLabel = stringResource(R.string.long_press_for_options)
+                    onClick = {
+                        if (isSelectionMode) onToggleSelection(bookmark.id) else onClickCard(bookmark.id)
+                    },
+                    onLongClick = if (isSelectionMode) ({}) else {
+                        { showBodyContextMenu = true }
+                    },
+                    onLongClickLabel = if (isSelectionMode) null else stringResource(R.string.long_press_for_options)
                 ),
             border = outlinedCardBorder().copy(
                 brush = androidx.compose.ui.graphics.SolidColor(
@@ -757,9 +856,13 @@ private fun BookmarkGridCardMobilePortrait(
                         modifier = Modifier
                             .fillMaxSize()
                             .combinedClickable(
-                                onClick = { onClickCard(bookmark.id) },
-                                onLongClick = { showImageContextMenu = true },
-                                onLongClickLabel = stringResource(R.string.long_press_for_options)
+                                onClick = {
+                                    if (isSelectionMode) onToggleSelection(bookmark.id) else onClickCard(bookmark.id)
+                                },
+                                onLongClick = if (isSelectionMode) ({}) else {
+                                    { showImageContextMenu = true }
+                                },
+                                onLongClickLabel = if (isSelectionMode) null else stringResource(R.string.long_press_for_options)
                             )
                     )
 
@@ -855,7 +958,9 @@ private fun BookmarkGridCardMobilePortrait(
                             LazyRow(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
                                 items(bookmark.labels) { label ->
                                     SuggestionChip(
-                                        onClick = { onClickLabel(label) },
+                                        onClick = {
+                                            if (isSelectionMode) onToggleSelection(bookmark.id) else onClickLabel(label)
+                                        },
                                         label = {
                                             Text(
                                                 text = label,
@@ -877,6 +982,7 @@ private fun BookmarkGridCardMobilePortrait(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.SpaceBetween
                     ) {
+                        if (!isSelectionMode) {
                         Row(horizontalArrangement = Arrangement.Start) {
                             IconButton(
                                 onClick = { onClickFavorite(bookmark.id, !bookmark.isMarked) },
@@ -906,14 +1012,25 @@ private fun BookmarkGridCardMobilePortrait(
                                 )
                             }
                         }
-                        IconButton(
-                            onClick = { onClickDelete(bookmark.id) },
-                            modifier = Modifier.size(48.dp)
-                        ) {
-                            Icon(
-                                imageVector = Icons.Filled.Delete,
-                                contentDescription = stringResource(R.string.action_delete),
+                        } else {
+                            Spacer(Modifier.width(1.dp))
+                        }
+                        if (isSelectionMode) {
+                            BookmarkSelectionIndicator(
+                                isSelected = isSelected,
+                                onClick = { onToggleSelection(bookmark.id) },
+                                outlineColor = MaterialTheme.colorScheme.outline
                             )
+                        } else {
+                            IconButton(
+                                onClick = { onClickDelete(bookmark.id) },
+                                modifier = Modifier.size(48.dp)
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Filled.Delete,
+                                    contentDescription = stringResource(R.string.action_delete),
+                                )
+                            }
                         }
                     }
                 }
@@ -941,7 +1058,7 @@ private fun BookmarkGridCardMobilePortrait(
             }
         }
 
-        if (showBodyContextMenu) {
+        if (showBodyContextMenu && !isSelectionMode) {
             LongPressContextMenuDialog(
                 headerImageUrl = bookmark.iconSrc,
                 title = bookmark.title,
@@ -976,7 +1093,7 @@ private fun BookmarkGridCardMobilePortrait(
 
             }
         }
-        if (showImageContextMenu && bookmark.imageSrc.isNotBlank()) {
+        if (showImageContextMenu && !isSelectionMode && bookmark.imageSrc.isNotBlank()) {
             LongPressContextMenuDialog(
                 headerImageUrl = bookmark.imageSrc,
                 title = bookmark.title,
@@ -1022,6 +1139,9 @@ private fun BookmarkGridCardNarrow(
     onClickCopyImage: (String) -> Unit = {},
     onClickDownloadImage: (String) -> Unit = {},
     onClickShareImage: (String) -> Unit = {},
+    isSelectionMode: Boolean = false,
+    isSelected: Boolean = false,
+    onToggleSelection: (String) -> Unit = {},
 ) {
     var showBodyContextMenu by remember { mutableStateOf(false) }
     var showImageContextMenu by remember { mutableStateOf(false) }
@@ -1031,10 +1151,15 @@ private fun BookmarkGridCardNarrow(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 12.dp, vertical = 8.dp)
+                .selectionSemantics(isSelectionMode, isSelected)
                 .combinedClickable(
-                    onClick = { onClickCard(bookmark.id) },
-                    onLongClick = { showBodyContextMenu = true },
-                    onLongClickLabel = stringResource(R.string.long_press_for_options)
+                    onClick = {
+                        if (isSelectionMode) onToggleSelection(bookmark.id) else onClickCard(bookmark.id)
+                    },
+                    onLongClick = if (isSelectionMode) ({}) else {
+                        { showBodyContextMenu = true }
+                    },
+                    onLongClickLabel = if (isSelectionMode) null else stringResource(R.string.long_press_for_options)
                 ),
             border = outlinedCardBorder().copy(
                 brush = androidx.compose.ui.graphics.SolidColor(
@@ -1061,9 +1186,13 @@ private fun BookmarkGridCardNarrow(
                         .width(100.dp)
                         .height(80.dp)
                         .combinedClickable(
-                            onClick = { onClickCard(bookmark.id) },
-                            onLongClick = { showImageContextMenu = true },
-                            onLongClickLabel = stringResource(R.string.long_press_for_options)
+                            onClick = {
+                                if (isSelectionMode) onToggleSelection(bookmark.id) else onClickCard(bookmark.id)
+                            },
+                            onLongClick = if (isSelectionMode) ({}) else {
+                                { showImageContextMenu = true }
+                            },
+                            onLongClickLabel = if (isSelectionMode) null else stringResource(R.string.long_press_for_options)
                         )
                 )
 
@@ -1152,7 +1281,9 @@ private fun BookmarkGridCardNarrow(
                     ) {
                         bookmark.labels.forEach { label ->
                             SuggestionChip(
-                                onClick = { onClickLabel(label) },
+                                onClick = {
+                                    if (isSelectionMode) onToggleSelection(bookmark.id) else onClickLabel(label)
+                                },
                                 label = {
                                     Text(
                                         text = label,
@@ -1172,6 +1303,7 @@ private fun BookmarkGridCardNarrow(
                         .padding(top = 4.dp),
                     horizontalArrangement = Arrangement.SpaceBetween
                 ) {
+                    if (!isSelectionMode) {
                     Row(horizontalArrangement = Arrangement.Start) {
                         IconButton(
                             onClick = { onClickFavorite(bookmark.id, !bookmark.isMarked) },
@@ -1204,15 +1336,25 @@ private fun BookmarkGridCardNarrow(
                             )
                         }
                     }
-                    IconButton(
-                        onClick = { onClickDelete(bookmark.id) },
-                        modifier = Modifier.size(36.dp)
-                    ) {
-                        Icon(
-                            imageVector = Icons.Filled.Delete,
-                            contentDescription = stringResource(R.string.action_delete),
-                            modifier = Modifier.size(20.dp)
+                    } else {
+                        Spacer(Modifier.width(1.dp))
+                    }
+                    if (isSelectionMode) {
+                        BookmarkSelectionIndicator(
+                            isSelected = isSelected,
+                            onClick = { onToggleSelection(bookmark.id) }
                         )
+                    } else {
+                        IconButton(
+                            onClick = { onClickDelete(bookmark.id) },
+                            modifier = Modifier.size(36.dp)
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.Delete,
+                                contentDescription = stringResource(R.string.action_delete),
+                                modifier = Modifier.size(20.dp)
+                            )
+                        }
                     }
                 }
             }
@@ -1239,7 +1381,7 @@ private fun BookmarkGridCardNarrow(
             }
         }
         }
-        if (showBodyContextMenu) {
+        if (showBodyContextMenu && !isSelectionMode) {
             LongPressContextMenuDialog(
                 headerImageUrl = bookmark.iconSrc,
                 title = bookmark.title,
@@ -1274,7 +1416,7 @@ private fun BookmarkGridCardNarrow(
 
             }
         }
-        if (showImageContextMenu && bookmark.imageSrc.isNotBlank()) {
+        if (showImageContextMenu && !isSelectionMode && bookmark.imageSrc.isNotBlank()) {
             LongPressContextMenuDialog(
                 headerImageUrl = bookmark.imageSrc,
                 title = bookmark.title,
@@ -1320,6 +1462,9 @@ private fun BookmarkGridCardWide(
     onClickDownloadImage: (String) -> Unit = {},
     onClickShareImage: (String) -> Unit = {},
     isInGrid: Boolean = false,
+    isSelectionMode: Boolean = false,
+    isSelected: Boolean = false,
+    onToggleSelection: (String) -> Unit = {},
     index: Int? = null,
 ) {
     var showBodyContextMenu by remember { mutableStateOf(false) }
@@ -1331,10 +1476,15 @@ private fun BookmarkGridCardWide(
             .fillMaxWidth()
             .then(if (isInGrid) Modifier.height(300.dp) else Modifier)
             .padding(horizontal = 12.dp, vertical = 6.dp)
+            .selectionSemantics(isSelectionMode, isSelected)
             .combinedClickable(
-                onClick = { onClickCard(bookmark.id) },
-                onLongClick = { showBodyContextMenu = true },
-                onLongClickLabel = stringResource(R.string.long_press_for_options)
+                onClick = {
+                    if (isSelectionMode) onToggleSelection(bookmark.id) else onClickCard(bookmark.id)
+                },
+                onLongClick = if (isSelectionMode) ({}) else {
+                    { showBodyContextMenu = true }
+                },
+                onLongClickLabel = if (isSelectionMode) null else stringResource(R.string.long_press_for_options)
             ),
         border = outlinedCardBorder().copy(
             brush = androidx.compose.ui.graphics.SolidColor(
@@ -1362,9 +1512,13 @@ private fun BookmarkGridCardWide(
                     modifier = Modifier
                         .fillMaxSize()
                         .combinedClickable(
-                            onClick = { onClickCard(bookmark.id) },
-                            onLongClick = { showImageContextMenu = true },
-                            onLongClickLabel = stringResource(R.string.long_press_for_options)
+                            onClick = {
+                                if (isSelectionMode) onToggleSelection(bookmark.id) else onClickCard(bookmark.id)
+                            },
+                            onLongClick = if (isSelectionMode) ({}) else {
+                                { showImageContextMenu = true }
+                            },
+                            onLongClickLabel = if (isSelectionMode) null else stringResource(R.string.long_press_for_options)
                         )
                 )
 
@@ -1453,7 +1607,9 @@ private fun BookmarkGridCardWide(
                     ) {
                         bookmark.labels.forEach { label ->
                             SuggestionChip(
-                                onClick = { onClickLabel(label) },
+                                onClick = {
+                                    if (isSelectionMode) onToggleSelection(bookmark.id) else onClickLabel(label)
+                                },
                                 label = {
                                     Text(
                                         text = label,
@@ -1477,6 +1633,7 @@ private fun BookmarkGridCardWide(
                         .padding(top = 4.dp),
                     horizontalArrangement = Arrangement.SpaceBetween
                 ) {
+                    if (!isSelectionMode) {
                     Row(horizontalArrangement = Arrangement.Start) {
                         IconButton(
                             onClick = { onClickFavorite(bookmark.id, !bookmark.isMarked) },
@@ -1509,15 +1666,25 @@ private fun BookmarkGridCardWide(
                             )
                         }
                     }
-                    IconButton(
-                        onClick = { onClickDelete(bookmark.id) },
-                        modifier = Modifier.size(36.dp)
-                    ) {
-                        Icon(
-                            imageVector = Icons.Filled.Delete,
-                            contentDescription = stringResource(R.string.action_delete),
-                            modifier = Modifier.size(20.dp)
+                    } else {
+                        Spacer(Modifier.width(1.dp))
+                    }
+                    if (isSelectionMode) {
+                        BookmarkSelectionIndicator(
+                            isSelected = isSelected,
+                            onClick = { onToggleSelection(bookmark.id) }
                         )
+                    } else {
+                        IconButton(
+                            onClick = { onClickDelete(bookmark.id) },
+                            modifier = Modifier.size(36.dp)
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.Delete,
+                                contentDescription = stringResource(R.string.action_delete),
+                                modifier = Modifier.size(20.dp)
+                            )
+                        }
                     }
                 }
             }
@@ -1544,7 +1711,7 @@ private fun BookmarkGridCardWide(
             }
         }
         }
-        if (showBodyContextMenu) {
+        if (showBodyContextMenu && !isSelectionMode) {
             LongPressContextMenuDialog(
                 headerImageUrl = bookmark.iconSrc,
                 title = bookmark.title,
@@ -1579,7 +1746,7 @@ private fun BookmarkGridCardWide(
 
             }
         }
-        if (showImageContextMenu && bookmark.imageSrc.isNotBlank()) {
+        if (showImageContextMenu && !isSelectionMode && bookmark.imageSrc.isNotBlank()) {
             LongPressContextMenuDialog(
                 headerImageUrl = bookmark.imageSrc,
                 title = bookmark.title,
@@ -1645,6 +1812,9 @@ fun BookmarkCompactCard(
     onClickDownloadImage: (String) -> Unit = {},
     onClickShareImage: (String) -> Unit = {},
     isWideLayout: Boolean = LocalIsWideLayout.current,
+    isSelectionMode: Boolean = false,
+    isSelected: Boolean = false,
+    onToggleSelection: (String) -> Unit = {},
     index: Int? = null
 ) {
     if (isWideLayout) {
@@ -1664,6 +1834,9 @@ fun BookmarkCompactCard(
             onClickCopyImage = onClickCopyImage,
             onClickDownloadImage = onClickDownloadImage,
             onClickShareImage = onClickShareImage,
+            isSelectionMode = isSelectionMode,
+            isSelected = isSelected,
+            onToggleSelection = onToggleSelection,
             index = index,
         )
     } else {
@@ -1683,6 +1856,9 @@ fun BookmarkCompactCard(
             onClickCopyImage = onClickCopyImage,
             onClickDownloadImage = onClickDownloadImage,
             onClickShareImage = onClickShareImage,
+            isSelectionMode = isSelectionMode,
+            isSelected = isSelected,
+            onToggleSelection = onToggleSelection,
             index = index,
         )
     }
@@ -1706,6 +1882,9 @@ private fun BookmarkCompactCardNarrow(
     onClickCopyImage: (String) -> Unit = {},
     onClickDownloadImage: (String) -> Unit = {},
     onClickShareImage: (String) -> Unit = {},
+    isSelectionMode: Boolean = false,
+    isSelected: Boolean = false,
+    onToggleSelection: (String) -> Unit = {},
     index: Int? = null
 ) {
     var showBodyContextMenu by remember { mutableStateOf(false) }
@@ -1715,10 +1894,15 @@ private fun BookmarkCompactCardNarrow(
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .selectionSemantics(isSelectionMode, isSelected)
             .combinedClickable(
-                onClick = { onClickCard(bookmark.id) },
-                onLongClick = { showBodyContextMenu = true },
-                onLongClickLabel = stringResource(R.string.long_press_for_options)
+                onClick = {
+                    if (isSelectionMode) onToggleSelection(bookmark.id) else onClickCard(bookmark.id)
+                },
+                onLongClick = if (isSelectionMode) ({}) else {
+                    { showBodyContextMenu = true }
+                },
+                onLongClickLabel = if (isSelectionMode) null else stringResource(R.string.long_press_for_options)
             )
             .padding(horizontal = 16.dp, vertical = 8.dp)
             .heightIn(min = CompactCardMinHeight)
@@ -1783,7 +1967,9 @@ private fun BookmarkCompactCardNarrow(
                 ) {
                     items(bookmark.labels) { label ->
                         SuggestionChip(
-                            onClick = { onClickLabel(label) },
+                            onClick = {
+                                if (isSelectionMode) onToggleSelection(bookmark.id) else onClickLabel(label)
+                            },
                             label = {
                                 Text(
                                     text = label,
@@ -1805,6 +1991,7 @@ private fun BookmarkCompactCardNarrow(
                     .padding(top = 6.dp),
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
+            if (!isSelectionMode) {
             Row(horizontalArrangement = Arrangement.Start) {
                 IconButton(
                     onClick = { onClickFavorite(bookmark.id, !bookmark.isMarked) },
@@ -1837,21 +2024,31 @@ private fun BookmarkCompactCardNarrow(
                     )
                 }
             }
-            IconButton(
-                onClick = { onClickDelete(bookmark.id) },
-                modifier = Modifier.size(36.dp)
-            ) {
-                Icon(
-                    imageVector = Icons.Filled.Delete,
-                    contentDescription = stringResource(R.string.action_delete),
-                    modifier = Modifier.size(20.dp)
+            } else {
+                Spacer(Modifier.width(1.dp))
+            }
+            if (isSelectionMode) {
+                BookmarkSelectionIndicator(
+                    isSelected = isSelected,
+                    onClick = { onToggleSelection(bookmark.id) }
                 )
+            } else {
+                IconButton(
+                    onClick = { onClickDelete(bookmark.id) },
+                    modifier = Modifier.size(36.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Delete,
+                        contentDescription = stringResource(R.string.action_delete),
+                        modifier = Modifier.size(20.dp)
+                    )
+                }
             }
             }
         }
     }
         HorizontalDivider()
-        if (showBodyContextMenu) {
+        if (showBodyContextMenu && !isSelectionMode) {
             LongPressContextMenuDialog(
                 headerImageUrl = bookmark.iconSrc,
                 title = bookmark.title,
@@ -1886,7 +2083,7 @@ private fun BookmarkCompactCardNarrow(
 
             }
         }
-        if (showImageContextMenu && bookmark.imageSrc.isNotBlank()) {
+        if (showImageContextMenu && !isSelectionMode && bookmark.imageSrc.isNotBlank()) {
             LongPressContextMenuDialog(
                 headerImageUrl = bookmark.imageSrc,
                 title = bookmark.title,
@@ -1931,6 +2128,9 @@ private fun BookmarkCompactCardWide(
     onClickCopyImage: (String) -> Unit = {},
     onClickDownloadImage: (String) -> Unit = {},
     onClickShareImage: (String) -> Unit = {},
+    isSelectionMode: Boolean = false,
+    isSelected: Boolean = false,
+    onToggleSelection: (String) -> Unit = {},
     index: Int? = null
 ) {
     var showBodyContextMenu by remember { mutableStateOf(false) }
@@ -1940,10 +2140,15 @@ private fun BookmarkCompactCardWide(
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .selectionSemantics(isSelectionMode, isSelected)
             .combinedClickable(
-                onClick = { onClickCard(bookmark.id) },
-                onLongClick = { showBodyContextMenu = true },
-                onLongClickLabel = stringResource(R.string.long_press_for_options)
+                onClick = {
+                    if (isSelectionMode) onToggleSelection(bookmark.id) else onClickCard(bookmark.id)
+                },
+                onLongClick = if (isSelectionMode) ({}) else {
+                    { showBodyContextMenu = true }
+                },
+                onLongClickLabel = if (isSelectionMode) null else stringResource(R.string.long_press_for_options)
             )
             .padding(horizontal = 16.dp, vertical = 8.dp)
             .heightIn(min = CompactCardMinHeight)
@@ -1972,46 +2177,53 @@ private fun BookmarkCompactCardWide(
 
                 Spacer(Modifier.width(4.dp))
 
-                // Action icons in title row (right-aligned)
-                IconButton(
-                    onClick = { onClickFavorite(bookmark.id, !bookmark.isMarked) },
-                    modifier = Modifier.size(36.dp)
-                ) {
-                    Icon(
-                        imageVector = if (bookmark.isMarked) Icons.Filled.Favorite else Icons.Outlined.FavoriteBorder,
-                        contentDescription = stringResource(R.string.action_favorite),
-                        modifier = Modifier.size(20.dp)
+                if (isSelectionMode) {
+                    BookmarkSelectionIndicator(
+                        isSelected = isSelected,
+                        onClick = { onToggleSelection(bookmark.id) }
                     )
-                }
-                IconButton(
-                    onClick = { onClickArchive(bookmark.id, !bookmark.isArchived) },
-                    modifier = Modifier.size(36.dp)
-                ) {
-                    Icon(
-                        imageVector = if (bookmark.isArchived) Icons.Filled.Inventory2 else Icons.Outlined.Inventory2,
-                        contentDescription = stringResource(R.string.action_archive),
-                        modifier = Modifier.size(20.dp)
-                    )
-                }
-                IconButton(
-                    onClick = { onClickOpenUrl(bookmark.id) },
-                    modifier = Modifier.size(36.dp)
-                ) {
-                    Icon(
-                        imageVector = Icons.Filled.Language,
-                        contentDescription = stringResource(R.string.action_view_original),
-                        modifier = Modifier.size(20.dp)
-                    )
-                }
-                IconButton(
-                    onClick = { onClickDelete(bookmark.id) },
-                    modifier = Modifier.size(36.dp)
-                ) {
-                    Icon(
-                        imageVector = Icons.Filled.Delete,
-                        contentDescription = stringResource(R.string.action_delete),
-                        modifier = Modifier.size(20.dp)
-                    )
+                } else {
+                    // Action icons in title row (right-aligned)
+                    IconButton(
+                        onClick = { onClickFavorite(bookmark.id, !bookmark.isMarked) },
+                        modifier = Modifier.size(36.dp)
+                    ) {
+                        Icon(
+                            imageVector = if (bookmark.isMarked) Icons.Filled.Favorite else Icons.Outlined.FavoriteBorder,
+                            contentDescription = stringResource(R.string.action_favorite),
+                            modifier = Modifier.size(20.dp)
+                        )
+                    }
+                    IconButton(
+                        onClick = { onClickArchive(bookmark.id, !bookmark.isArchived) },
+                        modifier = Modifier.size(36.dp)
+                    ) {
+                        Icon(
+                            imageVector = if (bookmark.isArchived) Icons.Filled.Inventory2 else Icons.Outlined.Inventory2,
+                            contentDescription = stringResource(R.string.action_archive),
+                            modifier = Modifier.size(20.dp)
+                        )
+                    }
+                    IconButton(
+                        onClick = { onClickOpenUrl(bookmark.id) },
+                        modifier = Modifier.size(36.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Language,
+                            contentDescription = stringResource(R.string.action_view_original),
+                            modifier = Modifier.size(20.dp)
+                        )
+                    }
+                    IconButton(
+                        onClick = { onClickDelete(bookmark.id) },
+                        modifier = Modifier.size(36.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Delete,
+                            contentDescription = stringResource(R.string.action_delete),
+                            modifier = Modifier.size(20.dp)
+                        )
+                    }
                 }
             }
 
@@ -2057,7 +2269,9 @@ private fun BookmarkCompactCardWide(
                     ) {
                         items(bookmark.labels) { label ->
                             SuggestionChip(
-                                onClick = { onClickLabel(label) },
+                                onClick = {
+                                    if (isSelectionMode) onToggleSelection(bookmark.id) else onClickLabel(label)
+                                },
                                 label = {
                                     Text(
                                         text = label,
@@ -2075,7 +2289,7 @@ private fun BookmarkCompactCardWide(
         }
     }
         HorizontalDivider()
-        if (showBodyContextMenu) {
+        if (showBodyContextMenu && !isSelectionMode) {
             LongPressContextMenuDialog(
                 headerImageUrl = bookmark.iconSrc,
                 title = bookmark.title,
@@ -2110,7 +2324,7 @@ private fun BookmarkCompactCardWide(
 
             }
         }
-        if (showImageContextMenu && bookmark.imageSrc.isNotBlank()) {
+        if (showImageContextMenu && !isSelectionMode && bookmark.imageSrc.isNotBlank()) {
             LongPressContextMenuDialog(
                 headerImageUrl = bookmark.imageSrc,
                 title = bookmark.title,

--- a/app/src/main/java/com/mydeck/app/ui/list/BookmarkListScreen.kt
+++ b/app/src/main/java/com/mydeck/app/ui/list/BookmarkListScreen.kt
@@ -584,6 +584,28 @@ fun BookmarkListScreen(
                     if (isMultiSelectMode) {
                         val targets = multiSelectTargets.value
                         if (multiSelectState.value.hasSelection) {
+                            // Archive slot: shows Unarchive when all selected are already
+                            // archived (one-tap reversal); otherwise shows Archive.
+                            val archiveBarIsRemove = targets.selectedAllArchived
+                            IconButton(
+                                onClick = {
+                                    dismissPendingDeleteSnackbar()
+                                    hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+                                    if (archiveBarIsRemove) {
+                                        viewModel.onUnarchiveSelectedBookmarks()
+                                    } else {
+                                        viewModel.onArchiveSelectedBookmarks()
+                                    }
+                                }
+                            ) {
+                                Icon(
+                                    imageVector = if (archiveBarIsRemove) Icons.Outlined.Inventory2 else Icons.Filled.Inventory2,
+                                    contentDescription = stringResource(
+                                        if (archiveBarIsRemove) R.string.action_remove_from_archive
+                                        else R.string.action_add_to_archive
+                                    )
+                                )
+                            }
                             // Favorite slot: shows Remove-favorite when all selected are already
                             // favorited (one-tap reversal); otherwise shows Add-favorite.
                             val favoriteBarIsRemove = targets.selectedAllFavorited
@@ -606,38 +628,6 @@ fun BookmarkListScreen(
                                     )
                                 )
                             }
-                            val archiveBarIsRemove = targets.selectedAllArchived
-                            IconButton(
-                                onClick = {
-                                    dismissPendingDeleteSnackbar()
-                                    hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
-                                    if (archiveBarIsRemove) {
-                                        viewModel.onUnarchiveSelectedBookmarks()
-                                    } else {
-                                        viewModel.onArchiveSelectedBookmarks()
-                                    }
-                                }
-                            ) {
-                                Icon(
-                                    imageVector = if (archiveBarIsRemove) Icons.Outlined.Inventory2 else Icons.Filled.Inventory2,
-                                    contentDescription = stringResource(
-                                        if (archiveBarIsRemove) R.string.action_remove_from_archive
-                                        else R.string.action_add_to_archive
-                                    )
-                                )
-                            }
-                            IconButton(
-                                onClick = {
-                                    dismissPendingDeleteSnackbar()
-                                    hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
-                                    viewModel.onDeleteSelectedBookmarks()
-                                }
-                            ) {
-                                Icon(
-                                    imageVector = Icons.Filled.Delete,
-                                    contentDescription = stringResource(R.string.action_delete)
-                                )
-                            }
                         }
                         Box {
                             IconButton(onClick = { showSelectionOverflowMenu = true }) {
@@ -651,69 +641,19 @@ fun BookmarkListScreen(
                                 onDismissRequest = { showSelectionOverflowMenu = false }
                             ) {
                                 if (multiSelectState.value.hasSelection) {
-                                    // Overflow slot is the OPPOSITE of the bar's favorite action.
-                                    val overflowFavoriteIsRemove = !targets.selectedAllFavorited
-                                    val overflowFavoriteEnabled = if (overflowFavoriteIsRemove) {
-                                        // Removing favorites only does something if some are favorited.
-                                        !targets.selectedAllUnfavorited
-                                    } else {
-                                        // Adding favorites only does something if some are NOT favorited.
-                                        !targets.selectedAllFavorited
-                                    }
                                     DropdownMenuItem(
                                         leadingIcon = {
                                             Icon(
-                                                imageVector = if (overflowFavoriteIsRemove) Icons.Outlined.FavoriteBorder else Icons.Filled.Favorite,
+                                                imageVector = Icons.Filled.Delete,
                                                 contentDescription = null
                                             )
                                         },
-                                        text = {
-                                            Text(stringResource(
-                                                if (overflowFavoriteIsRemove) R.string.action_remove_from_favorites
-                                                else R.string.action_add_to_favorites
-                                            ))
-                                        },
-                                        enabled = overflowFavoriteEnabled,
+                                        text = { Text(stringResource(R.string.action_delete)) },
                                         onClick = {
                                             showSelectionOverflowMenu = false
                                             dismissPendingDeleteSnackbar()
                                             hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
-                                            if (overflowFavoriteIsRemove) {
-                                                viewModel.onUnfavoriteSelectedBookmarks()
-                                            } else {
-                                                viewModel.onFavoriteSelectedBookmarks()
-                                            }
-                                        }
-                                    )
-                                    val overflowArchiveIsRemove = !targets.selectedAllArchived
-                                    val overflowArchiveEnabled = if (overflowArchiveIsRemove) {
-                                        !targets.selectedAllUnarchived
-                                    } else {
-                                        !targets.selectedAllArchived
-                                    }
-                                    DropdownMenuItem(
-                                        leadingIcon = {
-                                            Icon(
-                                                imageVector = if (overflowArchiveIsRemove) Icons.Outlined.Inventory2 else Icons.Filled.Inventory2,
-                                                contentDescription = null
-                                            )
-                                        },
-                                        text = {
-                                            Text(stringResource(
-                                                if (overflowArchiveIsRemove) R.string.action_remove_from_archive
-                                                else R.string.action_add_to_archive
-                                            ))
-                                        },
-                                        enabled = overflowArchiveEnabled,
-                                        onClick = {
-                                            showSelectionOverflowMenu = false
-                                            dismissPendingDeleteSnackbar()
-                                            hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
-                                            if (overflowArchiveIsRemove) {
-                                                viewModel.onUnarchiveSelectedBookmarks()
-                                            } else {
-                                                viewModel.onArchiveSelectedBookmarks()
-                                            }
+                                            viewModel.onDeleteSelectedBookmarks()
                                         }
                                     )
                                 }

--- a/app/src/main/java/com/mydeck/app/ui/list/BookmarkListScreen.kt
+++ b/app/src/main/java/com/mydeck/app/ui/list/BookmarkListScreen.kt
@@ -39,6 +39,8 @@ import androidx.compose.material.icons.filled.ArrowUpward
 import androidx.compose.material.icons.filled.RadioButtonUnchecked
 import androidx.compose.material.icons.filled.SelectAll
 import androidx.compose.material.icons.filled.Deselect
+import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material.icons.outlined.Inventory2
 import androidx.compose.material.icons.automirrored.filled.List
@@ -53,6 +55,7 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.DrawerState
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
@@ -166,13 +169,11 @@ fun BookmarkListScreen(
     val labelsWithCounts = viewModel.labelsWithCounts.collectAsState()
     val isLabelsSheetOpen = viewModel.isLabelsSheetOpen.collectAsState()
     val pendingDeletionBookmarkIds = viewModel.pendingDeletionBookmarkIds.collectAsState()
+    val pendingBatchDeletionBookmarkIds = viewModel.pendingBatchDeletionBookmarkIds.collectAsState()
     val multiSelectState = viewModel.multiSelectState.collectAsState()
     val multiSelectTargets = viewModel.multiSelectTargets.collectAsState()
     val swipeConfig = viewModel.swipeConfig.collectAsState()
 
-    var showLayoutMenu by remember { mutableStateOf(false) }
-    var showSortMenu by remember { mutableStateOf(false) }
-    var showOverflowMenu by remember { mutableStateOf(false) }
     var showSelectionOverflowMenu by remember { mutableStateOf(false) }
     var showRenameLabelDialog by remember { mutableStateOf(false) }
     var showDeleteLabelDialog by remember { mutableStateOf(false) }
@@ -436,20 +437,30 @@ fun BookmarkListScreen(
     LaunchedEffect(Unit) {
         viewModel.batchActionSnackbarEvent.collect { event ->
             snackbarHostState.currentSnackbarData?.dismiss()
-            val (stringRes, count) = when (event) {
-                is BatchActionSnackbarEvent.FavoritesAdded ->
-                    R.string.multi_select_set_as_favorite to event.count
-                is BatchActionSnackbarEvent.FavoritesRemoved ->
-                    R.string.multi_select_unset_as_favorite to event.count
-                is BatchActionSnackbarEvent.Archived ->
-                    R.string.multi_select_set_as_archived to event.count
-                is BatchActionSnackbarEvent.Unarchived ->
-                    R.string.multi_select_unset_as_archived to event.count
+            val stringRes = when (event) {
+                is BatchActionSnackbarEvent.FavoritesAdded -> R.string.multi_select_set_as_favorite
+                is BatchActionSnackbarEvent.FavoritesRemoved -> R.string.multi_select_unset_as_favorite
+                is BatchActionSnackbarEvent.Archived -> R.string.multi_select_set_as_archived
+                is BatchActionSnackbarEvent.Unarchived -> R.string.multi_select_unset_as_archived
+                is BatchActionSnackbarEvent.Deleted -> R.string.multi_select_deleted_count
             }
-            snackbarHostState.showSnackbar(
-                message = resources.getString(stringRes, count),
-                duration = SnackbarDuration.Short
+            // Delete is destructive and staged, so it stays until the user acts or interacts
+            // elsewhere (matching single-item delete); favorite/archive are already applied.
+            val duration = if (event is BatchActionSnackbarEvent.Deleted) {
+                SnackbarDuration.Indefinite
+            } else {
+                SnackbarDuration.Long
+            }
+            val result = snackbarHostState.showSnackbar(
+                message = resources.getString(stringRes, event.count),
+                actionLabel = undoActionLabel,
+                duration = duration
             )
+            if (result == androidx.compose.material3.SnackbarResult.ActionPerformed) {
+                viewModel.onUndoBatchAction(event)
+            } else {
+                viewModel.onConfirmBatchAction(event)
+            }
         }
     }
 
@@ -615,6 +626,18 @@ fun BookmarkListScreen(
                                     )
                                 )
                             }
+                            IconButton(
+                                onClick = {
+                                    dismissPendingDeleteSnackbar()
+                                    hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+                                    viewModel.onDeleteSelectedBookmarks()
+                                }
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Filled.Delete,
+                                    contentDescription = stringResource(R.string.action_delete)
+                                )
+                            }
                         }
                         Box {
                             IconButton(onClick = { showSelectionOverflowMenu = true }) {
@@ -717,159 +740,18 @@ fun BookmarkListScreen(
                             }
                         }
                     } else {
-                    // Layout button with dropdown — icon reflects current mode
-                    Box {
-                        val currentLayoutIcon = when (layoutMode.value) {
-                            LayoutMode.GRID -> Icons.Filled.Apps
-                            LayoutMode.COMPACT -> Icons.AutoMirrored.Filled.List
-                            LayoutMode.MOSAIC -> Icons.Filled.GridView
-                        }
-                        IconButton(onClick = {
-                            dismissPendingDeleteSnackbar()
-                            showLayoutMenu = true
-                        }) {
-                            Icon(currentLayoutIcon, contentDescription = stringResource(R.string.layout))
-                        }
-                        DropdownMenu(
-                            expanded = showLayoutMenu,
-                            onDismissRequest = { showLayoutMenu = false }
-                        ) {
-                            LayoutMode.entries.forEach { mode ->
-                                DropdownMenuItem(
-                                    leadingIcon = {
-                                        Icon(
-                                            imageVector = when (mode) {
-                                                LayoutMode.GRID -> Icons.Filled.Apps
-                                                LayoutMode.COMPACT -> Icons.AutoMirrored.Filled.List
-                                                LayoutMode.MOSAIC -> Icons.Filled.GridView
-                                            },
-                                            contentDescription = null
-                                        )
-                                    },
-                                    text = {
-                                        Text(
-                                            text = mode.displayName,
-                                            fontWeight = if (mode == layoutMode.value) FontWeight.Bold else FontWeight.Normal
-                                        )
-                                    },
-                                    onClick = {
-                                        viewModel.onLayoutModeSelected(mode)
-                                        showLayoutMenu = false
-                                    }
-                                )
-                            }
-                        }
-                    }
-
-                    // Sort button with dropdown — one row per category, arrow shows direction of active sort
-                    Box {
-                        IconButton(onClick = {
-                            dismissPendingDeleteSnackbar()
-                            showSortMenu = true
-                        }) {
-                            Icon(Icons.Filled.SwapVert, contentDescription = stringResource(R.string.sort))
-                        }
-                        DropdownMenu(
-                            expanded = showSortMenu,
-                            onDismissRequest = { showSortMenu = false }
-                        ) {
-                            // Groups: (label, descOption, ascOption)
-                            val sortGroups = listOf(
-                                Triple("Added", SortOption.ADDED_NEWEST, SortOption.ADDED_OLDEST),
-                                Triple("Published", SortOption.PUBLISHED_NEWEST, SortOption.PUBLISHED_OLDEST),
-                                Triple("Title", SortOption.TITLE_A_TO_Z, SortOption.TITLE_Z_TO_A),
-                                Triple("Site name", SortOption.SITE_A_TO_Z, SortOption.SITE_Z_TO_A),
-                                Triple("Duration", SortOption.DURATION_LONGEST, SortOption.DURATION_SHORTEST)
-                            )
-                            sortGroups.forEach { (label, firstOption, secondOption) ->
-                                val isFirstSelected = sortOption.value == firstOption
-                                val isSecondSelected = sortOption.value == secondOption
-                                val isGroupSelected = isFirstSelected || isSecondSelected
-                                val activeOption = if (isSecondSelected) secondOption else firstOption
-                                val isDescending = activeOption.sqlOrderBy.contains("DESC")
-                                DropdownMenuItem(
-                                    leadingIcon = {
-                                        if (isGroupSelected) {
-                                            Icon(
-                                                imageVector = if (isDescending) Icons.Filled.ArrowDownward else Icons.Filled.ArrowUpward,
-                                                contentDescription = null,
-                                                tint = MaterialTheme.colorScheme.primary
-                                            )
-                                        } else {
-                                            Spacer(Modifier.size(24.dp))
-                                        }
-                                    },
-                                    text = {
-                                        Text(
-                                            text = label,
-                                            color = if (isGroupSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface,
-                                            fontWeight = if (isGroupSelected) FontWeight.Bold else FontWeight.Normal
-                                        )
-                                    },
-                                    onClick = {
-                                        val newOption = when {
-                                            isFirstSelected -> secondOption  // toggle to other direction
-                                            isSecondSelected -> firstOption  // toggle back
-                                            else -> firstOption              // first tap: use default
-                                        }
-                                        viewModel.onSortOptionSelected(newOption)
-                                        showSortMenu = false
-                                    }
-                                )
-                            }
-                        }
-                    }
-
-                    if (isLabelMode) {
-                        // Overflow menu with Rename/Delete label options
-                        Box {
-                            IconButton(onClick = {
-                                dismissPendingDeleteSnackbar()
-                                showOverflowMenu = true
-                            }) {
-                                Icon(Icons.Filled.MoreVert, contentDescription = stringResource(R.string.more_options))
-                            }
-                            DropdownMenu(
-                                expanded = showOverflowMenu,
-                                onDismissRequest = { showOverflowMenu = false }
-                            ) {
-                                DropdownMenuItem(
-                                    text = { Text(stringResource(R.string.rename_label)) },
-                                    onClick = {
-                                        showRenameLabelDialog = true
-                                        showOverflowMenu = false
-                                    }
-                                )
-                                DropdownMenuItem(
-                                    text = { Text(stringResource(R.string.delete_label)) },
-                                    onClick = {
-                                        showDeleteLabelDialog = true
-                                        showOverflowMenu = false
-                                    }
-                                )
-                            }
-                        }
-                    } else {
-                        // Filter button (non-label mode only)
-                        IconButton(onClick = {
-                            dismissPendingDeleteSnackbar()
-                            viewModel.onOpenFilterSheet()
-                        }) {
-                            Icon(Icons.Filled.FilterList, contentDescription = stringResource(R.string.filter_bookmarks))
-                        }
-                    }
-                    IconButton(onClick = {
-                        dismissPendingDeleteSnackbar()
-                        showLayoutMenu = false
-                        showSortMenu = false
-                        showOverflowMenu = false
-                        viewModel.onEnterMultiSelectMode()
-                    }) {
-                        Icon(
-                            Icons.Filled.RadioButtonUnchecked,
-                            contentDescription = stringResource(R.string.action_select_bookmarks)
-                        )
-                    }
+                    BookmarkListBarActions(
+                        isLabelMode = isLabelMode,
+                        layoutMode = layoutMode.value,
+                        sortOption = sortOption.value,
+                        onLayoutModeSelected = { viewModel.onLayoutModeSelected(it) },
+                        onSortOptionSelected = { viewModel.onSortOptionSelected(it) },
+                        onDismissPendingDelete = dismissPendingDeleteSnackbar,
+                        onOpenFilterSheet = { viewModel.onOpenFilterSheet() },
+                        onEnterMultiSelectMode = { viewModel.onEnterMultiSelectMode() },
+                        onRequestRenameLabel = { showRenameLabelDialog = true },
+                        onRequestDeleteLabel = { showDeleteLabelDialog = true },
+                    )
                     }
                 }
             )
@@ -900,7 +782,8 @@ fun BookmarkListScreen(
             }
         }
     ) { padding ->
-        val hasPendingDeletion = pendingDeletionBookmarkIds.value.isNotEmpty()
+        val allPendingDeletionIds = pendingDeletionBookmarkIds.value.toSet() + pendingBatchDeletionBookmarkIds.value
+        val hasPendingDeletion = allPendingDeletionIds.isNotEmpty()
         Column(
             modifier = Modifier
                 .padding(padding)
@@ -959,7 +842,7 @@ fun BookmarkListScreen(
                                 scrollToTopTrigger = scrollToTopTrigger,
                                 layoutMode = layoutMode.value,
                                 bookmarks = uiState.bookmarks,
-                                pendingDeletionBookmarkIds = pendingDeletionBookmarkIds.value.toSet(),
+                                pendingDeletionBookmarkIds = allPendingDeletionIds,
                                 isMultiSelectMode = isMultiSelectMode,
                                 selectedBookmarkIds = multiSelectState.value.selectedIds,
                                 swipeConfig = swipeConfig.value,
@@ -1158,6 +1041,198 @@ fun BookmarkListScreen(
                 }
             }
         )
+    }
+}
+
+/**
+ * The normal / label-mode top-app-bar actions row (Layout, Sort, Overflow).
+ * Extracted as a standalone composable so it can be tested in isolation without
+ * wiring up a full BookmarkListViewModel.
+ */
+@Composable
+internal fun BookmarkListBarActions(
+    isLabelMode: Boolean,
+    layoutMode: LayoutMode,
+    sortOption: SortOption,
+    onLayoutModeSelected: (LayoutMode) -> Unit,
+    onSortOptionSelected: (SortOption) -> Unit,
+    onDismissPendingDelete: () -> Unit = {},
+    onOpenFilterSheet: () -> Unit,
+    onEnterMultiSelectMode: () -> Unit,
+    onRequestRenameLabel: () -> Unit,
+    onRequestDeleteLabel: () -> Unit,
+) {
+    var showLayoutMenu by remember { mutableStateOf(false) }
+    var showSortMenu by remember { mutableStateOf(false) }
+    var showOverflowMenu by remember { mutableStateOf(false) }
+
+    // Layout button with dropdown — icon reflects current mode
+    Box {
+        val currentLayoutIcon = when (layoutMode) {
+            LayoutMode.GRID -> Icons.Filled.Apps
+            LayoutMode.COMPACT -> Icons.AutoMirrored.Filled.List
+            LayoutMode.MOSAIC -> Icons.Filled.GridView
+        }
+        IconButton(onClick = {
+            onDismissPendingDelete()
+            showLayoutMenu = true
+        }) {
+            Icon(currentLayoutIcon, contentDescription = stringResource(R.string.layout))
+        }
+        DropdownMenu(
+            expanded = showLayoutMenu,
+            onDismissRequest = { showLayoutMenu = false }
+        ) {
+            LayoutMode.entries.forEach { mode ->
+                DropdownMenuItem(
+                    leadingIcon = {
+                        Icon(
+                            imageVector = when (mode) {
+                                LayoutMode.GRID -> Icons.Filled.Apps
+                                LayoutMode.COMPACT -> Icons.AutoMirrored.Filled.List
+                                LayoutMode.MOSAIC -> Icons.Filled.GridView
+                            },
+                            contentDescription = null
+                        )
+                    },
+                    text = {
+                        Text(
+                            text = mode.displayName,
+                            fontWeight = if (mode == layoutMode) FontWeight.Bold else FontWeight.Normal
+                        )
+                    },
+                    onClick = {
+                        onLayoutModeSelected(mode)
+                        showLayoutMenu = false
+                    }
+                )
+            }
+        }
+    }
+
+    // Sort button with dropdown — one row per category, arrow shows direction of active sort
+    Box {
+        IconButton(onClick = {
+            onDismissPendingDelete()
+            showSortMenu = true
+        }) {
+            Icon(Icons.Filled.SwapVert, contentDescription = stringResource(R.string.sort))
+        }
+        DropdownMenu(
+            expanded = showSortMenu,
+            onDismissRequest = { showSortMenu = false }
+        ) {
+            // Groups: (label, descOption, ascOption)
+            val sortGroups = listOf(
+                Triple("Added", SortOption.ADDED_NEWEST, SortOption.ADDED_OLDEST),
+                Triple("Published", SortOption.PUBLISHED_NEWEST, SortOption.PUBLISHED_OLDEST),
+                Triple("Title", SortOption.TITLE_A_TO_Z, SortOption.TITLE_Z_TO_A),
+                Triple("Site name", SortOption.SITE_A_TO_Z, SortOption.SITE_Z_TO_A),
+                Triple("Duration", SortOption.DURATION_LONGEST, SortOption.DURATION_SHORTEST)
+            )
+            sortGroups.forEach { (label, firstOption, secondOption) ->
+                val isFirstSelected = sortOption == firstOption
+                val isSecondSelected = sortOption == secondOption
+                val isGroupSelected = isFirstSelected || isSecondSelected
+                val activeOption = if (isSecondSelected) secondOption else firstOption
+                val isDescending = activeOption.sqlOrderBy.contains("DESC")
+                DropdownMenuItem(
+                    leadingIcon = {
+                        if (isGroupSelected) {
+                            Icon(
+                                imageVector = if (isDescending) Icons.Filled.ArrowDownward else Icons.Filled.ArrowUpward,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.primary
+                            )
+                        } else {
+                            Spacer(Modifier.size(24.dp))
+                        }
+                    },
+                    text = {
+                        Text(
+                            text = label,
+                            color = if (isGroupSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface,
+                            fontWeight = if (isGroupSelected) FontWeight.Bold else FontWeight.Normal
+                        )
+                    },
+                    onClick = {
+                        val newOption = when {
+                            isFirstSelected -> secondOption  // toggle to other direction
+                            isSecondSelected -> firstOption  // toggle back
+                            else -> firstOption              // first tap: use default
+                        }
+                        onSortOptionSelected(newOption)
+                        showSortMenu = false
+                    }
+                )
+            }
+        }
+    }
+
+    // Overflow menu — always present; same bar shape in normal and label modes.
+    // Label mode lists Rename/Delete label (label-scoped) above a divider, then
+    // Select bookmarks. Normal mode lists Filter, then Select bookmarks (no Filter
+    // in label mode — the label itself is the filter).
+    Box {
+        IconButton(onClick = {
+            onDismissPendingDelete()
+            showOverflowMenu = true
+        }) {
+            Icon(Icons.Filled.MoreVert, contentDescription = stringResource(R.string.more_options))
+        }
+        DropdownMenu(
+            expanded = showOverflowMenu,
+            onDismissRequest = { showOverflowMenu = false }
+        ) {
+            if (isLabelMode) {
+                DropdownMenuItem(
+                    leadingIcon = {
+                        Icon(Icons.Outlined.Edit, contentDescription = null)
+                    },
+                    text = { Text(stringResource(R.string.rename_label)) },
+                    onClick = {
+                        onRequestRenameLabel()
+                        showOverflowMenu = false
+                    }
+                )
+                DropdownMenuItem(
+                    leadingIcon = {
+                        Icon(Icons.Outlined.Delete, contentDescription = null)
+                    },
+                    text = { Text(stringResource(R.string.delete_label)) },
+                    onClick = {
+                        onRequestDeleteLabel()
+                        showOverflowMenu = false
+                    }
+                )
+                HorizontalDivider()
+            } else {
+                DropdownMenuItem(
+                    leadingIcon = {
+                        Icon(Icons.Filled.FilterList, contentDescription = null)
+                    },
+                    text = { Text(stringResource(R.string.filter_bookmarks)) },
+                    onClick = {
+                        showOverflowMenu = false
+                        onDismissPendingDelete()
+                        onOpenFilterSheet()
+                    }
+                )
+            }
+            DropdownMenuItem(
+                leadingIcon = {
+                    Icon(Icons.Filled.RadioButtonUnchecked, contentDescription = null)
+                },
+                text = { Text(stringResource(R.string.action_select_bookmarks)) },
+                onClick = {
+                    showOverflowMenu = false
+                    showLayoutMenu = false
+                    showSortMenu = false
+                    onDismissPendingDelete()
+                    onEnterMultiSelectMode()
+                }
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/mydeck/app/ui/list/BookmarkListScreen.kt
+++ b/app/src/main/java/com/mydeck/app/ui/list/BookmarkListScreen.kt
@@ -172,6 +172,7 @@ fun BookmarkListScreen(
     val pendingBatchDeletionBookmarkIds = viewModel.pendingBatchDeletionBookmarkIds.collectAsState()
     val multiSelectState = viewModel.multiSelectState.collectAsState()
     val multiSelectTargets = viewModel.multiSelectTargets.collectAsState()
+    val showAddLabelsPicker = viewModel.showAddLabelsPicker.collectAsState()
     val swipeConfig = viewModel.swipeConfig.collectAsState()
 
     var showSelectionOverflowMenu by remember { mutableStateOf(false) }
@@ -442,6 +443,7 @@ fun BookmarkListScreen(
                 is BatchActionSnackbarEvent.FavoritesRemoved -> R.string.multi_select_unset_as_favorite
                 is BatchActionSnackbarEvent.Archived -> R.string.multi_select_set_as_archived
                 is BatchActionSnackbarEvent.Unarchived -> R.string.multi_select_unset_as_archived
+                is BatchActionSnackbarEvent.LabelsAdded -> R.string.multi_select_labels_added
                 is BatchActionSnackbarEvent.Deleted -> R.string.multi_select_deleted_count
             }
             // Delete is destructive and staged, so it stays until the user acts or interacts
@@ -654,6 +656,20 @@ fun BookmarkListScreen(
                                             dismissPendingDeleteSnackbar()
                                             hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
                                             viewModel.onDeleteSelectedBookmarks()
+                                        }
+                                    )
+                                    DropdownMenuItem(
+                                        leadingIcon = {
+                                            Icon(
+                                                imageVector = Icons.AutoMirrored.Outlined.Label,
+                                                contentDescription = null
+                                            )
+                                        },
+                                        text = { Text(stringResource(R.string.add_labels)) },
+                                        onClick = {
+                                            showSelectionOverflowMenu = false
+                                            dismissPendingDeleteSnackbar()
+                                            viewModel.onAddLabelsToSelection()
                                         }
                                     )
                                 }
@@ -901,6 +917,23 @@ fun BookmarkListScreen(
                 onDeleteLabel = { label -> viewModel.onDeleteLabel(label) }
             ),
             onDismiss = { viewModel.onCloseLabelsSheet() }
+        )
+    }
+
+    // Multi-select: Add labels picker (additive union applied to the captured selection).
+    // The mode is remembered so it stays referentially stable across this screen's frequent
+    // recompositions; otherwise the sheet's remember(mode) would reset the in-progress selection.
+    if (showAddLabelsPicker.value) {
+        val addLabelsMode = remember {
+            LabelPickerMode.MultiSelect(
+                initialSelection = emptySet(),
+                onDone = { chosen -> viewModel.onLabelsPicked(chosen) }
+            )
+        }
+        LabelPickerBottomSheet(
+            labels = labelsWithCounts.value,
+            mode = addLabelsMode,
+            onDismiss = { viewModel.onDismissAddLabelsPicker() }
         )
     }
 

--- a/app/src/main/java/com/mydeck/app/ui/list/BookmarkListScreen.kt
+++ b/app/src/main/java/com/mydeck/app/ui/list/BookmarkListScreen.kt
@@ -37,6 +37,10 @@ import androidx.compose.material.icons.filled.FilterList
 import androidx.compose.material.icons.filled.ArrowDownward
 import androidx.compose.material.icons.filled.ArrowUpward
 import androidx.compose.material.icons.filled.RadioButtonUnchecked
+import androidx.compose.material.icons.filled.SelectAll
+import androidx.compose.material.icons.filled.Deselect
+import androidx.compose.material.icons.outlined.FavoriteBorder
+import androidx.compose.material.icons.outlined.Inventory2
 import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.automirrored.outlined.Label
 import androidx.compose.material.icons.outlined.Bookmarks
@@ -163,11 +167,13 @@ fun BookmarkListScreen(
     val isLabelsSheetOpen = viewModel.isLabelsSheetOpen.collectAsState()
     val pendingDeletionBookmarkIds = viewModel.pendingDeletionBookmarkIds.collectAsState()
     val multiSelectState = viewModel.multiSelectState.collectAsState()
+    val multiSelectTargets = viewModel.multiSelectTargets.collectAsState()
     val swipeConfig = viewModel.swipeConfig.collectAsState()
 
     var showLayoutMenu by remember { mutableStateOf(false) }
     var showSortMenu by remember { mutableStateOf(false) }
     var showOverflowMenu by remember { mutableStateOf(false) }
+    var showSelectionOverflowMenu by remember { mutableStateOf(false) }
     var showRenameLabelDialog by remember { mutableStateOf(false) }
     var showDeleteLabelDialog by remember { mutableStateOf(false) }
     var scrollToTopTrigger by remember { mutableStateOf(0) }
@@ -426,6 +432,27 @@ fun BookmarkListScreen(
         }
     }
 
+    val resources = context.resources
+    LaunchedEffect(Unit) {
+        viewModel.batchActionSnackbarEvent.collect { event ->
+            snackbarHostState.currentSnackbarData?.dismiss()
+            val (pluralRes, count) = when (event) {
+                is BatchActionSnackbarEvent.FavoritesAdded ->
+                    R.plurals.multi_select_set_as_favorite to event.count
+                is BatchActionSnackbarEvent.FavoritesRemoved ->
+                    R.plurals.multi_select_unset_as_favorite to event.count
+                is BatchActionSnackbarEvent.Archived ->
+                    R.plurals.multi_select_set_as_archived to event.count
+                is BatchActionSnackbarEvent.Unarchived ->
+                    R.plurals.multi_select_unset_as_archived to event.count
+            }
+            snackbarHostState.showSnackbar(
+                message = resources.getQuantityString(pluralRes, count, count),
+                duration = SnackbarDuration.Short
+            )
+        }
+    }
+
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_STOP) {
@@ -544,29 +571,148 @@ fun BookmarkListScreen(
                 },
                 actions = {
                     if (isMultiSelectMode) {
+                        val targets = multiSelectTargets.value
                         if (multiSelectState.value.hasSelection) {
+                            // Favorite slot: shows Remove-favorite when all selected are already
+                            // favorited (one-tap reversal); otherwise shows Add-favorite.
+                            val favoriteBarIsRemove = targets.selectedAllFavorited
                             IconButton(
                                 onClick = {
                                     dismissPendingDeleteSnackbar()
                                     hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
-                                    viewModel.onFavoriteSelectedBookmarks()
+                                    if (favoriteBarIsRemove) {
+                                        viewModel.onUnfavoriteSelectedBookmarks()
+                                    } else {
+                                        viewModel.onFavoriteSelectedBookmarks()
+                                    }
                                 }
                             ) {
                                 Icon(
-                                    Icons.Filled.Favorite,
-                                    contentDescription = stringResource(R.string.action_favorite)
+                                    imageVector = if (favoriteBarIsRemove) Icons.Outlined.FavoriteBorder else Icons.Filled.Favorite,
+                                    contentDescription = stringResource(
+                                        if (favoriteBarIsRemove) R.string.action_remove_from_favorites
+                                        else R.string.action_add_to_favorites
+                                    )
                                 )
                             }
+                            val archiveBarIsRemove = targets.selectedAllArchived
                             IconButton(
                                 onClick = {
                                     dismissPendingDeleteSnackbar()
                                     hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
-                                    viewModel.onArchiveSelectedBookmarks()
+                                    if (archiveBarIsRemove) {
+                                        viewModel.onUnarchiveSelectedBookmarks()
+                                    } else {
+                                        viewModel.onArchiveSelectedBookmarks()
+                                    }
                                 }
                             ) {
                                 Icon(
-                                    Icons.Filled.Inventory2,
-                                    contentDescription = stringResource(R.string.action_archive)
+                                    imageVector = if (archiveBarIsRemove) Icons.Outlined.Inventory2 else Icons.Filled.Inventory2,
+                                    contentDescription = stringResource(
+                                        if (archiveBarIsRemove) R.string.action_remove_from_archive
+                                        else R.string.action_add_to_archive
+                                    )
+                                )
+                            }
+                        }
+                        Box {
+                            IconButton(onClick = { showSelectionOverflowMenu = true }) {
+                                Icon(
+                                    Icons.Filled.MoreVert,
+                                    contentDescription = stringResource(R.string.more_options)
+                                )
+                            }
+                            DropdownMenu(
+                                expanded = showSelectionOverflowMenu,
+                                onDismissRequest = { showSelectionOverflowMenu = false }
+                            ) {
+                                if (multiSelectState.value.hasSelection) {
+                                    // Overflow slot is the OPPOSITE of the bar's favorite action.
+                                    val overflowFavoriteIsRemove = !targets.selectedAllFavorited
+                                    val overflowFavoriteEnabled = if (overflowFavoriteIsRemove) {
+                                        // Removing favorites only does something if some are favorited.
+                                        !targets.selectedAllUnfavorited
+                                    } else {
+                                        // Adding favorites only does something if some are NOT favorited.
+                                        !targets.selectedAllFavorited
+                                    }
+                                    DropdownMenuItem(
+                                        leadingIcon = {
+                                            Icon(
+                                                imageVector = if (overflowFavoriteIsRemove) Icons.Outlined.FavoriteBorder else Icons.Filled.Favorite,
+                                                contentDescription = null
+                                            )
+                                        },
+                                        text = {
+                                            Text(stringResource(
+                                                if (overflowFavoriteIsRemove) R.string.action_remove_from_favorites
+                                                else R.string.action_add_to_favorites
+                                            ))
+                                        },
+                                        enabled = overflowFavoriteEnabled,
+                                        onClick = {
+                                            showSelectionOverflowMenu = false
+                                            dismissPendingDeleteSnackbar()
+                                            hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+                                            if (overflowFavoriteIsRemove) {
+                                                viewModel.onUnfavoriteSelectedBookmarks()
+                                            } else {
+                                                viewModel.onFavoriteSelectedBookmarks()
+                                            }
+                                        }
+                                    )
+                                    val overflowArchiveIsRemove = !targets.selectedAllArchived
+                                    val overflowArchiveEnabled = if (overflowArchiveIsRemove) {
+                                        !targets.selectedAllUnarchived
+                                    } else {
+                                        !targets.selectedAllArchived
+                                    }
+                                    DropdownMenuItem(
+                                        leadingIcon = {
+                                            Icon(
+                                                imageVector = if (overflowArchiveIsRemove) Icons.Outlined.Inventory2 else Icons.Filled.Inventory2,
+                                                contentDescription = null
+                                            )
+                                        },
+                                        text = {
+                                            Text(stringResource(
+                                                if (overflowArchiveIsRemove) R.string.action_remove_from_archive
+                                                else R.string.action_add_to_archive
+                                            ))
+                                        },
+                                        enabled = overflowArchiveEnabled,
+                                        onClick = {
+                                            showSelectionOverflowMenu = false
+                                            dismissPendingDeleteSnackbar()
+                                            hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+                                            if (overflowArchiveIsRemove) {
+                                                viewModel.onUnarchiveSelectedBookmarks()
+                                            } else {
+                                                viewModel.onArchiveSelectedBookmarks()
+                                            }
+                                        }
+                                    )
+                                }
+                                val allSelected = targets.allVisibleSelected
+                                DropdownMenuItem(
+                                    leadingIcon = {
+                                        Icon(
+                                            imageVector = if (allSelected) Icons.Filled.Deselect else Icons.Filled.SelectAll,
+                                            contentDescription = null
+                                        )
+                                    },
+                                    text = {
+                                        Text(stringResource(
+                                            if (allSelected) R.string.action_deselect_all
+                                            else R.string.action_select_all
+                                        ))
+                                    },
+                                    onClick = {
+                                        showSelectionOverflowMenu = false
+                                        dismissPendingDeleteSnackbar()
+                                        viewModel.onToggleSelectAllBookmarks()
+                                    }
                                 )
                             }
                         }

--- a/app/src/main/java/com/mydeck/app/ui/list/BookmarkListScreen.kt
+++ b/app/src/main/java/com/mydeck/app/ui/list/BookmarkListScreen.kt
@@ -436,18 +436,18 @@ fun BookmarkListScreen(
     LaunchedEffect(Unit) {
         viewModel.batchActionSnackbarEvent.collect { event ->
             snackbarHostState.currentSnackbarData?.dismiss()
-            val (pluralRes, count) = when (event) {
+            val (stringRes, count) = when (event) {
                 is BatchActionSnackbarEvent.FavoritesAdded ->
-                    R.plurals.multi_select_set_as_favorite to event.count
+                    R.string.multi_select_set_as_favorite to event.count
                 is BatchActionSnackbarEvent.FavoritesRemoved ->
-                    R.plurals.multi_select_unset_as_favorite to event.count
+                    R.string.multi_select_unset_as_favorite to event.count
                 is BatchActionSnackbarEvent.Archived ->
-                    R.plurals.multi_select_set_as_archived to event.count
+                    R.string.multi_select_set_as_archived to event.count
                 is BatchActionSnackbarEvent.Unarchived ->
-                    R.plurals.multi_select_unset_as_archived to event.count
+                    R.string.multi_select_unset_as_archived to event.count
             }
             snackbarHostState.showSnackbar(
-                message = resources.getQuantityString(pluralRes, count, count),
+                message = resources.getString(stringRes, count),
                 duration = SnackbarDuration.Short
             )
         }

--- a/app/src/main/java/com/mydeck/app/ui/list/BookmarkListScreen.kt
+++ b/app/src/main/java/com/mydeck/app/ui/list/BookmarkListScreen.kt
@@ -26,14 +26,17 @@ import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.SwapVert
 import androidx.compose.material.icons.filled.GridView
 import androidx.compose.material.icons.filled.Apps
+import androidx.compose.material.icons.filled.Inventory2
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.FilterList
 import androidx.compose.material.icons.filled.ArrowDownward
 import androidx.compose.material.icons.filled.ArrowUpward
+import androidx.compose.material.icons.filled.RadioButtonUnchecked
 import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.automirrored.outlined.Label
 import androidx.compose.material.icons.outlined.Bookmarks
@@ -159,6 +162,7 @@ fun BookmarkListScreen(
     val labelsWithCounts = viewModel.labelsWithCounts.collectAsState()
     val isLabelsSheetOpen = viewModel.isLabelsSheetOpen.collectAsState()
     val pendingDeletionBookmarkIds = viewModel.pendingDeletionBookmarkIds.collectAsState()
+    val multiSelectState = viewModel.multiSelectState.collectAsState()
     val swipeConfig = viewModel.swipeConfig.collectAsState()
 
     var showLayoutMenu by remember { mutableStateOf(false) }
@@ -181,6 +185,7 @@ fun BookmarkListScreen(
     val syncFraction by viewModel.syncFraction.collectAsState()
 
     val isLabelMode = activeLabel.value != null
+    val isMultiSelectMode = multiSelectState.value.active
     val dismissPendingDeleteSnackbar: () -> Unit = {
         snackbarHostState.currentSnackbarData?.dismiss()
     }
@@ -434,6 +439,12 @@ fun BookmarkListScreen(
         }
     }
 
+    DisposableEffect(viewModel) {
+        onDispose {
+            viewModel.onExitMultiSelectMode()
+        }
+    }
+
     // Determine the current view title based on drawer preset
     val currentPresetTitle = when (drawerPreset.value) {
         DrawerPreset.MY_LIST -> stringResource(id = R.string.my_list)
@@ -470,7 +481,14 @@ fun BookmarkListScreen(
             Column {
             TopAppBar(
                 title = {
-                    if (isLabelMode) {
+                    if (isMultiSelectMode) {
+                        Text(
+                            text = stringResource(
+                                R.string.selected_bookmark_count,
+                                multiSelectState.value.selectedCount
+                            )
+                        )
+                    } else if (isLabelMode) {
                         Row(
                             verticalAlignment = Alignment.CenterVertically,
                             modifier = Modifier.clickable {
@@ -498,7 +516,19 @@ fun BookmarkListScreen(
                     }
                 },
                 navigationIcon = {
-                    if (showNavigationIcon) {
+                    if (isMultiSelectMode) {
+                        IconButton(
+                            onClick = {
+                                dismissPendingDeleteSnackbar()
+                                viewModel.onExitMultiSelectMode()
+                            }
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.Clear,
+                                contentDescription = stringResource(R.string.action_exit_selection_mode)
+                            )
+                        }
+                    } else if (showNavigationIcon) {
                         IconButton(
                             onClick = {
                                 dismissPendingDeleteSnackbar()
@@ -513,6 +543,34 @@ fun BookmarkListScreen(
                     }
                 },
                 actions = {
+                    if (isMultiSelectMode) {
+                        if (multiSelectState.value.hasSelection) {
+                            IconButton(
+                                onClick = {
+                                    dismissPendingDeleteSnackbar()
+                                    hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+                                    viewModel.onFavoriteSelectedBookmarks()
+                                }
+                            ) {
+                                Icon(
+                                    Icons.Filled.Favorite,
+                                    contentDescription = stringResource(R.string.action_favorite)
+                                )
+                            }
+                            IconButton(
+                                onClick = {
+                                    dismissPendingDeleteSnackbar()
+                                    hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+                                    viewModel.onArchiveSelectedBookmarks()
+                                }
+                            ) {
+                                Icon(
+                                    Icons.Filled.Inventory2,
+                                    contentDescription = stringResource(R.string.action_archive)
+                                )
+                            }
+                        }
+                    } else {
                     // Layout button with dropdown — icon reflects current mode
                     Box {
                         val currentLayoutIcon = when (layoutMode.value) {
@@ -654,6 +712,19 @@ fun BookmarkListScreen(
                             Icon(Icons.Filled.FilterList, contentDescription = stringResource(R.string.filter_bookmarks))
                         }
                     }
+                    IconButton(onClick = {
+                        dismissPendingDeleteSnackbar()
+                        showLayoutMenu = false
+                        showSortMenu = false
+                        showOverflowMenu = false
+                        viewModel.onEnterMultiSelectMode()
+                    }) {
+                        Icon(
+                            Icons.Filled.RadioButtonUnchecked,
+                            contentDescription = stringResource(R.string.action_select_bookmarks)
+                        )
+                    }
+                    }
                 }
             )
             val fraction = syncFraction
@@ -666,18 +737,20 @@ fun BookmarkListScreen(
             }
         },
         floatingActionButton = {
-            val clipboardManager = LocalClipboardManager.current
-            FloatingActionButton(
-                onClick = {
-                    dismissPendingDeleteSnackbar()
-                    val clipboardText = clipboardManager.getText()?.text
-                    viewModel.openCreateBookmarkDialog(clipboardText)
+            if (!isMultiSelectMode) {
+                val clipboardManager = LocalClipboardManager.current
+                FloatingActionButton(
+                    onClick = {
+                        dismissPendingDeleteSnackbar()
+                        val clipboardText = clipboardManager.getText()?.text
+                        viewModel.openCreateBookmarkDialog(clipboardText)
+                    }
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Add,
+                        contentDescription = stringResource(id = R.string.add_bookmark)
+                    )
                 }
-            ) {
-                Icon(
-                    imageVector = Icons.Filled.Add,
-                    contentDescription = stringResource(id = R.string.add_bookmark)
-                )
             }
         }
     ) { padding ->
@@ -701,7 +774,7 @@ fun BookmarkListScreen(
                 }
         ) {
             // FilterBar: visible when filters are active beyond preset defaults, not in label mode
-            if (!isLabelMode) {
+            if (!isLabelMode && !isMultiSelectMode) {
                 FilterBar(
                     filterFormState = filterFormState.value,
                     drawerPreset = drawerPreset.value,
@@ -741,8 +814,11 @@ fun BookmarkListScreen(
                                 layoutMode = layoutMode.value,
                                 bookmarks = uiState.bookmarks,
                                 pendingDeletionBookmarkIds = pendingDeletionBookmarkIds.value.toSet(),
+                                isMultiSelectMode = isMultiSelectMode,
+                                selectedBookmarkIds = multiSelectState.value.selectedIds,
                                 swipeConfig = swipeConfig.value,
                                 onClickBookmark = onClickBookmark,
+                                onToggleBookmarkSelection = { viewModel.onToggleBookmarkSelected(it) },
                                 onClickDelete = onClickDelete,
                                 onClickArchive = onClickArchive,
                                 onClickFavorite = onClickFavorite,
@@ -1023,9 +1099,12 @@ fun BookmarkListView(
     layoutMode: LayoutMode = LayoutMode.GRID,
     bookmarks: List<BookmarkListItem>,
     pendingDeletionBookmarkIds: Set<String> = emptySet(),
+    isMultiSelectMode: Boolean = false,
+    selectedBookmarkIds: Set<String> = emptySet(),
     swipeConfig: SwipeConfig = SwipeConfig.Default,
     isMultiColumn: Boolean = LocalIsWideLayout.current,
     onClickBookmark: (String) -> Unit,
+    onToggleBookmarkSelection: (String) -> Unit = {},
     onClickDelete: (String) -> Unit,
     onClickFavorite: (String, Boolean) -> Unit,
     onClickArchive: (String, Boolean) -> Unit,
@@ -1082,6 +1161,15 @@ fun BookmarkListView(
                     val noop2: (String, Boolean) -> Unit = { _, _ -> }
                     val noop2s: (String, String) -> Unit = { _, _ -> }
                     val noopShare: (String, String) -> Unit = { _, _ -> }
+                    val isSelected = bookmark.id in selectedBookmarkIds
+                    val selectionModeForCard = isMultiSelectMode && !isPendingDeletion
+                    val selectBookmark: (String) -> Unit = { onToggleBookmarkSelection(it) }
+                    val cardClick = when {
+                        isPendingDeletion -> confirmDelete
+                        selectionModeForCard -> selectBookmark
+                        else -> onClickBookmark
+                    }
+                    val actionsDisabled = isPendingDeletion || selectionModeForCard
                     SwipeWrappedBookmark(
                         bookmark = bookmark,
                         isPendingDeletion = isPendingDeletion,
@@ -1095,60 +1183,69 @@ fun BookmarkListView(
                         when (layoutMode) {
                             LayoutMode.GRID -> BookmarkGridCard(
                                 bookmark = bookmark,
-                                onClickCard = if (isPendingDeletion) confirmDelete else onClickBookmark,
-                                onClickDelete = if (isPendingDeletion) noop else onClickDelete,
-                                onClickArchive = if (isPendingDeletion) noop2 else onClickArchive,
-                                onClickFavorite = if (isPendingDeletion) noop2 else onClickFavorite,
-                                onClickLabel = if (isPendingDeletion) noop else onClickLabel,
-                                onClickOpenUrl = if (isPendingDeletion) noop else onClickOpenUrl,
-                                onClickOpenInBrowser = if (isPendingDeletion) noop else onClickOpenInBrowser,
-                                onClickCopyLink = if (isPendingDeletion) noop else onClickCopyLink,
-                                onClickCopyLinkText = if (isPendingDeletion) noop else onClickCopyLinkText,
-                                onClickShareLink = if (isPendingDeletion) noopShare else onClickShareLink,
-                                onClickOpenInBrowserFromMenu = if (isPendingDeletion) noop else onClickOpenInBrowserFromMenu,
-                                onClickCopyImage = if (isPendingDeletion) noop else onClickCopyImage,
-                                onClickDownloadLink = if (isPendingDeletion) noop2s else onClickDownloadLink,
-                                onClickDownloadImage = if (isPendingDeletion) noop else onClickDownloadImage,
-                                onClickShareImage = if (isPendingDeletion) noop else onClickShareImage,
+                                onClickCard = cardClick,
+                                onClickDelete = if (actionsDisabled) noop else onClickDelete,
+                                onClickArchive = if (actionsDisabled) noop2 else onClickArchive,
+                                onClickFavorite = if (actionsDisabled) noop2 else onClickFavorite,
+                                onClickLabel = if (actionsDisabled) noop else onClickLabel,
+                                onClickOpenUrl = if (actionsDisabled) noop else onClickOpenUrl,
+                                onClickOpenInBrowser = if (actionsDisabled) noop else onClickOpenInBrowser,
+                                onClickCopyLink = if (actionsDisabled) noop else onClickCopyLink,
+                                onClickCopyLinkText = if (actionsDisabled) noop else onClickCopyLinkText,
+                                onClickShareLink = if (actionsDisabled) noopShare else onClickShareLink,
+                                onClickOpenInBrowserFromMenu = if (actionsDisabled) noop else onClickOpenInBrowserFromMenu,
+                                onClickCopyImage = if (actionsDisabled) noop else onClickCopyImage,
+                                onClickDownloadLink = if (actionsDisabled) noop2s else onClickDownloadLink,
+                                onClickDownloadImage = if (actionsDisabled) noop else onClickDownloadImage,
+                                onClickShareImage = if (actionsDisabled) noop else onClickShareImage,
+                                isSelectionMode = selectionModeForCard,
+                                isSelected = isSelected,
+                                onToggleSelection = onToggleBookmarkSelection,
                                 isInGrid = true,
                                 index = index + 1,
                             )
                             LayoutMode.COMPACT -> BookmarkCompactCard(
                                 bookmark = bookmark,
-                                onClickCard = if (isPendingDeletion) confirmDelete else onClickBookmark,
-                                onClickDelete = if (isPendingDeletion) noop else onClickDelete,
-                                onClickArchive = if (isPendingDeletion) noop2 else onClickArchive,
-                                onClickFavorite = if (isPendingDeletion) noop2 else onClickFavorite,
-                                onClickLabel = if (isPendingDeletion) noop else onClickLabel,
-                                onClickOpenUrl = if (isPendingDeletion) noop else onClickOpenUrl,
-                                onClickOpenInBrowser = if (isPendingDeletion) noop else onClickOpenInBrowser,
-                                onClickCopyLink = if (isPendingDeletion) noop else onClickCopyLink,
-                                onClickCopyLinkText = if (isPendingDeletion) noop else onClickCopyLinkText,
-                                onClickShareLink = if (isPendingDeletion) noopShare else onClickShareLink,
-                                onClickOpenInBrowserFromMenu = if (isPendingDeletion) noop else onClickOpenInBrowserFromMenu,
-                                onClickCopyImage = if (isPendingDeletion) noop else onClickCopyImage,
-                                onClickDownloadLink = if (isPendingDeletion) noop2s else onClickDownloadLink,
-                                onClickDownloadImage = if (isPendingDeletion) noop else onClickDownloadImage,
-                                onClickShareImage = if (isPendingDeletion) noop else onClickShareImage,
+                                onClickCard = cardClick,
+                                onClickDelete = if (actionsDisabled) noop else onClickDelete,
+                                onClickArchive = if (actionsDisabled) noop2 else onClickArchive,
+                                onClickFavorite = if (actionsDisabled) noop2 else onClickFavorite,
+                                onClickLabel = if (actionsDisabled) noop else onClickLabel,
+                                onClickOpenUrl = if (actionsDisabled) noop else onClickOpenUrl,
+                                onClickOpenInBrowser = if (actionsDisabled) noop else onClickOpenInBrowser,
+                                onClickCopyLink = if (actionsDisabled) noop else onClickCopyLink,
+                                onClickCopyLinkText = if (actionsDisabled) noop else onClickCopyLinkText,
+                                onClickShareLink = if (actionsDisabled) noopShare else onClickShareLink,
+                                onClickOpenInBrowserFromMenu = if (actionsDisabled) noop else onClickOpenInBrowserFromMenu,
+                                onClickCopyImage = if (actionsDisabled) noop else onClickCopyImage,
+                                onClickDownloadLink = if (actionsDisabled) noop2s else onClickDownloadLink,
+                                onClickDownloadImage = if (actionsDisabled) noop else onClickDownloadImage,
+                                onClickShareImage = if (actionsDisabled) noop else onClickShareImage,
+                                isSelectionMode = selectionModeForCard,
+                                isSelected = isSelected,
+                                onToggleSelection = onToggleBookmarkSelection,
                                 index = index + 1,
                             )
                             LayoutMode.MOSAIC -> BookmarkMosaicCard(
                                 bookmark = bookmark,
-                                onClickCard = if (isPendingDeletion) confirmDelete else onClickBookmark,
-                                onClickDelete = if (isPendingDeletion) noop else onClickDelete,
-                                onClickArchive = if (isPendingDeletion) noop2 else onClickArchive,
-                                onClickFavorite = if (isPendingDeletion) noop2 else onClickFavorite,
-                                onClickLabel = if (isPendingDeletion) noop else onClickLabel,
-                                onClickOpenUrl = if (isPendingDeletion) noop else onClickOpenUrl,
-                                onClickOpenInBrowser = if (isPendingDeletion) noop else onClickOpenInBrowser,
-                                onClickCopyLink = if (isPendingDeletion) noop else onClickCopyLink,
-                                onClickCopyLinkText = if (isPendingDeletion) noop else onClickCopyLinkText,
-                                onClickShareLink = if (isPendingDeletion) noopShare else onClickShareLink,
-                                onClickOpenInBrowserFromMenu = if (isPendingDeletion) noop else onClickOpenInBrowserFromMenu,
-                                onClickCopyImage = if (isPendingDeletion) noop else onClickCopyImage,
-                                onClickDownloadLink = if (isPendingDeletion) noop2s else onClickDownloadLink,
-                                onClickDownloadImage = if (isPendingDeletion) noop else onClickDownloadImage,
-                                onClickShareImage = if (isPendingDeletion) noop else onClickShareImage,
+                                onClickCard = cardClick,
+                                onClickDelete = if (actionsDisabled) noop else onClickDelete,
+                                onClickArchive = if (actionsDisabled) noop2 else onClickArchive,
+                                onClickFavorite = if (actionsDisabled) noop2 else onClickFavorite,
+                                onClickLabel = if (actionsDisabled) noop else onClickLabel,
+                                onClickOpenUrl = if (actionsDisabled) noop else onClickOpenUrl,
+                                onClickOpenInBrowser = if (actionsDisabled) noop else onClickOpenInBrowser,
+                                onClickCopyLink = if (actionsDisabled) noop else onClickCopyLink,
+                                onClickCopyLinkText = if (actionsDisabled) noop else onClickCopyLinkText,
+                                onClickShareLink = if (actionsDisabled) noopShare else onClickShareLink,
+                                onClickOpenInBrowserFromMenu = if (actionsDisabled) noop else onClickOpenInBrowserFromMenu,
+                                onClickCopyImage = if (actionsDisabled) noop else onClickCopyImage,
+                                onClickDownloadLink = if (actionsDisabled) noop2s else onClickDownloadLink,
+                                onClickDownloadImage = if (actionsDisabled) noop else onClickDownloadImage,
+                                onClickShareImage = if (actionsDisabled) noop else onClickShareImage,
+                                isSelectionMode = selectionModeForCard,
+                                isSelected = isSelected,
+                                onToggleSelection = onToggleBookmarkSelection,
                                 index = index + 1,
                             )
                         }
@@ -1181,10 +1278,19 @@ fun BookmarkListView(
                     val noop2: (String, Boolean) -> Unit = { _, _ -> }
                     val noop2s: (String, String) -> Unit = { _, _ -> }
                     val noopShare: (String, String) -> Unit = { _, _ -> }
+                    val isSelected = bookmark.id in selectedBookmarkIds
+                    val selectionModeForCard = isMultiSelectMode && !isPendingDeletion
+                    val selectBookmark: (String) -> Unit = { onToggleBookmarkSelection(it) }
+                    val cardClick = when {
+                        isPendingDeletion -> confirmDelete
+                        selectionModeForCard -> selectBookmark
+                        else -> onClickBookmark
+                    }
+                    val actionsDisabled = isPendingDeletion || selectionModeForCard
                     SwipeWrappedBookmark(
                         bookmark = bookmark,
                         isPendingDeletion = isPendingDeletion,
-                        swipeConfig = swipeConfig,
+                        swipeConfig = if (isMultiSelectMode) swipeConfig.copy(enabled = false) else swipeConfig,
                         onClickArchive = onClickArchive,
                         onClickDelete = onClickDelete,
                         onClickFavorite = onClickFavorite,
@@ -1194,60 +1300,69 @@ fun BookmarkListView(
                         when (layoutMode) {
                             LayoutMode.GRID -> BookmarkGridCard(
                                 bookmark = bookmark,
-                                onClickCard = if (isPendingDeletion) confirmDelete else onClickBookmark,
-                                onClickDelete = if (isPendingDeletion) noop else onClickDelete,
-                                onClickArchive = if (isPendingDeletion) noop2 else onClickArchive,
-                                onClickFavorite = if (isPendingDeletion) noop2 else onClickFavorite,
-                                onClickLabel = if (isPendingDeletion) noop else onClickLabel,
-                                onClickOpenUrl = if (isPendingDeletion) noop else onClickOpenUrl,
-                                onClickOpenInBrowser = if (isPendingDeletion) noop else onClickOpenInBrowser,
-                                onClickCopyLink = if (isPendingDeletion) noop else onClickCopyLink,
-                                onClickCopyLinkText = if (isPendingDeletion) noop else onClickCopyLinkText,
-                                onClickShareLink = if (isPendingDeletion) noopShare else onClickShareLink,
-                                onClickOpenInBrowserFromMenu = if (isPendingDeletion) noop else onClickOpenInBrowserFromMenu,
-                                onClickCopyImage = if (isPendingDeletion) noop else onClickCopyImage,
-                                onClickDownloadLink = if (isPendingDeletion) noop2s else onClickDownloadLink,
-                                onClickDownloadImage = if (isPendingDeletion) noop else onClickDownloadImage,
-                                onClickShareImage = if (isPendingDeletion) noop else onClickShareImage,
+                                onClickCard = cardClick,
+                                onClickDelete = if (actionsDisabled) noop else onClickDelete,
+                                onClickArchive = if (actionsDisabled) noop2 else onClickArchive,
+                                onClickFavorite = if (actionsDisabled) noop2 else onClickFavorite,
+                                onClickLabel = if (actionsDisabled) noop else onClickLabel,
+                                onClickOpenUrl = if (actionsDisabled) noop else onClickOpenUrl,
+                                onClickOpenInBrowser = if (actionsDisabled) noop else onClickOpenInBrowser,
+                                onClickCopyLink = if (actionsDisabled) noop else onClickCopyLink,
+                                onClickCopyLinkText = if (actionsDisabled) noop else onClickCopyLinkText,
+                                onClickShareLink = if (actionsDisabled) noopShare else onClickShareLink,
+                                onClickOpenInBrowserFromMenu = if (actionsDisabled) noop else onClickOpenInBrowserFromMenu,
+                                onClickCopyImage = if (actionsDisabled) noop else onClickCopyImage,
+                                onClickDownloadLink = if (actionsDisabled) noop2s else onClickDownloadLink,
+                                onClickDownloadImage = if (actionsDisabled) noop else onClickDownloadImage,
+                                onClickShareImage = if (actionsDisabled) noop else onClickShareImage,
+                                isSelectionMode = selectionModeForCard,
+                                isSelected = isSelected,
+                                onToggleSelection = onToggleBookmarkSelection,
                                 useMobilePortraitLayout = useMobilePortraitGridLayout,
                                 index = index + 1,
                             )
                             LayoutMode.COMPACT -> BookmarkCompactCard(
                                 bookmark = bookmark,
-                                onClickCard = if (isPendingDeletion) confirmDelete else onClickBookmark,
-                                onClickDelete = if (isPendingDeletion) noop else onClickDelete,
-                                onClickArchive = if (isPendingDeletion) noop2 else onClickArchive,
-                                onClickFavorite = if (isPendingDeletion) noop2 else onClickFavorite,
-                                onClickLabel = if (isPendingDeletion) noop else onClickLabel,
-                                onClickOpenUrl = if (isPendingDeletion) noop else onClickOpenUrl,
-                                onClickOpenInBrowser = if (isPendingDeletion) noop else onClickOpenInBrowser,
-                                onClickCopyLink = if (isPendingDeletion) noop else onClickCopyLink,
-                                onClickCopyLinkText = if (isPendingDeletion) noop else onClickCopyLinkText,
-                                onClickShareLink = if (isPendingDeletion) noopShare else onClickShareLink,
-                                onClickOpenInBrowserFromMenu = if (isPendingDeletion) noop else onClickOpenInBrowserFromMenu,
-                                onClickCopyImage = if (isPendingDeletion) noop else onClickCopyImage,
-                                onClickDownloadLink = if (isPendingDeletion) noop2s else onClickDownloadLink,
-                                onClickDownloadImage = if (isPendingDeletion) noop else onClickDownloadImage,
-                                onClickShareImage = if (isPendingDeletion) noop else onClickShareImage,
+                                onClickCard = cardClick,
+                                onClickDelete = if (actionsDisabled) noop else onClickDelete,
+                                onClickArchive = if (actionsDisabled) noop2 else onClickArchive,
+                                onClickFavorite = if (actionsDisabled) noop2 else onClickFavorite,
+                                onClickLabel = if (actionsDisabled) noop else onClickLabel,
+                                onClickOpenUrl = if (actionsDisabled) noop else onClickOpenUrl,
+                                onClickOpenInBrowser = if (actionsDisabled) noop else onClickOpenInBrowser,
+                                onClickCopyLink = if (actionsDisabled) noop else onClickCopyLink,
+                                onClickCopyLinkText = if (actionsDisabled) noop else onClickCopyLinkText,
+                                onClickShareLink = if (actionsDisabled) noopShare else onClickShareLink,
+                                onClickOpenInBrowserFromMenu = if (actionsDisabled) noop else onClickOpenInBrowserFromMenu,
+                                onClickCopyImage = if (actionsDisabled) noop else onClickCopyImage,
+                                onClickDownloadLink = if (actionsDisabled) noop2s else onClickDownloadLink,
+                                onClickDownloadImage = if (actionsDisabled) noop else onClickDownloadImage,
+                                onClickShareImage = if (actionsDisabled) noop else onClickShareImage,
+                                isSelectionMode = selectionModeForCard,
+                                isSelected = isSelected,
+                                onToggleSelection = onToggleBookmarkSelection,
                                 index = index + 1,
                             )
                             LayoutMode.MOSAIC -> BookmarkMosaicCard(
                                 bookmark = bookmark,
-                                onClickCard = if (isPendingDeletion) confirmDelete else onClickBookmark,
-                                onClickDelete = if (isPendingDeletion) noop else onClickDelete,
-                                onClickArchive = if (isPendingDeletion) noop2 else onClickArchive,
-                                onClickFavorite = if (isPendingDeletion) noop2 else onClickFavorite,
-                                onClickLabel = if (isPendingDeletion) noop else onClickLabel,
-                                onClickOpenUrl = if (isPendingDeletion) noop else onClickOpenUrl,
-                                onClickOpenInBrowser = if (isPendingDeletion) noop else onClickOpenInBrowser,
-                                onClickCopyLink = if (isPendingDeletion) noop else onClickCopyLink,
-                                onClickCopyLinkText = if (isPendingDeletion) noop else onClickCopyLinkText,
-                                onClickShareLink = if (isPendingDeletion) noopShare else onClickShareLink,
-                                onClickOpenInBrowserFromMenu = if (isPendingDeletion) noop else onClickOpenInBrowserFromMenu,
-                                onClickCopyImage = if (isPendingDeletion) noop else onClickCopyImage,
-                                onClickDownloadLink = if (isPendingDeletion) noop2s else onClickDownloadLink,
-                                onClickDownloadImage = if (isPendingDeletion) noop else onClickDownloadImage,
-                                onClickShareImage = if (isPendingDeletion) noop else onClickShareImage,
+                                onClickCard = cardClick,
+                                onClickDelete = if (actionsDisabled) noop else onClickDelete,
+                                onClickArchive = if (actionsDisabled) noop2 else onClickArchive,
+                                onClickFavorite = if (actionsDisabled) noop2 else onClickFavorite,
+                                onClickLabel = if (actionsDisabled) noop else onClickLabel,
+                                onClickOpenUrl = if (actionsDisabled) noop else onClickOpenUrl,
+                                onClickOpenInBrowser = if (actionsDisabled) noop else onClickOpenInBrowser,
+                                onClickCopyLink = if (actionsDisabled) noop else onClickCopyLink,
+                                onClickCopyLinkText = if (actionsDisabled) noop else onClickCopyLinkText,
+                                onClickShareLink = if (actionsDisabled) noopShare else onClickShareLink,
+                                onClickOpenInBrowserFromMenu = if (actionsDisabled) noop else onClickOpenInBrowserFromMenu,
+                                onClickCopyImage = if (actionsDisabled) noop else onClickCopyImage,
+                                onClickDownloadLink = if (actionsDisabled) noop2s else onClickDownloadLink,
+                                onClickDownloadImage = if (actionsDisabled) noop else onClickDownloadImage,
+                                onClickShareImage = if (actionsDisabled) noop else onClickShareImage,
+                                isSelectionMode = selectionModeForCard,
+                                isSelected = isSelected,
+                                onToggleSelection = onToggleBookmarkSelection,
                                 index = index + 1,
                             )
                         }

--- a/app/src/main/java/com/mydeck/app/ui/list/BookmarkListViewModel.kt
+++ b/app/src/main/java/com/mydeck/app/ui/list/BookmarkListViewModel.kt
@@ -11,6 +11,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import com.mydeck.app.BuildConfig
 import com.mydeck.app.R
+import com.mydeck.app.domain.BookmarkBatchUpdate
 import com.mydeck.app.domain.BookmarkRepository
 import com.mydeck.app.domain.model.Bookmark
 import com.mydeck.app.domain.model.BookmarkCounts
@@ -52,6 +53,21 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.delay
 import timber.log.Timber
 import javax.inject.Inject
+
+data class MultiSelectState(
+    val active: Boolean = false,
+    val selectedIds: Set<String> = emptySet()
+) {
+    val selectedCount: Int get() = selectedIds.size
+    val hasSelection: Boolean get() = selectedIds.isNotEmpty()
+    fun isSelected(bookmarkId: String): Boolean = bookmarkId in selectedIds
+}
+
+private data class SelectedBookmarkActionState(
+    val id: String,
+    val isMarked: Boolean,
+    val isArchived: Boolean
+)
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
@@ -100,6 +116,9 @@ class BookmarkListViewModel @Inject constructor(
     // Pending deletion IDs tracked per staged snackbar so rapid deletes keep item identity.
     private val _pendingDeletionBookmarkIds = MutableStateFlow<List<String>>(emptyList())
     val pendingDeletionBookmarkIds = _pendingDeletionBookmarkIds.asStateFlow()
+
+    private val _multiSelectState = MutableStateFlow(MultiSelectState())
+    val multiSelectState = _multiSelectState.asStateFlow()
 
     // Constraint feedback: one-shot snackbar message when content sync is blocked
     private val _constraintSnackbarEvent = Channel<Int>(Channel.BUFFERED)
@@ -290,6 +309,7 @@ class BookmarkListViewModel @Inject constructor(
             }.combine(loadBookmarksHasFailed) { (visibleBookmarks, initialSyncPerformed), hasLoadFailed ->
                 Triple(visibleBookmarks, initialSyncPerformed, hasLoadFailed)
             }.collectLatest { (visibleBookmarks, initialSyncPerformed, hasLoadFailed) ->
+                dropSelectedIdsMissingFrom(visibleBookmarks)
                 _uiState.update { currentState ->
                     val updateBookmarkState = (currentState as? UiState.Success)?.updateBookmarkState
                     when {
@@ -310,6 +330,7 @@ class BookmarkListViewModel @Inject constructor(
     // --- Drawer preset navigation ---
 
     fun onSelectDrawerPreset(preset: DrawerPreset) {
+        clearMultiSelectState()
         _drawerPreset.value = preset
         _filterFormState.value = FilterFormState.fromPreset(preset)
         _activeLabel.value = null
@@ -325,6 +346,7 @@ class BookmarkListViewModel @Inject constructor(
     // --- Label mode ---
 
     fun onClickLabel(label: String) {
+        clearMultiSelectState()
         if (_activeLabel.value == label) {
             // Toggle off label mode, return to previous drawer preset
             _activeLabel.value = null
@@ -381,11 +403,13 @@ class BookmarkListViewModel @Inject constructor(
     }
 
     fun onApplyFilter(filterFormState: FilterFormState) {
+        clearMultiSelectState()
         _filterFormState.value = filterFormState
         _isFilterSheetOpen.value = false
     }
 
     fun onResetFilter() {
+        clearMultiSelectState()
         _filterFormState.value = FilterFormState.fromPreset(_drawerPreset.value)
         _isFilterSheetOpen.value = false
     }
@@ -584,6 +608,95 @@ class BookmarkListViewModel @Inject constructor(
                 bookmarkId = bookmarkId,
                 isArchived = isArchived
             )
+        }
+    }
+
+    fun onEnterMultiSelectMode() {
+        _multiSelectState.value = MultiSelectState(active = true)
+    }
+
+    fun onExitMultiSelectMode() {
+        clearMultiSelectState()
+    }
+
+    fun onToggleBookmarkSelected(bookmarkId: String) {
+        _multiSelectState.update { state ->
+            if (!state.active) {
+                state
+            } else {
+                val selectedIds = if (bookmarkId in state.selectedIds) {
+                    state.selectedIds - bookmarkId
+                } else {
+                    state.selectedIds + bookmarkId
+                }
+                state.copy(selectedIds = selectedIds)
+            }
+        }
+    }
+
+    fun onFavoriteSelectedBookmarks() {
+        val snapshots = selectedBookmarkActionSnapshots()
+        if (snapshots.isEmpty()) return
+
+        clearMultiSelectState()
+        updateBookmark {
+            updateBookmarkUseCase.updateBookmarks(
+                snapshots.map { snapshot ->
+                    BookmarkBatchUpdate(
+                        bookmarkId = snapshot.id,
+                        isFavorite = !snapshot.isMarked
+                    )
+                }
+            )
+        }
+    }
+
+    fun onArchiveSelectedBookmarks() {
+        val snapshots = selectedBookmarkActionSnapshots()
+        if (snapshots.isEmpty()) return
+
+        clearMultiSelectState()
+        updateBookmark {
+            updateBookmarkUseCase.updateBookmarks(
+                snapshots.map { snapshot ->
+                    BookmarkBatchUpdate(
+                        bookmarkId = snapshot.id,
+                        isArchived = !snapshot.isArchived
+                    )
+                }
+            )
+        }
+    }
+
+    private fun selectedBookmarkActionSnapshots(): List<SelectedBookmarkActionState> {
+        val selectedIds = _multiSelectState.value.selectedIds
+        if (selectedIds.isEmpty()) return emptyList()
+
+        val bookmarks = (_uiState.value as? UiState.Success)?.bookmarks.orEmpty()
+        return bookmarks
+            .asSequence()
+            .filter { it.id in selectedIds }
+            .map {
+                SelectedBookmarkActionState(
+                    id = it.id,
+                    isMarked = it.isMarked,
+                    isArchived = it.isArchived
+                )
+            }
+            .toList()
+    }
+
+    private fun clearMultiSelectState() {
+        _multiSelectState.value = MultiSelectState()
+    }
+
+    private fun dropSelectedIdsMissingFrom(visibleBookmarks: List<BookmarkListItem>) {
+        if (!_multiSelectState.value.active) return
+
+        val visibleIds = visibleBookmarks.mapTo(mutableSetOf()) { it.id }
+        _multiSelectState.update { state ->
+            val retainedIds = state.selectedIds.intersect(visibleIds)
+            if (retainedIds == state.selectedIds) state else state.copy(selectedIds = retainedIds)
         }
     }
 

--- a/app/src/main/java/com/mydeck/app/ui/list/BookmarkListViewModel.kt
+++ b/app/src/main/java/com/mydeck/app/ui/list/BookmarkListViewModel.kt
@@ -762,7 +762,6 @@ class BookmarkListViewModel @Inject constructor(
 
         val selectedCount = snapshots.size
         val itemsToUpdate = snapshots.filter { it.isMarked != targetFavorite }
-        clearMultiSelectState()
 
         if (itemsToUpdate.isNotEmpty()) {
             updateBookmark {
@@ -791,7 +790,6 @@ class BookmarkListViewModel @Inject constructor(
 
         val selectedCount = snapshots.size
         val itemsToUpdate = snapshots.filter { it.isArchived != targetArchived }
-        clearMultiSelectState()
 
         if (itemsToUpdate.isNotEmpty()) {
             updateBookmark {
@@ -858,7 +856,11 @@ class BookmarkListViewModel @Inject constructor(
         val visibleIds = visibleBookmarks.mapTo(mutableSetOf()) { it.id }
         _multiSelectState.update { state ->
             val retainedIds = state.selectedIds.intersect(visibleIds)
-            if (retainedIds == state.selectedIds) state else state.copy(selectedIds = retainedIds)
+            when {
+                retainedIds == state.selectedIds -> state
+                retainedIds.isEmpty() -> MultiSelectState()
+                else -> state.copy(selectedIds = retainedIds)
+            }
         }
     }
 

--- a/app/src/main/java/com/mydeck/app/ui/list/BookmarkListViewModel.kt
+++ b/app/src/main/java/com/mydeck/app/ui/list/BookmarkListViewModel.kt
@@ -73,10 +73,16 @@ data class MultiSelectTargets(
 
 sealed class BatchActionSnackbarEvent {
     abstract val count: Int
-    data class FavoritesAdded(override val count: Int) : BatchActionSnackbarEvent()
-    data class FavoritesRemoved(override val count: Int) : BatchActionSnackbarEvent()
-    data class Archived(override val count: Int) : BatchActionSnackbarEvent()
-    data class Unarchived(override val count: Int) : BatchActionSnackbarEvent()
+
+    // Favorite/archive events carry the ids actually changed (skip-no-op filtered out) so
+    // Undo can revert exactly those items back to their prior state in a single transaction.
+    data class FavoritesAdded(override val count: Int, val changedIds: List<String>) : BatchActionSnackbarEvent()
+    data class FavoritesRemoved(override val count: Int, val changedIds: List<String>) : BatchActionSnackbarEvent()
+    data class Archived(override val count: Int, val changedIds: List<String>) : BatchActionSnackbarEvent()
+    data class Unarchived(override val count: Int, val changedIds: List<String>) : BatchActionSnackbarEvent()
+
+    // Delete is staged (not yet written); confirm/cancel act on the batch-pending set held in the ViewModel.
+    data class Deleted(override val count: Int) : BatchActionSnackbarEvent()
 }
 
 private data class SelectedBookmarkActionState(
@@ -132,6 +138,11 @@ class BookmarkListViewModel @Inject constructor(
     // Pending deletion IDs tracked per staged snackbar so rapid deletes keep item identity.
     private val _pendingDeletionBookmarkIds = MutableStateFlow<List<String>>(emptyList())
     val pendingDeletionBookmarkIds = _pendingDeletionBookmarkIds.asStateFlow()
+
+    // Batch (multi-select) pending deletion kept separate from single-item pending deletion so the
+    // batch confirms/cancels atomically and Undo restores exactly the staged batch set.
+    private val _pendingBatchDeletionBookmarkIds = MutableStateFlow<Set<String>>(emptySet())
+    val pendingBatchDeletionBookmarkIds = _pendingBatchDeletionBookmarkIds.asStateFlow()
 
     private val _multiSelectState = MutableStateFlow(MultiSelectState())
     val multiSelectState = _multiSelectState.asStateFlow()
@@ -680,6 +691,71 @@ class BookmarkListViewModel @Inject constructor(
 
     fun onUnarchiveSelectedBookmarks() = applyBatchArchive(targetArchived = false)
 
+    // Stage all selected bookmarks as batch-pending-delete: grey them out, leave selection mode, and
+    // emit a Snackbar. No DB write happens here — it is deferred until the Snackbar is confirmed.
+    fun onDeleteSelectedBookmarks() {
+        val selectedIds = _multiSelectState.value.selectedIds
+        if (selectedIds.isEmpty()) return
+
+        val staged = selectedIds.toSet()
+        _pendingBatchDeletionBookmarkIds.value = staged
+        clearMultiSelectState()
+        _batchActionSnackbarEvent.trySend(BatchActionSnackbarEvent.Deleted(staged.size))
+    }
+
+    // Confirm path (Snackbar dismissed/timed out/interaction elsewhere): soft-delete the staged batch
+    // locally and enqueue delete pending actions for sync, in one transaction.
+    fun onConfirmBatchDeletion() {
+        val ids = _pendingBatchDeletionBookmarkIds.value
+        if (ids.isEmpty()) return
+
+        _pendingBatchDeletionBookmarkIds.value = emptySet()
+        updateBookmark {
+            updateBookmarkUseCase.deleteBookmarks(ids.toList())
+        }
+    }
+
+    // Undo path: restore the staged batch from pending-delete UI state without enqueuing any deletes.
+    fun onCancelBatchDeletion() {
+        _pendingBatchDeletionBookmarkIds.value = emptySet()
+    }
+
+    // Snackbar Undo for every batch action. Favorite/archive were applied optimistically, so Undo
+    // reverts only the items actually changed; delete was merely staged, so Undo cancels the stage.
+    fun onUndoBatchAction(event: BatchActionSnackbarEvent) {
+        when (event) {
+            is BatchActionSnackbarEvent.FavoritesAdded -> revertBatchFavorite(event.changedIds, revertTo = false)
+            is BatchActionSnackbarEvent.FavoritesRemoved -> revertBatchFavorite(event.changedIds, revertTo = true)
+            is BatchActionSnackbarEvent.Archived -> revertBatchArchive(event.changedIds, revertTo = false)
+            is BatchActionSnackbarEvent.Unarchived -> revertBatchArchive(event.changedIds, revertTo = true)
+            is BatchActionSnackbarEvent.Deleted -> onCancelBatchDeletion()
+        }
+    }
+
+    // Snackbar dismissal for every batch action. Only delete has deferred work to commit on dismiss;
+    // favorite/archive are already applied, so dismissing is a no-op for them.
+    fun onConfirmBatchAction(event: BatchActionSnackbarEvent) {
+        if (event is BatchActionSnackbarEvent.Deleted) onConfirmBatchDeletion()
+    }
+
+    private fun revertBatchFavorite(changedIds: List<String>, revertTo: Boolean) {
+        if (changedIds.isEmpty()) return
+        updateBookmark {
+            updateBookmarkUseCase.updateBookmarks(
+                changedIds.map { BookmarkBatchUpdate(bookmarkId = it, isFavorite = revertTo) }
+            )
+        }
+    }
+
+    private fun revertBatchArchive(changedIds: List<String>, revertTo: Boolean) {
+        if (changedIds.isEmpty()) return
+        updateBookmark {
+            updateBookmarkUseCase.updateBookmarks(
+                changedIds.map { BookmarkBatchUpdate(bookmarkId = it, isArchived = revertTo) }
+            )
+        }
+    }
+
     private fun applyBatchFavorite(targetFavorite: Boolean) {
         val snapshots = selectedBookmarkActionSnapshots()
         if (snapshots.isEmpty()) return
@@ -700,10 +776,11 @@ class BookmarkListViewModel @Inject constructor(
                 )
             }
         }
+        val changedIds = itemsToUpdate.map { it.id }
         val event = if (targetFavorite) {
-            BatchActionSnackbarEvent.FavoritesAdded(selectedCount)
+            BatchActionSnackbarEvent.FavoritesAdded(selectedCount, changedIds)
         } else {
-            BatchActionSnackbarEvent.FavoritesRemoved(selectedCount)
+            BatchActionSnackbarEvent.FavoritesRemoved(selectedCount, changedIds)
         }
         _batchActionSnackbarEvent.trySend(event)
     }
@@ -728,10 +805,11 @@ class BookmarkListViewModel @Inject constructor(
                 )
             }
         }
+        val changedIds = itemsToUpdate.map { it.id }
         val event = if (targetArchived) {
-            BatchActionSnackbarEvent.Archived(selectedCount)
+            BatchActionSnackbarEvent.Archived(selectedCount, changedIds)
         } else {
-            BatchActionSnackbarEvent.Unarchived(selectedCount)
+            BatchActionSnackbarEvent.Unarchived(selectedCount, changedIds)
         }
         _batchActionSnackbarEvent.trySend(event)
     }

--- a/app/src/main/java/com/mydeck/app/ui/list/BookmarkListViewModel.kt
+++ b/app/src/main/java/com/mydeck/app/ui/list/BookmarkListViewModel.kt
@@ -63,6 +63,22 @@ data class MultiSelectState(
     fun isSelected(bookmarkId: String): Boolean = bookmarkId in selectedIds
 }
 
+data class MultiSelectTargets(
+    val allVisibleSelected: Boolean = false,
+    val selectedAllFavorited: Boolean = false,
+    val selectedAllUnfavorited: Boolean = false,
+    val selectedAllArchived: Boolean = false,
+    val selectedAllUnarchived: Boolean = false
+)
+
+sealed class BatchActionSnackbarEvent {
+    abstract val count: Int
+    data class FavoritesAdded(override val count: Int) : BatchActionSnackbarEvent()
+    data class FavoritesRemoved(override val count: Int) : BatchActionSnackbarEvent()
+    data class Archived(override val count: Int) : BatchActionSnackbarEvent()
+    data class Unarchived(override val count: Int) : BatchActionSnackbarEvent()
+}
+
 private data class SelectedBookmarkActionState(
     val id: String,
     val isMarked: Boolean,
@@ -246,6 +262,28 @@ class BookmarkListViewModel @Inject constructor(
 
     private val _uiState = MutableStateFlow<UiState>(UiState.Loading)
     val uiState = _uiState.asStateFlow()
+
+    val multiSelectTargets: StateFlow<MultiSelectTargets> = combine(
+        _multiSelectState,
+        _uiState
+    ) { selection, ui ->
+        val bookmarks = (ui as? UiState.Success)?.bookmarks.orEmpty()
+        val allVisibleSelected = bookmarks.isNotEmpty() &&
+            bookmarks.all { it.id in selection.selectedIds }
+        val selectedItems = bookmarks.filter { it.id in selection.selectedIds }
+        val hasSelection = selectedItems.isNotEmpty()
+        MultiSelectTargets(
+            allVisibleSelected = allVisibleSelected,
+            selectedAllFavorited = hasSelection && selectedItems.all { it.isMarked },
+            selectedAllUnfavorited = hasSelection && selectedItems.none { it.isMarked },
+            selectedAllArchived = hasSelection && selectedItems.all { it.isArchived },
+            selectedAllUnarchived = hasSelection && selectedItems.none { it.isArchived }
+        )
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, MultiSelectTargets())
+
+    private val _batchActionSnackbarEvent = Channel<BatchActionSnackbarEvent>(Channel.BUFFERED)
+    val batchActionSnackbarEvent: Flow<BatchActionSnackbarEvent> =
+        _batchActionSnackbarEvent.receiveAsFlow()
 
     init {
         viewModelScope.launch {
@@ -634,37 +672,83 @@ class BookmarkListViewModel @Inject constructor(
         }
     }
 
-    fun onFavoriteSelectedBookmarks() {
+    fun onFavoriteSelectedBookmarks() = applyBatchFavorite(targetFavorite = true)
+
+    fun onUnfavoriteSelectedBookmarks() = applyBatchFavorite(targetFavorite = false)
+
+    fun onArchiveSelectedBookmarks() = applyBatchArchive(targetArchived = true)
+
+    fun onUnarchiveSelectedBookmarks() = applyBatchArchive(targetArchived = false)
+
+    private fun applyBatchFavorite(targetFavorite: Boolean) {
         val snapshots = selectedBookmarkActionSnapshots()
         if (snapshots.isEmpty()) return
 
+        val selectedCount = snapshots.size
+        val itemsToUpdate = snapshots.filter { it.isMarked != targetFavorite }
         clearMultiSelectState()
-        updateBookmark {
-            updateBookmarkUseCase.updateBookmarks(
-                snapshots.map { snapshot ->
-                    BookmarkBatchUpdate(
-                        bookmarkId = snapshot.id,
-                        isFavorite = !snapshot.isMarked
-                    )
-                }
-            )
+
+        if (itemsToUpdate.isNotEmpty()) {
+            updateBookmark {
+                updateBookmarkUseCase.updateBookmarks(
+                    itemsToUpdate.map { snapshot ->
+                        BookmarkBatchUpdate(
+                            bookmarkId = snapshot.id,
+                            isFavorite = targetFavorite
+                        )
+                    }
+                )
+            }
         }
+        val event = if (targetFavorite) {
+            BatchActionSnackbarEvent.FavoritesAdded(selectedCount)
+        } else {
+            BatchActionSnackbarEvent.FavoritesRemoved(selectedCount)
+        }
+        _batchActionSnackbarEvent.trySend(event)
     }
 
-    fun onArchiveSelectedBookmarks() {
+    private fun applyBatchArchive(targetArchived: Boolean) {
         val snapshots = selectedBookmarkActionSnapshots()
         if (snapshots.isEmpty()) return
 
+        val selectedCount = snapshots.size
+        val itemsToUpdate = snapshots.filter { it.isArchived != targetArchived }
         clearMultiSelectState()
-        updateBookmark {
-            updateBookmarkUseCase.updateBookmarks(
-                snapshots.map { snapshot ->
-                    BookmarkBatchUpdate(
-                        bookmarkId = snapshot.id,
-                        isArchived = !snapshot.isArchived
-                    )
-                }
-            )
+
+        if (itemsToUpdate.isNotEmpty()) {
+            updateBookmark {
+                updateBookmarkUseCase.updateBookmarks(
+                    itemsToUpdate.map { snapshot ->
+                        BookmarkBatchUpdate(
+                            bookmarkId = snapshot.id,
+                            isArchived = targetArchived
+                        )
+                    }
+                )
+            }
+        }
+        val event = if (targetArchived) {
+            BatchActionSnackbarEvent.Archived(selectedCount)
+        } else {
+            BatchActionSnackbarEvent.Unarchived(selectedCount)
+        }
+        _batchActionSnackbarEvent.trySend(event)
+    }
+
+    fun onToggleSelectAllBookmarks() {
+        val visibleIds = (_uiState.value as? UiState.Success)
+            ?.bookmarks
+            ?.mapTo(linkedSetOf<String>()) { it.id }
+            ?: linkedSetOf()
+        _multiSelectState.update { state ->
+            if (!state.active) {
+                state
+            } else if (visibleIds.isNotEmpty() && state.selectedIds == visibleIds) {
+                state.copy(selectedIds = emptySet())
+            } else {
+                state.copy(selectedIds = visibleIds)
+            }
         }
     }
 

--- a/app/src/main/java/com/mydeck/app/ui/list/BookmarkListViewModel.kt
+++ b/app/src/main/java/com/mydeck/app/ui/list/BookmarkListViewModel.kt
@@ -81,6 +81,13 @@ sealed class BatchActionSnackbarEvent {
     data class Archived(override val count: Int, val changedIds: List<String>) : BatchActionSnackbarEvent()
     data class Unarchived(override val count: Int, val changedIds: List<String>) : BatchActionSnackbarEvent()
 
+    // Labels are applied optimistically (like favorite/archive); Undo restores each changed
+    // bookmark's prior label list, so the event carries those snapshots.
+    data class LabelsAdded(
+        override val count: Int,
+        val priorLabelsByBookmark: Map<String, List<String>>
+    ) : BatchActionSnackbarEvent()
+
     // Delete is staged (not yet written); confirm/cancel act on the batch-pending set held in the ViewModel.
     data class Deleted(override val count: Int) : BatchActionSnackbarEvent()
 }
@@ -146,6 +153,14 @@ class BookmarkListViewModel @Inject constructor(
 
     private val _multiSelectState = MutableStateFlow(MultiSelectState())
     val multiSelectState = _multiSelectState.asStateFlow()
+
+    // Add-labels picker: holds the selection captured when the picker opened, so selection-mode
+    // changes while the picker is open do not affect which bookmarks get the labels.
+    private val _addLabelsPickerTargetIds = MutableStateFlow<List<String>>(emptyList())
+    val addLabelsPickerTargetIds = _addLabelsPickerTargetIds.asStateFlow()
+
+    private val _showAddLabelsPicker = MutableStateFlow(false)
+    val showAddLabelsPicker = _showAddLabelsPicker.asStateFlow()
 
     // Constraint feedback: one-shot snackbar message when content sync is blocked
     private val _constraintSnackbarEvent = Channel<Int>(Channel.BUFFERED)
@@ -691,6 +706,34 @@ class BookmarkListViewModel @Inject constructor(
 
     fun onUnarchiveSelectedBookmarks() = applyBatchArchive(targetArchived = false)
 
+    // Capture the current selection and open the add-labels picker. The captured ids drive the
+    // apply, so toggling selection (or auto-exit) while the picker is open has no effect.
+    fun onAddLabelsToSelection() {
+        val selectedIds = _multiSelectState.value.selectedIds
+        if (selectedIds.isEmpty()) return
+        _addLabelsPickerTargetIds.value = selectedIds.toList()
+        _showAddLabelsPicker.value = true
+    }
+
+    fun onDismissAddLabelsPicker() {
+        _showAddLabelsPicker.value = false
+        _addLabelsPickerTargetIds.value = emptyList()
+    }
+
+    fun onLabelsPicked(chosen: Set<String>) {
+        val targetIds = _addLabelsPickerTargetIds.value
+        onDismissAddLabelsPicker()
+        if (chosen.isEmpty() || targetIds.isEmpty()) return
+
+        val selectedCount = targetIds.size
+        viewModelScope.launch {
+            val priorByBookmark = updateBookmarkUseCase.addLabelsToBookmarks(targetIds, chosen.toList())
+            _batchActionSnackbarEvent.trySend(
+                BatchActionSnackbarEvent.LabelsAdded(selectedCount, priorByBookmark)
+            )
+        }
+    }
+
     // Stage all selected bookmarks as batch-pending-delete: grey them out, leave selection mode, and
     // emit a Snackbar. No DB write happens here — it is deferred until the Snackbar is confirmed.
     fun onDeleteSelectedBookmarks() {
@@ -728,6 +771,7 @@ class BookmarkListViewModel @Inject constructor(
             is BatchActionSnackbarEvent.FavoritesRemoved -> revertBatchFavorite(event.changedIds, revertTo = true)
             is BatchActionSnackbarEvent.Archived -> revertBatchArchive(event.changedIds, revertTo = false)
             is BatchActionSnackbarEvent.Unarchived -> revertBatchArchive(event.changedIds, revertTo = true)
+            is BatchActionSnackbarEvent.LabelsAdded -> revertBatchLabels(event.priorLabelsByBookmark)
             is BatchActionSnackbarEvent.Deleted -> onCancelBatchDeletion()
         }
     }
@@ -753,6 +797,13 @@ class BookmarkListViewModel @Inject constructor(
             updateBookmarkUseCase.updateBookmarks(
                 changedIds.map { BookmarkBatchUpdate(bookmarkId = it, isArchived = revertTo) }
             )
+        }
+    }
+
+    private fun revertBatchLabels(priorLabelsByBookmark: Map<String, List<String>>) {
+        if (priorLabelsByBookmark.isEmpty()) return
+        viewModelScope.launch {
+            updateBookmarkUseCase.restoreBookmarkLabels(priorLabelsByBookmark)
         }
     }
 

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -125,6 +125,7 @@ other{}
     <string name="multi_select_set_as_archived">%1$d set as archived</string>
     <string name="multi_select_unset_as_archived">%1$d unset as archived</string>
     <string name="multi_select_deleted_count">%1$d bookmarks deleted</string>
+    <string name="multi_select_labels_added">Labels added to %1$d bookmarks</string>
     <string name="action_add_to_favorites">Add favorite</string>
     <string name="action_remove_from_favorites">Favorit entfernen</string>
     <string name="action_add_to_archive">Archivieren</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -120,22 +120,10 @@ other{}
     <string name="bookmark_state_archived">Archived</string>
     <string name="bookmark_state_not_archived">Not archived</string>
     <string name="selected_bookmark_count">%1$d selected</string>
-    <plurals name="multi_select_set_as_favorite">
-        <item quantity="one">%d set as favorite</item>
-        <item quantity="other">%d set as favorites</item>
-    </plurals>
-    <plurals name="multi_select_unset_as_favorite">
-        <item quantity="one">%d unset as favorite</item>
-        <item quantity="other">%d unset as favorites</item>
-    </plurals>
-    <plurals name="multi_select_set_as_archived">
-        <item quantity="one">%d set as archived</item>
-        <item quantity="other">%d set as archived</item>
-    </plurals>
-    <plurals name="multi_select_unset_as_archived">
-        <item quantity="one">%d unset as archived</item>
-        <item quantity="other">%d unset as archived</item>
-    </plurals>
+    <string name="multi_select_set_as_favorite">%1$d set as favorite</string>
+    <string name="multi_select_unset_as_favorite">%1$d unset as favorite</string>
+    <string name="multi_select_set_as_archived">%1$d set as archived</string>
+    <string name="multi_select_unset_as_archived">%1$d unset as archived</string>
     <string name="action_add_to_favorites">Add favorite</string>
     <string name="action_remove_from_favorites">Favorit entfernen</string>
     <string name="action_add_to_archive">Archivieren</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -113,8 +113,30 @@ other{}
     <string name="action_exit_selection_mode">Exit selection mode</string>
     <string name="action_select_bookmark">Select bookmark</string>
     <string name="action_deselect_bookmark">Deselect bookmark</string>
+    <string name="action_select_all">Select all</string>
+    <string name="action_deselect_all">Deselect all</string>
+    <string name="bookmark_state_favorited">Favorited</string>
+    <string name="bookmark_state_not_favorited">Not favorited</string>
+    <string name="bookmark_state_archived">Archived</string>
+    <string name="bookmark_state_not_archived">Not archived</string>
     <string name="selected_bookmark_count">%1$d selected</string>
-    <string name="action_add_to_favorites">Zu Favoriten hinzufügen</string>
+    <plurals name="multi_select_set_as_favorite">
+        <item quantity="one">%d set as favorite</item>
+        <item quantity="other">%d set as favorites</item>
+    </plurals>
+    <plurals name="multi_select_unset_as_favorite">
+        <item quantity="one">%d unset as favorite</item>
+        <item quantity="other">%d unset as favorites</item>
+    </plurals>
+    <plurals name="multi_select_set_as_archived">
+        <item quantity="one">%d set as archived</item>
+        <item quantity="other">%d set as archived</item>
+    </plurals>
+    <plurals name="multi_select_unset_as_archived">
+        <item quantity="one">%d unset as archived</item>
+        <item quantity="other">%d unset as archived</item>
+    </plurals>
+    <string name="action_add_to_favorites">Add favorite</string>
     <string name="action_remove_from_favorites">Favorit entfernen</string>
     <string name="action_add_to_archive">Archivieren</string>
     <string name="action_remove_from_archive">Aus dem Archiv entfernen</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -124,6 +124,7 @@ other{}
     <string name="multi_select_unset_as_favorite">%1$d unset as favorite</string>
     <string name="multi_select_set_as_archived">%1$d set as archived</string>
     <string name="multi_select_unset_as_archived">%1$d unset as archived</string>
+    <string name="multi_select_deleted_count">%1$d bookmarks deleted</string>
     <string name="action_add_to_favorites">Add favorite</string>
     <string name="action_remove_from_favorites">Favorit entfernen</string>
     <string name="action_add_to_archive">Archivieren</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -109,6 +109,11 @@ other{}
     <!-- Bookmark Card Actions -->
     <string name="action_favorite">Favorit</string>
     <string name="action_archive">Archiv</string>
+    <string name="action_select_bookmarks">Select bookmarks</string>
+    <string name="action_exit_selection_mode">Exit selection mode</string>
+    <string name="action_select_bookmark">Select bookmark</string>
+    <string name="action_deselect_bookmark">Deselect bookmark</string>
+    <string name="selected_bookmark_count">%1$d selected</string>
     <string name="action_add_to_favorites">Zu Favoriten hinzufügen</string>
     <string name="action_remove_from_favorites">Favorit entfernen</string>
     <string name="action_add_to_archive">Archivieren</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -98,8 +98,30 @@ other{}
     <string name="action_exit_selection_mode">Exit selection mode</string>
     <string name="action_select_bookmark">Select bookmark</string>
     <string name="action_deselect_bookmark">Deselect bookmark</string>
+    <string name="action_select_all">Select all</string>
+    <string name="action_deselect_all">Deselect all</string>
+    <string name="bookmark_state_favorited">Favorited</string>
+    <string name="bookmark_state_not_favorited">Not favorited</string>
+    <string name="bookmark_state_archived">Archived</string>
+    <string name="bookmark_state_not_archived">Not archived</string>
     <string name="selected_bookmark_count">%1$d selected</string>
-    <string name="action_add_to_favorites">Añadir a favoritos</string>
+    <plurals name="multi_select_set_as_favorite">
+        <item quantity="one">%d set as favorite</item>
+        <item quantity="other">%d set as favorites</item>
+    </plurals>
+    <plurals name="multi_select_unset_as_favorite">
+        <item quantity="one">%d unset as favorite</item>
+        <item quantity="other">%d unset as favorites</item>
+    </plurals>
+    <plurals name="multi_select_set_as_archived">
+        <item quantity="one">%d set as archived</item>
+        <item quantity="other">%d set as archived</item>
+    </plurals>
+    <plurals name="multi_select_unset_as_archived">
+        <item quantity="one">%d unset as archived</item>
+        <item quantity="other">%d unset as archived</item>
+    </plurals>
+    <string name="action_add_to_favorites">Add favorite</string>
     <string name="action_remove_from_favorites">Eliminar favorito</string>
     <string name="action_add_to_archive">Archivar</string>
     <string name="action_remove_from_archive">Desarchivar</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -109,6 +109,7 @@ other{}
     <string name="multi_select_unset_as_favorite">%1$d unset as favorite</string>
     <string name="multi_select_set_as_archived">%1$d set as archived</string>
     <string name="multi_select_unset_as_archived">%1$d unset as archived</string>
+    <string name="multi_select_deleted_count">%1$d bookmarks deleted</string>
     <string name="action_add_to_favorites">Add favorite</string>
     <string name="action_remove_from_favorites">Eliminar favorito</string>
     <string name="action_add_to_archive">Archivar</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -110,6 +110,7 @@ other{}
     <string name="multi_select_set_as_archived">%1$d set as archived</string>
     <string name="multi_select_unset_as_archived">%1$d unset as archived</string>
     <string name="multi_select_deleted_count">%1$d bookmarks deleted</string>
+    <string name="multi_select_labels_added">Labels added to %1$d bookmarks</string>
     <string name="action_add_to_favorites">Add favorite</string>
     <string name="action_remove_from_favorites">Eliminar favorito</string>
     <string name="action_add_to_archive">Archivar</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -105,22 +105,10 @@ other{}
     <string name="bookmark_state_archived">Archived</string>
     <string name="bookmark_state_not_archived">Not archived</string>
     <string name="selected_bookmark_count">%1$d selected</string>
-    <plurals name="multi_select_set_as_favorite">
-        <item quantity="one">%d set as favorite</item>
-        <item quantity="other">%d set as favorites</item>
-    </plurals>
-    <plurals name="multi_select_unset_as_favorite">
-        <item quantity="one">%d unset as favorite</item>
-        <item quantity="other">%d unset as favorites</item>
-    </plurals>
-    <plurals name="multi_select_set_as_archived">
-        <item quantity="one">%d set as archived</item>
-        <item quantity="other">%d set as archived</item>
-    </plurals>
-    <plurals name="multi_select_unset_as_archived">
-        <item quantity="one">%d unset as archived</item>
-        <item quantity="other">%d unset as archived</item>
-    </plurals>
+    <string name="multi_select_set_as_favorite">%1$d set as favorite</string>
+    <string name="multi_select_unset_as_favorite">%1$d unset as favorite</string>
+    <string name="multi_select_set_as_archived">%1$d set as archived</string>
+    <string name="multi_select_unset_as_archived">%1$d unset as archived</string>
     <string name="action_add_to_favorites">Add favorite</string>
     <string name="action_remove_from_favorites">Eliminar favorito</string>
     <string name="action_add_to_archive">Archivar</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -94,6 +94,11 @@ other{}
     <!-- Bookmark Card Actions -->
     <string name="action_favorite">Favorito</string>
     <string name="action_archive">Archivo</string>
+    <string name="action_select_bookmarks">Select bookmarks</string>
+    <string name="action_exit_selection_mode">Exit selection mode</string>
+    <string name="action_select_bookmark">Select bookmark</string>
+    <string name="action_deselect_bookmark">Deselect bookmark</string>
+    <string name="selected_bookmark_count">%1$d selected</string>
     <string name="action_add_to_favorites">Añadir a favoritos</string>
     <string name="action_remove_from_favorites">Eliminar favorito</string>
     <string name="action_add_to_archive">Archivar</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -200,8 +200,30 @@
     <string name="action_exit_selection_mode">Exit selection mode</string>
     <string name="action_select_bookmark">Select bookmark</string>
     <string name="action_deselect_bookmark">Deselect bookmark</string>
+    <string name="action_select_all">Select all</string>
+    <string name="action_deselect_all">Deselect all</string>
+    <string name="bookmark_state_favorited">Favorited</string>
+    <string name="bookmark_state_not_favorited">Not favorited</string>
+    <string name="bookmark_state_archived">Archived</string>
+    <string name="bookmark_state_not_archived">Not archived</string>
     <string name="selected_bookmark_count">%1$d selected</string>
-    <string name="action_add_to_favorites">Ajouter aux favoris</string>
+    <plurals name="multi_select_set_as_favorite">
+        <item quantity="one">%d set as favorite</item>
+        <item quantity="other">%d set as favorites</item>
+    </plurals>
+    <plurals name="multi_select_unset_as_favorite">
+        <item quantity="one">%d unset as favorite</item>
+        <item quantity="other">%d unset as favorites</item>
+    </plurals>
+    <plurals name="multi_select_set_as_archived">
+        <item quantity="one">%d set as archived</item>
+        <item quantity="other">%d set as archived</item>
+    </plurals>
+    <plurals name="multi_select_unset_as_archived">
+        <item quantity="one">%d unset as archived</item>
+        <item quantity="other">%d unset as archived</item>
+    </plurals>
+    <string name="action_add_to_favorites">Add favorite</string>
     <string name="action_remove_from_favorites">Retirer le favori</string>
     <string name="action_add_to_archive">Archiver</string>
     <string name="action_remove_from_archive">Désarchiver</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -207,22 +207,10 @@
     <string name="bookmark_state_archived">Archived</string>
     <string name="bookmark_state_not_archived">Not archived</string>
     <string name="selected_bookmark_count">%1$d selected</string>
-    <plurals name="multi_select_set_as_favorite">
-        <item quantity="one">%d set as favorite</item>
-        <item quantity="other">%d set as favorites</item>
-    </plurals>
-    <plurals name="multi_select_unset_as_favorite">
-        <item quantity="one">%d unset as favorite</item>
-        <item quantity="other">%d unset as favorites</item>
-    </plurals>
-    <plurals name="multi_select_set_as_archived">
-        <item quantity="one">%d set as archived</item>
-        <item quantity="other">%d set as archived</item>
-    </plurals>
-    <plurals name="multi_select_unset_as_archived">
-        <item quantity="one">%d unset as archived</item>
-        <item quantity="other">%d unset as archived</item>
-    </plurals>
+    <string name="multi_select_set_as_favorite">%1$d set as favorite</string>
+    <string name="multi_select_unset_as_favorite">%1$d unset as favorite</string>
+    <string name="multi_select_set_as_archived">%1$d set as archived</string>
+    <string name="multi_select_unset_as_archived">%1$d unset as archived</string>
     <string name="action_add_to_favorites">Add favorite</string>
     <string name="action_remove_from_favorites">Retirer le favori</string>
     <string name="action_add_to_archive">Archiver</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -196,6 +196,11 @@
     <!-- Bookmark Card Actions -->
     <string name="action_favorite">Favori</string>
     <string name="action_archive">Archive</string>
+    <string name="action_select_bookmarks">Select bookmarks</string>
+    <string name="action_exit_selection_mode">Exit selection mode</string>
+    <string name="action_select_bookmark">Select bookmark</string>
+    <string name="action_deselect_bookmark">Deselect bookmark</string>
+    <string name="selected_bookmark_count">%1$d selected</string>
     <string name="action_add_to_favorites">Ajouter aux favoris</string>
     <string name="action_remove_from_favorites">Retirer le favori</string>
     <string name="action_add_to_archive">Archiver</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -197,6 +197,7 @@
     <string name="action_favorite">Favori</string>
     <string name="action_archive">Archive</string>
     <string name="action_select_bookmarks">Select bookmarks</string>
+    <string name="multi_select_deleted_count">%1$d bookmarks deleted</string>
     <string name="action_exit_selection_mode">Exit selection mode</string>
     <string name="action_select_bookmark">Select bookmark</string>
     <string name="action_deselect_bookmark">Deselect bookmark</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -198,6 +198,7 @@
     <string name="action_archive">Archive</string>
     <string name="action_select_bookmarks">Select bookmarks</string>
     <string name="multi_select_deleted_count">%1$d bookmarks deleted</string>
+    <string name="multi_select_labels_added">Labels added to %1$d bookmarks</string>
     <string name="action_exit_selection_mode">Exit selection mode</string>
     <string name="action_select_bookmark">Select bookmark</string>
     <string name="action_deselect_bookmark">Deselect bookmark</string>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -88,8 +88,30 @@ other{}
     <string name="action_exit_selection_mode">Exit selection mode</string>
     <string name="action_select_bookmark">Select bookmark</string>
     <string name="action_deselect_bookmark">Deselect bookmark</string>
+    <string name="action_select_all">Select all</string>
+    <string name="action_deselect_all">Deselect all</string>
+    <string name="bookmark_state_favorited">Favorited</string>
+    <string name="bookmark_state_not_favorited">Not favorited</string>
+    <string name="bookmark_state_archived">Archived</string>
+    <string name="bookmark_state_not_archived">Not archived</string>
     <string name="selected_bookmark_count">%1$d selected</string>
-    <string name="action_add_to_favorites">Engadir a favoritos</string>
+    <plurals name="multi_select_set_as_favorite">
+        <item quantity="one">%d set as favorite</item>
+        <item quantity="other">%d set as favorites</item>
+    </plurals>
+    <plurals name="multi_select_unset_as_favorite">
+        <item quantity="one">%d unset as favorite</item>
+        <item quantity="other">%d unset as favorites</item>
+    </plurals>
+    <plurals name="multi_select_set_as_archived">
+        <item quantity="one">%d set as archived</item>
+        <item quantity="other">%d set as archived</item>
+    </plurals>
+    <plurals name="multi_select_unset_as_archived">
+        <item quantity="one">%d unset as archived</item>
+        <item quantity="other">%d unset as archived</item>
+    </plurals>
+    <string name="action_add_to_favorites">Add favorite</string>
     <string name="action_remove_from_favorites">Eliminar favorito</string>
     <string name="action_add_to_archive">Arquivar</string>
     <string name="action_remove_from_archive">Desarquivar</string>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -99,6 +99,7 @@ other{}
     <string name="multi_select_unset_as_favorite">%1$d unset as favorite</string>
     <string name="multi_select_set_as_archived">%1$d set as archived</string>
     <string name="multi_select_unset_as_archived">%1$d unset as archived</string>
+    <string name="multi_select_deleted_count">%1$d bookmarks deleted</string>
     <string name="action_add_to_favorites">Add favorite</string>
     <string name="action_remove_from_favorites">Eliminar favorito</string>
     <string name="action_add_to_archive">Arquivar</string>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -100,6 +100,7 @@ other{}
     <string name="multi_select_set_as_archived">%1$d set as archived</string>
     <string name="multi_select_unset_as_archived">%1$d unset as archived</string>
     <string name="multi_select_deleted_count">%1$d bookmarks deleted</string>
+    <string name="multi_select_labels_added">Labels added to %1$d bookmarks</string>
     <string name="action_add_to_favorites">Add favorite</string>
     <string name="action_remove_from_favorites">Eliminar favorito</string>
     <string name="action_add_to_archive">Arquivar</string>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -84,6 +84,11 @@ other{}
     <!-- Bookmark Card Actions -->
     <string name="action_favorite">Favorecer</string>
     <string name="action_archive">Arquivar</string>
+    <string name="action_select_bookmarks">Select bookmarks</string>
+    <string name="action_exit_selection_mode">Exit selection mode</string>
+    <string name="action_select_bookmark">Select bookmark</string>
+    <string name="action_deselect_bookmark">Deselect bookmark</string>
+    <string name="selected_bookmark_count">%1$d selected</string>
     <string name="action_add_to_favorites">Engadir a favoritos</string>
     <string name="action_remove_from_favorites">Eliminar favorito</string>
     <string name="action_add_to_archive">Arquivar</string>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -95,22 +95,10 @@ other{}
     <string name="bookmark_state_archived">Archived</string>
     <string name="bookmark_state_not_archived">Not archived</string>
     <string name="selected_bookmark_count">%1$d selected</string>
-    <plurals name="multi_select_set_as_favorite">
-        <item quantity="one">%d set as favorite</item>
-        <item quantity="other">%d set as favorites</item>
-    </plurals>
-    <plurals name="multi_select_unset_as_favorite">
-        <item quantity="one">%d unset as favorite</item>
-        <item quantity="other">%d unset as favorites</item>
-    </plurals>
-    <plurals name="multi_select_set_as_archived">
-        <item quantity="one">%d set as archived</item>
-        <item quantity="other">%d set as archived</item>
-    </plurals>
-    <plurals name="multi_select_unset_as_archived">
-        <item quantity="one">%d unset as archived</item>
-        <item quantity="other">%d unset as archived</item>
-    </plurals>
+    <string name="multi_select_set_as_favorite">%1$d set as favorite</string>
+    <string name="multi_select_unset_as_favorite">%1$d unset as favorite</string>
+    <string name="multi_select_set_as_archived">%1$d set as archived</string>
+    <string name="multi_select_unset_as_archived">%1$d unset as archived</string>
     <string name="action_add_to_favorites">Add favorite</string>
     <string name="action_remove_from_favorites">Eliminar favorito</string>
     <string name="action_add_to_archive">Arquivar</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -196,6 +196,11 @@
     <!-- Bookmark Card Actions -->
     <string name="action_favorite">Ulubione</string>
     <string name="action_archive">Archiwum</string>
+    <string name="action_select_bookmarks">Select bookmarks</string>
+    <string name="action_exit_selection_mode">Exit selection mode</string>
+    <string name="action_select_bookmark">Select bookmark</string>
+    <string name="action_deselect_bookmark">Deselect bookmark</string>
+    <string name="selected_bookmark_count">%1$d selected</string>
     <string name="action_add_to_favorites">Dodaj do ulubionych</string>
     <string name="action_remove_from_favorites">Usuń ulubiony</string>
     <string name="action_add_to_archive">Archiwizuj</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -198,6 +198,7 @@
     <string name="action_archive">Archiwum</string>
     <string name="action_select_bookmarks">Select bookmarks</string>
     <string name="multi_select_deleted_count">%1$d bookmarks deleted</string>
+    <string name="multi_select_labels_added">Labels added to %1$d bookmarks</string>
     <string name="action_exit_selection_mode">Exit selection mode</string>
     <string name="action_select_bookmark">Select bookmark</string>
     <string name="action_deselect_bookmark">Deselect bookmark</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -197,6 +197,7 @@
     <string name="action_favorite">Ulubione</string>
     <string name="action_archive">Archiwum</string>
     <string name="action_select_bookmarks">Select bookmarks</string>
+    <string name="multi_select_deleted_count">%1$d bookmarks deleted</string>
     <string name="action_exit_selection_mode">Exit selection mode</string>
     <string name="action_select_bookmark">Select bookmark</string>
     <string name="action_deselect_bookmark">Deselect bookmark</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -200,8 +200,38 @@
     <string name="action_exit_selection_mode">Exit selection mode</string>
     <string name="action_select_bookmark">Select bookmark</string>
     <string name="action_deselect_bookmark">Deselect bookmark</string>
+    <string name="action_select_all">Select all</string>
+    <string name="action_deselect_all">Deselect all</string>
+    <string name="bookmark_state_favorited">Favorited</string>
+    <string name="bookmark_state_not_favorited">Not favorited</string>
+    <string name="bookmark_state_archived">Archived</string>
+    <string name="bookmark_state_not_archived">Not archived</string>
     <string name="selected_bookmark_count">%1$d selected</string>
-    <string name="action_add_to_favorites">Dodaj do ulubionych</string>
+    <plurals name="multi_select_set_as_favorite">
+        <item quantity="one">%d set as favorite</item>
+        <item quantity="few">%d set as favorites</item>
+        <item quantity="many">%d set as favorites</item>
+        <item quantity="other">%d set as favorites</item>
+    </plurals>
+    <plurals name="multi_select_unset_as_favorite">
+        <item quantity="one">%d unset as favorite</item>
+        <item quantity="few">%d unset as favorites</item>
+        <item quantity="many">%d unset as favorites</item>
+        <item quantity="other">%d unset as favorites</item>
+    </plurals>
+    <plurals name="multi_select_set_as_archived">
+        <item quantity="one">%d set as archived</item>
+        <item quantity="few">%d set as archived</item>
+        <item quantity="many">%d set as archived</item>
+        <item quantity="other">%d set as archived</item>
+    </plurals>
+    <plurals name="multi_select_unset_as_archived">
+        <item quantity="one">%d unset as archived</item>
+        <item quantity="few">%d unset as archived</item>
+        <item quantity="many">%d unset as archived</item>
+        <item quantity="other">%d unset as archived</item>
+    </plurals>
+    <string name="action_add_to_favorites">Add favorite</string>
     <string name="action_remove_from_favorites">Usuń ulubiony</string>
     <string name="action_add_to_archive">Archiwizuj</string>
     <string name="action_remove_from_archive">Odarchiwizuj</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -207,30 +207,10 @@
     <string name="bookmark_state_archived">Archived</string>
     <string name="bookmark_state_not_archived">Not archived</string>
     <string name="selected_bookmark_count">%1$d selected</string>
-    <plurals name="multi_select_set_as_favorite">
-        <item quantity="one">%d set as favorite</item>
-        <item quantity="few">%d set as favorites</item>
-        <item quantity="many">%d set as favorites</item>
-        <item quantity="other">%d set as favorites</item>
-    </plurals>
-    <plurals name="multi_select_unset_as_favorite">
-        <item quantity="one">%d unset as favorite</item>
-        <item quantity="few">%d unset as favorites</item>
-        <item quantity="many">%d unset as favorites</item>
-        <item quantity="other">%d unset as favorites</item>
-    </plurals>
-    <plurals name="multi_select_set_as_archived">
-        <item quantity="one">%d set as archived</item>
-        <item quantity="few">%d set as archived</item>
-        <item quantity="many">%d set as archived</item>
-        <item quantity="other">%d set as archived</item>
-    </plurals>
-    <plurals name="multi_select_unset_as_archived">
-        <item quantity="one">%d unset as archived</item>
-        <item quantity="few">%d unset as archived</item>
-        <item quantity="many">%d unset as archived</item>
-        <item quantity="other">%d unset as archived</item>
-    </plurals>
+    <string name="multi_select_set_as_favorite">%1$d set as favorite</string>
+    <string name="multi_select_unset_as_favorite">%1$d unset as favorite</string>
+    <string name="multi_select_set_as_archived">%1$d set as archived</string>
+    <string name="multi_select_unset_as_archived">%1$d unset as archived</string>
     <string name="action_add_to_favorites">Add favorite</string>
     <string name="action_remove_from_favorites">Usuń ulubiony</string>
     <string name="action_add_to_archive">Archiwizuj</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -197,6 +197,7 @@
     <string name="action_favorite">Favorito</string>
     <string name="action_archive">Arquivo</string>
     <string name="action_select_bookmarks">Select bookmarks</string>
+    <string name="multi_select_deleted_count">%1$d bookmarks deleted</string>
     <string name="action_exit_selection_mode">Exit selection mode</string>
     <string name="action_select_bookmark">Select bookmark</string>
     <string name="action_deselect_bookmark">Deselect bookmark</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -196,6 +196,11 @@
     <!-- Bookmark Card Actions -->
     <string name="action_favorite">Favorito</string>
     <string name="action_archive">Arquivo</string>
+    <string name="action_select_bookmarks">Select bookmarks</string>
+    <string name="action_exit_selection_mode">Exit selection mode</string>
+    <string name="action_select_bookmark">Select bookmark</string>
+    <string name="action_deselect_bookmark">Deselect bookmark</string>
+    <string name="selected_bookmark_count">%1$d selected</string>
     <string name="action_add_to_favorites">Adicionar aos favoritos</string>
     <string name="action_remove_from_favorites">Remover favorito</string>
     <string name="action_add_to_archive">Arquivar</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -200,8 +200,30 @@
     <string name="action_exit_selection_mode">Exit selection mode</string>
     <string name="action_select_bookmark">Select bookmark</string>
     <string name="action_deselect_bookmark">Deselect bookmark</string>
+    <string name="action_select_all">Select all</string>
+    <string name="action_deselect_all">Deselect all</string>
+    <string name="bookmark_state_favorited">Favorited</string>
+    <string name="bookmark_state_not_favorited">Not favorited</string>
+    <string name="bookmark_state_archived">Archived</string>
+    <string name="bookmark_state_not_archived">Not archived</string>
     <string name="selected_bookmark_count">%1$d selected</string>
-    <string name="action_add_to_favorites">Adicionar aos favoritos</string>
+    <plurals name="multi_select_set_as_favorite">
+        <item quantity="one">%d set as favorite</item>
+        <item quantity="other">%d set as favorites</item>
+    </plurals>
+    <plurals name="multi_select_unset_as_favorite">
+        <item quantity="one">%d unset as favorite</item>
+        <item quantity="other">%d unset as favorites</item>
+    </plurals>
+    <plurals name="multi_select_set_as_archived">
+        <item quantity="one">%d set as archived</item>
+        <item quantity="other">%d set as archived</item>
+    </plurals>
+    <plurals name="multi_select_unset_as_archived">
+        <item quantity="one">%d unset as archived</item>
+        <item quantity="other">%d unset as archived</item>
+    </plurals>
+    <string name="action_add_to_favorites">Add favorite</string>
     <string name="action_remove_from_favorites">Remover favorito</string>
     <string name="action_add_to_archive">Arquivar</string>
     <string name="action_remove_from_archive">Desarquivar</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -207,22 +207,10 @@
     <string name="bookmark_state_archived">Archived</string>
     <string name="bookmark_state_not_archived">Not archived</string>
     <string name="selected_bookmark_count">%1$d selected</string>
-    <plurals name="multi_select_set_as_favorite">
-        <item quantity="one">%d set as favorite</item>
-        <item quantity="other">%d set as favorites</item>
-    </plurals>
-    <plurals name="multi_select_unset_as_favorite">
-        <item quantity="one">%d unset as favorite</item>
-        <item quantity="other">%d unset as favorites</item>
-    </plurals>
-    <plurals name="multi_select_set_as_archived">
-        <item quantity="one">%d set as archived</item>
-        <item quantity="other">%d set as archived</item>
-    </plurals>
-    <plurals name="multi_select_unset_as_archived">
-        <item quantity="one">%d unset as archived</item>
-        <item quantity="other">%d unset as archived</item>
-    </plurals>
+    <string name="multi_select_set_as_favorite">%1$d set as favorite</string>
+    <string name="multi_select_unset_as_favorite">%1$d unset as favorite</string>
+    <string name="multi_select_set_as_archived">%1$d set as archived</string>
+    <string name="multi_select_unset_as_archived">%1$d unset as archived</string>
     <string name="action_add_to_favorites">Add favorite</string>
     <string name="action_remove_from_favorites">Remover favorito</string>
     <string name="action_add_to_archive">Arquivar</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -198,6 +198,7 @@
     <string name="action_archive">Arquivo</string>
     <string name="action_select_bookmarks">Select bookmarks</string>
     <string name="multi_select_deleted_count">%1$d bookmarks deleted</string>
+    <string name="multi_select_labels_added">Labels added to %1$d bookmarks</string>
     <string name="action_exit_selection_mode">Exit selection mode</string>
     <string name="action_select_bookmark">Select bookmark</string>
     <string name="action_deselect_bookmark">Deselect bookmark</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -207,30 +207,10 @@
     <string name="bookmark_state_archived">Archived</string>
     <string name="bookmark_state_not_archived">Not archived</string>
     <string name="selected_bookmark_count">%1$d selected</string>
-    <plurals name="multi_select_set_as_favorite">
-        <item quantity="one">%d set as favorite</item>
-        <item quantity="few">%d set as favorites</item>
-        <item quantity="many">%d set as favorites</item>
-        <item quantity="other">%d set as favorites</item>
-    </plurals>
-    <plurals name="multi_select_unset_as_favorite">
-        <item quantity="one">%d unset as favorite</item>
-        <item quantity="few">%d unset as favorites</item>
-        <item quantity="many">%d unset as favorites</item>
-        <item quantity="other">%d unset as favorites</item>
-    </plurals>
-    <plurals name="multi_select_set_as_archived">
-        <item quantity="one">%d set as archived</item>
-        <item quantity="few">%d set as archived</item>
-        <item quantity="many">%d set as archived</item>
-        <item quantity="other">%d set as archived</item>
-    </plurals>
-    <plurals name="multi_select_unset_as_archived">
-        <item quantity="one">%d unset as archived</item>
-        <item quantity="few">%d unset as archived</item>
-        <item quantity="many">%d unset as archived</item>
-        <item quantity="other">%d unset as archived</item>
-    </plurals>
+    <string name="multi_select_set_as_favorite">%1$d set as favorite</string>
+    <string name="multi_select_unset_as_favorite">%1$d unset as favorite</string>
+    <string name="multi_select_set_as_archived">%1$d set as archived</string>
+    <string name="multi_select_unset_as_archived">%1$d unset as archived</string>
     <string name="action_add_to_favorites">Add favorite</string>
     <string name="action_remove_from_favorites">Удалить из избранного</string>
     <string name="action_add_to_archive">Архивировать</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -196,6 +196,11 @@
     <!-- Bookmark Card Actions -->
     <string name="action_favorite">Избранное</string>
     <string name="action_archive">Архив</string>
+    <string name="action_select_bookmarks">Select bookmarks</string>
+    <string name="action_exit_selection_mode">Exit selection mode</string>
+    <string name="action_select_bookmark">Select bookmark</string>
+    <string name="action_deselect_bookmark">Deselect bookmark</string>
+    <string name="selected_bookmark_count">%1$d selected</string>
     <string name="action_add_to_favorites">Добавить в избранное</string>
     <string name="action_remove_from_favorites">Удалить из избранного</string>
     <string name="action_add_to_archive">Архивировать</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -197,6 +197,7 @@
     <string name="action_favorite">Избранное</string>
     <string name="action_archive">Архив</string>
     <string name="action_select_bookmarks">Select bookmarks</string>
+    <string name="multi_select_deleted_count">%1$d bookmarks deleted</string>
     <string name="action_exit_selection_mode">Exit selection mode</string>
     <string name="action_select_bookmark">Select bookmark</string>
     <string name="action_deselect_bookmark">Deselect bookmark</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -198,6 +198,7 @@
     <string name="action_archive">Архив</string>
     <string name="action_select_bookmarks">Select bookmarks</string>
     <string name="multi_select_deleted_count">%1$d bookmarks deleted</string>
+    <string name="multi_select_labels_added">Labels added to %1$d bookmarks</string>
     <string name="action_exit_selection_mode">Exit selection mode</string>
     <string name="action_select_bookmark">Select bookmark</string>
     <string name="action_deselect_bookmark">Deselect bookmark</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -200,8 +200,38 @@
     <string name="action_exit_selection_mode">Exit selection mode</string>
     <string name="action_select_bookmark">Select bookmark</string>
     <string name="action_deselect_bookmark">Deselect bookmark</string>
+    <string name="action_select_all">Select all</string>
+    <string name="action_deselect_all">Deselect all</string>
+    <string name="bookmark_state_favorited">Favorited</string>
+    <string name="bookmark_state_not_favorited">Not favorited</string>
+    <string name="bookmark_state_archived">Archived</string>
+    <string name="bookmark_state_not_archived">Not archived</string>
     <string name="selected_bookmark_count">%1$d selected</string>
-    <string name="action_add_to_favorites">Добавить в избранное</string>
+    <plurals name="multi_select_set_as_favorite">
+        <item quantity="one">%d set as favorite</item>
+        <item quantity="few">%d set as favorites</item>
+        <item quantity="many">%d set as favorites</item>
+        <item quantity="other">%d set as favorites</item>
+    </plurals>
+    <plurals name="multi_select_unset_as_favorite">
+        <item quantity="one">%d unset as favorite</item>
+        <item quantity="few">%d unset as favorites</item>
+        <item quantity="many">%d unset as favorites</item>
+        <item quantity="other">%d unset as favorites</item>
+    </plurals>
+    <plurals name="multi_select_set_as_archived">
+        <item quantity="one">%d set as archived</item>
+        <item quantity="few">%d set as archived</item>
+        <item quantity="many">%d set as archived</item>
+        <item quantity="other">%d set as archived</item>
+    </plurals>
+    <plurals name="multi_select_unset_as_archived">
+        <item quantity="one">%d unset as archived</item>
+        <item quantity="few">%d unset as archived</item>
+        <item quantity="many">%d unset as archived</item>
+        <item quantity="other">%d unset as archived</item>
+    </plurals>
+    <string name="action_add_to_favorites">Add favorite</string>
     <string name="action_remove_from_favorites">Удалить из избранного</string>
     <string name="action_add_to_archive">Архивировать</string>
     <string name="action_remove_from_archive">Разархивировать</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -196,6 +196,11 @@
     <!-- Bookmark Card Actions -->
     <string name="action_favorite">Обране</string>
     <string name="action_archive">Архів</string>
+    <string name="action_select_bookmarks">Select bookmarks</string>
+    <string name="action_exit_selection_mode">Exit selection mode</string>
+    <string name="action_select_bookmark">Select bookmark</string>
+    <string name="action_deselect_bookmark">Deselect bookmark</string>
+    <string name="selected_bookmark_count">%1$d selected</string>
     <string name="action_add_to_favorites">Додати до обраних</string>
     <string name="action_remove_from_favorites">Видалити з обраних</string>
     <string name="action_add_to_archive">Архівувати</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -198,6 +198,7 @@
     <string name="action_archive">Архів</string>
     <string name="action_select_bookmarks">Select bookmarks</string>
     <string name="multi_select_deleted_count">%1$d bookmarks deleted</string>
+    <string name="multi_select_labels_added">Labels added to %1$d bookmarks</string>
     <string name="action_exit_selection_mode">Exit selection mode</string>
     <string name="action_select_bookmark">Select bookmark</string>
     <string name="action_deselect_bookmark">Deselect bookmark</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -197,6 +197,7 @@
     <string name="action_favorite">Обране</string>
     <string name="action_archive">Архів</string>
     <string name="action_select_bookmarks">Select bookmarks</string>
+    <string name="multi_select_deleted_count">%1$d bookmarks deleted</string>
     <string name="action_exit_selection_mode">Exit selection mode</string>
     <string name="action_select_bookmark">Select bookmark</string>
     <string name="action_deselect_bookmark">Deselect bookmark</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -207,30 +207,10 @@
     <string name="bookmark_state_archived">Archived</string>
     <string name="bookmark_state_not_archived">Not archived</string>
     <string name="selected_bookmark_count">%1$d selected</string>
-    <plurals name="multi_select_set_as_favorite">
-        <item quantity="one">%d set as favorite</item>
-        <item quantity="few">%d set as favorites</item>
-        <item quantity="many">%d set as favorites</item>
-        <item quantity="other">%d set as favorites</item>
-    </plurals>
-    <plurals name="multi_select_unset_as_favorite">
-        <item quantity="one">%d unset as favorite</item>
-        <item quantity="few">%d unset as favorites</item>
-        <item quantity="many">%d unset as favorites</item>
-        <item quantity="other">%d unset as favorites</item>
-    </plurals>
-    <plurals name="multi_select_set_as_archived">
-        <item quantity="one">%d set as archived</item>
-        <item quantity="few">%d set as archived</item>
-        <item quantity="many">%d set as archived</item>
-        <item quantity="other">%d set as archived</item>
-    </plurals>
-    <plurals name="multi_select_unset_as_archived">
-        <item quantity="one">%d unset as archived</item>
-        <item quantity="few">%d unset as archived</item>
-        <item quantity="many">%d unset as archived</item>
-        <item quantity="other">%d unset as archived</item>
-    </plurals>
+    <string name="multi_select_set_as_favorite">%1$d set as favorite</string>
+    <string name="multi_select_unset_as_favorite">%1$d unset as favorite</string>
+    <string name="multi_select_set_as_archived">%1$d set as archived</string>
+    <string name="multi_select_unset_as_archived">%1$d unset as archived</string>
     <string name="action_add_to_favorites">Add favorite</string>
     <string name="action_remove_from_favorites">Видалити з обраних</string>
     <string name="action_add_to_archive">Архівувати</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -200,8 +200,38 @@
     <string name="action_exit_selection_mode">Exit selection mode</string>
     <string name="action_select_bookmark">Select bookmark</string>
     <string name="action_deselect_bookmark">Deselect bookmark</string>
+    <string name="action_select_all">Select all</string>
+    <string name="action_deselect_all">Deselect all</string>
+    <string name="bookmark_state_favorited">Favorited</string>
+    <string name="bookmark_state_not_favorited">Not favorited</string>
+    <string name="bookmark_state_archived">Archived</string>
+    <string name="bookmark_state_not_archived">Not archived</string>
     <string name="selected_bookmark_count">%1$d selected</string>
-    <string name="action_add_to_favorites">Додати до обраних</string>
+    <plurals name="multi_select_set_as_favorite">
+        <item quantity="one">%d set as favorite</item>
+        <item quantity="few">%d set as favorites</item>
+        <item quantity="many">%d set as favorites</item>
+        <item quantity="other">%d set as favorites</item>
+    </plurals>
+    <plurals name="multi_select_unset_as_favorite">
+        <item quantity="one">%d unset as favorite</item>
+        <item quantity="few">%d unset as favorites</item>
+        <item quantity="many">%d unset as favorites</item>
+        <item quantity="other">%d unset as favorites</item>
+    </plurals>
+    <plurals name="multi_select_set_as_archived">
+        <item quantity="one">%d set as archived</item>
+        <item quantity="few">%d set as archived</item>
+        <item quantity="many">%d set as archived</item>
+        <item quantity="other">%d set as archived</item>
+    </plurals>
+    <plurals name="multi_select_unset_as_archived">
+        <item quantity="one">%d unset as archived</item>
+        <item quantity="few">%d unset as archived</item>
+        <item quantity="many">%d unset as archived</item>
+        <item quantity="other">%d unset as archived</item>
+    </plurals>
+    <string name="action_add_to_favorites">Add favorite</string>
     <string name="action_remove_from_favorites">Видалити з обраних</string>
     <string name="action_add_to_archive">Архівувати</string>
     <string name="action_remove_from_archive">Розархівувати</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -152,6 +152,7 @@
     <string name="multi_select_unset_as_favorite">%1$d unset as favorite</string>
     <string name="multi_select_set_as_archived">%1$d set as archived</string>
     <string name="multi_select_unset_as_archived">%1$d unset as archived</string>
+    <string name="multi_select_deleted_count">%1$d bookmarks deleted</string>
     <string name="action_add_to_favorites">Add favorite</string>
     <string name="action_remove_from_favorites">移除收藏</string>
     <string name="action_add_to_archive">存档</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -137,6 +137,11 @@
     <string name="swipe_a11y_favorite">Toggle favorite</string>
     <string name="action_favorite">收藏</string>
     <string name="action_archive">存档</string>
+    <string name="action_select_bookmarks">Select bookmarks</string>
+    <string name="action_exit_selection_mode">Exit selection mode</string>
+    <string name="action_select_bookmark">Select bookmark</string>
+    <string name="action_deselect_bookmark">Deselect bookmark</string>
+    <string name="selected_bookmark_count">%1$d selected</string>
     <string name="action_add_to_favorites">添加到收藏</string>
     <string name="action_remove_from_favorites">移除收藏</string>
     <string name="action_add_to_archive">存档</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -153,6 +153,7 @@
     <string name="multi_select_set_as_archived">%1$d set as archived</string>
     <string name="multi_select_unset_as_archived">%1$d unset as archived</string>
     <string name="multi_select_deleted_count">%1$d bookmarks deleted</string>
+    <string name="multi_select_labels_added">Labels added to %1$d bookmarks</string>
     <string name="action_add_to_favorites">Add favorite</string>
     <string name="action_remove_from_favorites">移除收藏</string>
     <string name="action_add_to_archive">存档</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -141,8 +141,30 @@
     <string name="action_exit_selection_mode">Exit selection mode</string>
     <string name="action_select_bookmark">Select bookmark</string>
     <string name="action_deselect_bookmark">Deselect bookmark</string>
+    <string name="action_select_all">Select all</string>
+    <string name="action_deselect_all">Deselect all</string>
+    <string name="bookmark_state_favorited">Favorited</string>
+    <string name="bookmark_state_not_favorited">Not favorited</string>
+    <string name="bookmark_state_archived">Archived</string>
+    <string name="bookmark_state_not_archived">Not archived</string>
     <string name="selected_bookmark_count">%1$d selected</string>
-    <string name="action_add_to_favorites">添加到收藏</string>
+    <plurals name="multi_select_set_as_favorite">
+        <item quantity="one">%d set as favorite</item>
+        <item quantity="other">%d set as favorites</item>
+    </plurals>
+    <plurals name="multi_select_unset_as_favorite">
+        <item quantity="one">%d unset as favorite</item>
+        <item quantity="other">%d unset as favorites</item>
+    </plurals>
+    <plurals name="multi_select_set_as_archived">
+        <item quantity="one">%d set as archived</item>
+        <item quantity="other">%d set as archived</item>
+    </plurals>
+    <plurals name="multi_select_unset_as_archived">
+        <item quantity="one">%d unset as archived</item>
+        <item quantity="other">%d unset as archived</item>
+    </plurals>
+    <string name="action_add_to_favorites">Add favorite</string>
     <string name="action_remove_from_favorites">移除收藏</string>
     <string name="action_add_to_archive">存档</string>
     <string name="action_remove_from_archive">取消存档</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -148,22 +148,10 @@
     <string name="bookmark_state_archived">Archived</string>
     <string name="bookmark_state_not_archived">Not archived</string>
     <string name="selected_bookmark_count">%1$d selected</string>
-    <plurals name="multi_select_set_as_favorite">
-        <item quantity="one">%d set as favorite</item>
-        <item quantity="other">%d set as favorites</item>
-    </plurals>
-    <plurals name="multi_select_unset_as_favorite">
-        <item quantity="one">%d unset as favorite</item>
-        <item quantity="other">%d unset as favorites</item>
-    </plurals>
-    <plurals name="multi_select_set_as_archived">
-        <item quantity="one">%d set as archived</item>
-        <item quantity="other">%d set as archived</item>
-    </plurals>
-    <plurals name="multi_select_unset_as_archived">
-        <item quantity="one">%d unset as archived</item>
-        <item quantity="other">%d unset as archived</item>
-    </plurals>
+    <string name="multi_select_set_as_favorite">%1$d set as favorite</string>
+    <string name="multi_select_unset_as_favorite">%1$d unset as favorite</string>
+    <string name="multi_select_set_as_archived">%1$d set as archived</string>
+    <string name="multi_select_unset_as_archived">%1$d unset as archived</string>
     <string name="action_add_to_favorites">Add favorite</string>
     <string name="action_remove_from_favorites">移除收藏</string>
     <string name="action_add_to_archive">存档</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -152,22 +152,10 @@ other{}
     <string name="bookmark_state_archived">Archived</string>
     <string name="bookmark_state_not_archived">Not archived</string>
     <string name="selected_bookmark_count">%1$d selected</string>
-    <plurals name="multi_select_set_as_favorite">
-        <item quantity="one">%d set as favorite</item>
-        <item quantity="other">%d set as favorites</item>
-    </plurals>
-    <plurals name="multi_select_unset_as_favorite">
-        <item quantity="one">%d unset as favorite</item>
-        <item quantity="other">%d unset as favorites</item>
-    </plurals>
-    <plurals name="multi_select_set_as_archived">
-        <item quantity="one">%d set as archived</item>
-        <item quantity="other">%d set as archived</item>
-    </plurals>
-    <plurals name="multi_select_unset_as_archived">
-        <item quantity="one">%d unset as archived</item>
-        <item quantity="other">%d unset as archived</item>
-    </plurals>
+    <string name="multi_select_set_as_favorite">%1$d set as favorite</string>
+    <string name="multi_select_unset_as_favorite">%1$d unset as favorite</string>
+    <string name="multi_select_set_as_archived">%1$d set as archived</string>
+    <string name="multi_select_unset_as_archived">%1$d unset as archived</string>
     <string name="action_add_to_favorites">Add favorite</string>
     <string name="action_remove_from_favorites">Remove favorite</string>
     <string name="action_add_to_archive">Archive</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -145,8 +145,30 @@ other{}
     <string name="action_exit_selection_mode">Exit selection mode</string>
     <string name="action_select_bookmark">Select bookmark</string>
     <string name="action_deselect_bookmark">Deselect bookmark</string>
+    <string name="action_select_all">Select all</string>
+    <string name="action_deselect_all">Deselect all</string>
+    <string name="bookmark_state_favorited">Favorited</string>
+    <string name="bookmark_state_not_favorited">Not favorited</string>
+    <string name="bookmark_state_archived">Archived</string>
+    <string name="bookmark_state_not_archived">Not archived</string>
     <string name="selected_bookmark_count">%1$d selected</string>
-    <string name="action_add_to_favorites">Add to favorites</string>
+    <plurals name="multi_select_set_as_favorite">
+        <item quantity="one">%d set as favorite</item>
+        <item quantity="other">%d set as favorites</item>
+    </plurals>
+    <plurals name="multi_select_unset_as_favorite">
+        <item quantity="one">%d unset as favorite</item>
+        <item quantity="other">%d unset as favorites</item>
+    </plurals>
+    <plurals name="multi_select_set_as_archived">
+        <item quantity="one">%d set as archived</item>
+        <item quantity="other">%d set as archived</item>
+    </plurals>
+    <plurals name="multi_select_unset_as_archived">
+        <item quantity="one">%d unset as archived</item>
+        <item quantity="other">%d unset as archived</item>
+    </plurals>
+    <string name="action_add_to_favorites">Add favorite</string>
     <string name="action_remove_from_favorites">Remove favorite</string>
     <string name="action_add_to_archive">Archive</string>
     <string name="action_remove_from_archive">Unarchive</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -141,6 +141,11 @@ other{}
     <!-- Bookmark Card Actions -->
     <string name="action_favorite">Favorite</string>
     <string name="action_archive">Archive</string>
+    <string name="action_select_bookmarks">Select bookmarks</string>
+    <string name="action_exit_selection_mode">Exit selection mode</string>
+    <string name="action_select_bookmark">Select bookmark</string>
+    <string name="action_deselect_bookmark">Deselect bookmark</string>
+    <string name="selected_bookmark_count">%1$d selected</string>
     <string name="action_add_to_favorites">Add to favorites</string>
     <string name="action_remove_from_favorites">Remove favorite</string>
     <string name="action_add_to_archive">Archive</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -157,6 +157,7 @@ other{}
     <string name="multi_select_set_as_archived">%1$d set as archived</string>
     <string name="multi_select_unset_as_archived">%1$d unset as archived</string>
     <string name="multi_select_deleted_count">%1$d bookmarks deleted</string>
+    <string name="multi_select_labels_added">Labels added to %1$d bookmarks</string>
     <string name="action_add_to_favorites">Add favorite</string>
     <string name="action_remove_from_favorites">Remove favorite</string>
     <string name="action_add_to_archive">Archive</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -156,6 +156,7 @@ other{}
     <string name="multi_select_unset_as_favorite">%1$d unset as favorite</string>
     <string name="multi_select_set_as_archived">%1$d set as archived</string>
     <string name="multi_select_unset_as_archived">%1$d unset as archived</string>
+    <string name="multi_select_deleted_count">%1$d bookmarks deleted</string>
     <string name="action_add_to_favorites">Add favorite</string>
     <string name="action_remove_from_favorites">Remove favorite</string>
     <string name="action_add_to_archive">Archive</string>

--- a/app/src/test/java/com/mydeck/app/domain/BookmarkRepositoryImplTest.kt
+++ b/app/src/test/java/com/mydeck/app/domain/BookmarkRepositoryImplTest.kt
@@ -218,6 +218,54 @@ class BookmarkRepositoryImplTest {
     }
 
     @Test
+    fun `updateBookmarks favorite updates local rows queues actions and schedules sync once`() = runTest {
+        val updates = listOf(
+            BookmarkBatchUpdate(bookmarkId = "bookmark-1", isFavorite = true),
+            BookmarkBatchUpdate(bookmarkId = "bookmark-2", isFavorite = false)
+        )
+
+        bookmarkRepositoryImpl.updateBookmarks(updates)
+
+        coVerify { bookmarkDao.updateIsMarked("bookmark-1", true) }
+        coVerify { bookmarkDao.updateIsMarked("bookmark-2", false) }
+        coVerify {
+            pendingActionDao.insert(match {
+                it.bookmarkId == "bookmark-1" && it.actionType == ActionType.TOGGLE_FAVORITE
+            })
+        }
+        coVerify {
+            pendingActionDao.insert(match {
+                it.bookmarkId == "bookmark-2" && it.actionType == ActionType.TOGGLE_FAVORITE
+            })
+        }
+        verify(exactly = 1) { syncScheduler.scheduleActionSync() }
+    }
+
+    @Test
+    fun `updateBookmarks archive updates local rows queues actions and schedules sync once`() = runTest {
+        val updates = listOf(
+            BookmarkBatchUpdate(bookmarkId = "bookmark-1", isArchived = true),
+            BookmarkBatchUpdate(bookmarkId = "bookmark-2", isArchived = false)
+        )
+
+        bookmarkRepositoryImpl.updateBookmarks(updates)
+
+        coVerify { bookmarkDao.updateIsArchived("bookmark-1", true) }
+        coVerify { bookmarkDao.updateIsArchived("bookmark-2", false) }
+        coVerify {
+            pendingActionDao.insert(match {
+                it.bookmarkId == "bookmark-1" && it.actionType == ActionType.TOGGLE_ARCHIVE
+            })
+        }
+        coVerify {
+            pendingActionDao.insert(match {
+                it.bookmarkId == "bookmark-2" && it.actionType == ActionType.TOGGLE_ARCHIVE
+            })
+        }
+        verify(exactly = 1) { syncScheduler.scheduleActionSync() }
+    }
+
+    @Test
     fun `deleteBookmark performs soft delete and queues action`() = runTest {
         // Arrange
         val bookmarkId = "123"

--- a/app/src/test/java/com/mydeck/app/domain/BookmarkRepositoryImplTest.kt
+++ b/app/src/test/java/com/mydeck/app/domain/BookmarkRepositoryImplTest.kt
@@ -858,6 +858,55 @@ class BookmarkRepositoryImplTest {
         assertTrue(result is BookmarkRepository.UpdateResult.Error)
     }
 
+    @Test
+    fun `addLabelsToBookmarks unions labels, preserves existing, and returns prior labels of changed`() = runTest {
+        val bk1 = bookmarkDto.copy(id = "bk-1").toDomain().copy(labels = listOf("home")).toEntity()
+        val bk2 = bookmarkDto.copy(id = "bk-2").toDomain().copy(labels = listOf("work")).toEntity()
+        coEvery { bookmarkDao.getAllBookmarksWithContent() } returns listOf(bk1, bk2)
+
+        val prior = bookmarkRepositoryImpl.addLabelsToBookmarks(listOf("bk-1", "bk-2"), listOf("work"))
+
+        // bk-1 gains "work" (kept "home"); bk-2 already had "work" → no-op.
+        assertEquals(mapOf("bk-1" to listOf("home")), prior)
+        coVerify(exactly = 1) {
+            bookmarkDao.updateLabels("bk-1", match { it.contains("home") && it.contains("work") })
+        }
+        coVerify(exactly = 0) { bookmarkDao.updateLabels("bk-2", any()) }
+        verify { syncScheduler.scheduleActionSync() }
+    }
+
+    @Test
+    fun `addLabelsToBookmarks collapses duplicates and is a no-op when nothing changes`() = runTest {
+        val bk1 = bookmarkDto.copy(id = "bk-1").toDomain().copy(labels = listOf("work", "home")).toEntity()
+        coEvery { bookmarkDao.getAllBookmarksWithContent() } returns listOf(bk1)
+
+        val prior = bookmarkRepositoryImpl.addLabelsToBookmarks(listOf("bk-1"), listOf("work", "home"))
+
+        assertTrue(prior.isEmpty())
+        coVerify(exactly = 0) { bookmarkDao.updateLabels(any(), any()) }
+        verify(exactly = 0) { syncScheduler.scheduleActionSync() }
+    }
+
+    @Test
+    fun `addLabelsToBookmarks is a no-op for empty labels`() = runTest {
+        val prior = bookmarkRepositoryImpl.addLabelsToBookmarks(listOf("bk-1"), emptyList())
+
+        assertTrue(prior.isEmpty())
+        coVerify(exactly = 0) { bookmarkDao.getAllBookmarksWithContent() }
+        coVerify(exactly = 0) { bookmarkDao.updateLabels(any(), any()) }
+    }
+
+    @Test
+    fun `restoreBookmarkLabels writes captured prior labels and schedules sync`() = runTest {
+        bookmarkRepositoryImpl.restoreBookmarkLabels(
+            mapOf("bk-1" to listOf("home"), "bk-2" to emptyList())
+        )
+
+        coVerify(exactly = 1) { bookmarkDao.updateLabels("bk-1", match { it.contains("home") }) }
+        coVerify(exactly = 1) { bookmarkDao.updateLabels("bk-2", any()) }
+        verify { syncScheduler.scheduleActionSync() }
+    }
+
     // ── Single-bookmark operations ────────────────────────────────────────────
 
     @Test

--- a/app/src/test/java/com/mydeck/app/ui/list/BookmarkCardSelectionTest.kt
+++ b/app/src/test/java/com/mydeck/app/ui/list/BookmarkCardSelectionTest.kt
@@ -1,0 +1,126 @@
+package com.mydeck.app.ui.list
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.longClick
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import com.mydeck.app.domain.model.Bookmark
+import com.mydeck.app.domain.model.BookmarkListItem
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class BookmarkCardSelectionTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `selection mode hides favorite and archive actions and shows select indicator`() {
+        val toggles = AtomicInteger(0)
+        val navigations = AtomicInteger(0)
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                BookmarkGridCard(
+                    bookmark = bookmarkListItem(),
+                    onClickCard = { navigations.incrementAndGet() },
+                    onClickDelete = {},
+                    onClickFavorite = { _, _ -> },
+                    onClickArchive = { _, _ -> },
+                    isSelectionMode = true,
+                    isSelected = false,
+                    onToggleSelection = { toggles.incrementAndGet() }
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithContentDescription("Favorite").assertDoesNotExist()
+        composeTestRule.onNodeWithContentDescription("Archive").assertDoesNotExist()
+        composeTestRule.onNodeWithContentDescription("Select bookmark").assertExists()
+
+        composeTestRule.onNodeWithText("Test Bookmark").performClick()
+
+        assertEquals(1, toggles.get())
+        assertEquals(0, navigations.get())
+    }
+
+    @Test
+    fun `selected card exposes deselect indicator`() {
+        composeTestRule.setContent {
+            MaterialTheme {
+                BookmarkGridCard(
+                    bookmark = bookmarkListItem(),
+                    onClickCard = {},
+                    onClickDelete = {},
+                    onClickFavorite = { _, _ -> },
+                    onClickArchive = { _, _ -> },
+                    isSelectionMode = true,
+                    isSelected = true,
+                    onToggleSelection = {}
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithContentDescription("Deselect bookmark").assertExists()
+    }
+
+    @Test
+    fun `long press does not open context menu in selection mode`() {
+        val toggles = AtomicInteger(0)
+        val navigations = AtomicInteger(0)
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                BookmarkGridCard(
+                    bookmark = bookmarkListItem(),
+                    onClickCard = { navigations.incrementAndGet() },
+                    onClickDelete = {},
+                    onClickFavorite = { _, _ -> },
+                    onClickArchive = { _, _ -> },
+                    isSelectionMode = true,
+                    isSelected = false,
+                    onToggleSelection = { toggles.incrementAndGet() }
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("Test Bookmark").performTouchInput { longClick() }
+
+        composeTestRule.onNodeWithText("Copy link").assertDoesNotExist()
+        assertEquals(0, navigations.get())
+    }
+
+    private fun bookmarkListItem() = BookmarkListItem(
+        id = "bookmark-1",
+        href = "https://example.com/api/bookmarks/bookmark-1",
+        url = "https://example.com/bookmark-1",
+        title = "Test Bookmark",
+        siteName = "Example",
+        isMarked = false,
+        isArchived = false,
+        isRead = false,
+        readProgress = 0,
+        thumbnailSrc = "",
+        iconSrc = "",
+        imageSrc = "",
+        labels = listOf("work"),
+        type = Bookmark.Type.Article,
+        readingTime = null,
+        created = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()),
+        wordCount = null,
+        published = null
+    )
+}

--- a/app/src/test/java/com/mydeck/app/ui/list/BookmarkCardSelectionTest.kt
+++ b/app/src/test/java/com/mydeck/app/ui/list/BookmarkCardSelectionTest.kt
@@ -28,9 +28,11 @@ class BookmarkCardSelectionTest {
     val composeTestRule = createComposeRule()
 
     @Test
-    fun `selection mode hides favorite and archive actions and shows select indicator`() {
+    fun `selection mode shows favorite and archive state indicators alongside select indicator`() {
         val toggles = AtomicInteger(0)
         val navigations = AtomicInteger(0)
+        val favoriteToggles = AtomicInteger(0)
+        val archiveToggles = AtomicInteger(0)
 
         composeTestRule.setContent {
             MaterialTheme {
@@ -38,8 +40,8 @@ class BookmarkCardSelectionTest {
                     bookmark = bookmarkListItem(),
                     onClickCard = { navigations.incrementAndGet() },
                     onClickDelete = {},
-                    onClickFavorite = { _, _ -> },
-                    onClickArchive = { _, _ -> },
+                    onClickFavorite = { _, _ -> favoriteToggles.incrementAndGet() },
+                    onClickArchive = { _, _ -> archiveToggles.incrementAndGet() },
                     isSelectionMode = true,
                     isSelected = false,
                     onToggleSelection = { toggles.incrementAndGet() }
@@ -49,12 +51,37 @@ class BookmarkCardSelectionTest {
 
         composeTestRule.onNodeWithContentDescription("Favorite").assertDoesNotExist()
         composeTestRule.onNodeWithContentDescription("Archive").assertDoesNotExist()
+        composeTestRule.onNodeWithContentDescription("Not favorited").assertExists()
+        composeTestRule.onNodeWithContentDescription("Not archived").assertExists()
         composeTestRule.onNodeWithContentDescription("Select bookmark").assertExists()
 
         composeTestRule.onNodeWithText("Test Bookmark").performClick()
 
+        assertEquals(0, favoriteToggles.get())
+        assertEquals(0, archiveToggles.get())
         assertEquals(1, toggles.get())
         assertEquals(0, navigations.get())
+    }
+
+    @Test
+    fun `selection mode reflects favorited and archived state`() {
+        composeTestRule.setContent {
+            MaterialTheme {
+                BookmarkGridCard(
+                    bookmark = bookmarkListItem(isMarked = true, isArchived = true),
+                    onClickCard = {},
+                    onClickDelete = {},
+                    onClickFavorite = { _, _ -> },
+                    onClickArchive = { _, _ -> },
+                    isSelectionMode = true,
+                    isSelected = false,
+                    onToggleSelection = {}
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithContentDescription("Favorited").assertExists()
+        composeTestRule.onNodeWithContentDescription("Archived").assertExists()
     }
 
     @Test
@@ -103,14 +130,17 @@ class BookmarkCardSelectionTest {
         assertEquals(0, navigations.get())
     }
 
-    private fun bookmarkListItem() = BookmarkListItem(
+    private fun bookmarkListItem(
+        isMarked: Boolean = false,
+        isArchived: Boolean = false
+    ) = BookmarkListItem(
         id = "bookmark-1",
         href = "https://example.com/api/bookmarks/bookmark-1",
         url = "https://example.com/bookmark-1",
         title = "Test Bookmark",
         siteName = "Example",
-        isMarked = false,
-        isArchived = false,
+        isMarked = isMarked,
+        isArchived = isArchived,
         isRead = false,
         readProgress = 0,
         thumbnailSrc = "",

--- a/app/src/test/java/com/mydeck/app/ui/list/BookmarkListViewModelTest.kt
+++ b/app/src/test/java/com/mydeck/app/ui/list/BookmarkListViewModelTest.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import com.mydeck.app.R
+import com.mydeck.app.domain.BookmarkBatchUpdate
 import com.mydeck.app.domain.BookmarkRepository
 import com.mydeck.app.domain.HighlightsRepository
 import com.mydeck.app.domain.model.Bookmark
@@ -133,6 +134,20 @@ class BookmarkListViewModelTest {
         every { settingsDataStore.urlFlow } returns kotlinx.coroutines.flow.MutableStateFlow(null)
         every { settingsDataStore.tokenFlow } returns kotlinx.coroutines.flow.MutableStateFlow(null)
     }
+
+    private fun createViewModel() = BookmarkListViewModel(
+        updateBookmarkUseCase,
+        fullSyncUseCase,
+        workManager,
+        bookmarkRepository,
+        context,
+        settingsDataStore,
+        savedStateHandle,
+        contentSyncPolicyEvaluator,
+        contentPackageManager,
+        syncScheduler,
+        connectivityMonitor
+    )
 
     @After
     fun tearDown() {
@@ -1450,6 +1465,177 @@ class BookmarkListViewModelTest {
         assertEquals(option, viewModel.sortOption.value)
         coVerify { settingsDataStore.saveSortOption(option.name) }
     }
+
+    @Test
+    fun `enter multi-select starts active with zero selected`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onEnterMultiSelectMode()
+
+        assertTrue(viewModel.multiSelectState.value.active)
+        assertEquals(0, viewModel.multiSelectState.value.selectedCount)
+        assertFalse(viewModel.multiSelectState.value.hasSelection)
+    }
+
+    @Test
+    fun `toggle bookmark selection adds and removes selected id`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onEnterMultiSelectMode()
+        viewModel.onToggleBookmarkSelected("bookmark-1")
+        assertEquals(setOf("bookmark-1"), viewModel.multiSelectState.value.selectedIds)
+
+        viewModel.onToggleBookmarkSelected("bookmark-1")
+        assertTrue(viewModel.multiSelectState.value.active)
+        assertEquals(emptySet<String>(), viewModel.multiSelectState.value.selectedIds)
+    }
+
+    @Test
+    fun `exit multi-select clears selected ids`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onEnterMultiSelectMode()
+        viewModel.onToggleBookmarkSelected("bookmark-1")
+        viewModel.onExitMultiSelectMode()
+
+        assertFalse(viewModel.multiSelectState.value.active)
+        assertEquals(emptySet<String>(), viewModel.multiSelectState.value.selectedIds)
+    }
+
+    @Test
+    fun `context change clears multi-select state`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onEnterMultiSelectMode()
+        viewModel.onToggleBookmarkSelected("bookmark-1")
+        viewModel.onApplyFilter(com.mydeck.app.domain.model.FilterFormState(search = "updated"))
+
+        assertEquals(MultiSelectState(), viewModel.multiSelectState.value)
+    }
+
+    @Test
+    fun `visible list refresh drops selected ids that are no longer visible`() = runTest {
+        val bookmarkFlow = MutableStateFlow(
+            listOf(bookmarkListItem("bookmark-1"), bookmarkListItem("bookmark-2"))
+        )
+        every {
+            bookmarkRepository.observeFilteredBookmarkListItems(
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any()
+            )
+        } returns bookmarkFlow
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onEnterMultiSelectMode()
+        viewModel.onToggleBookmarkSelected("bookmark-1")
+        viewModel.onToggleBookmarkSelected("bookmark-2")
+
+        bookmarkFlow.value = listOf(bookmarkListItem("bookmark-2"))
+        advanceUntilIdle()
+
+        assertTrue(viewModel.multiSelectState.value.active)
+        assertEquals(setOf("bookmark-2"), viewModel.multiSelectState.value.selectedIds)
+    }
+
+    @Test
+    fun `batch favorite toggles from captured selected bookmark state`() = runTest {
+        val visibleBookmarks = listOf(
+            bookmarkListItem("not-favorite", isMarked = false),
+            bookmarkListItem("favorite", isMarked = true),
+            bookmarkListItem("unselected", isMarked = false)
+        )
+        every {
+            bookmarkRepository.observeFilteredBookmarkListItems(
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any()
+            )
+        } returns flowOf(visibleBookmarks)
+        coEvery { updateBookmarkUseCase.updateBookmarks(any()) } returns UpdateBookmarkUseCase.Result.Success
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onEnterMultiSelectMode()
+        viewModel.onToggleBookmarkSelected("not-favorite")
+        viewModel.onToggleBookmarkSelected("favorite")
+        viewModel.onFavoriteSelectedBookmarks()
+        advanceUntilIdle()
+
+        coVerify {
+            updateBookmarkUseCase.updateBookmarks(
+                listOf(
+                    BookmarkBatchUpdate(bookmarkId = "not-favorite", isFavorite = true),
+                    BookmarkBatchUpdate(bookmarkId = "favorite", isFavorite = false)
+                )
+            )
+        }
+        assertEquals(MultiSelectState(), viewModel.multiSelectState.value)
+    }
+
+    @Test
+    fun `batch archive toggles from captured selected bookmark state`() = runTest {
+        val visibleBookmarks = listOf(
+            bookmarkListItem("not-archived", isArchived = false),
+            bookmarkListItem("archived", isArchived = true),
+            bookmarkListItem("unselected", isArchived = false)
+        )
+        every {
+            bookmarkRepository.observeFilteredBookmarkListItems(
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any()
+            )
+        } returns flowOf(visibleBookmarks)
+        coEvery { updateBookmarkUseCase.updateBookmarks(any()) } returns UpdateBookmarkUseCase.Result.Success
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onEnterMultiSelectMode()
+        viewModel.onToggleBookmarkSelected("not-archived")
+        viewModel.onToggleBookmarkSelected("archived")
+        viewModel.onArchiveSelectedBookmarks()
+        advanceUntilIdle()
+
+        coVerify {
+            updateBookmarkUseCase.updateBookmarks(
+                listOf(
+                    BookmarkBatchUpdate(bookmarkId = "not-archived", isArchived = true),
+                    BookmarkBatchUpdate(bookmarkId = "archived", isArchived = false)
+                )
+            )
+        }
+        assertEquals(MultiSelectState(), viewModel.multiSelectState.value)
+    }
+
+    private fun bookmarkListItem(
+        id: String,
+        isMarked: Boolean = false,
+        isArchived: Boolean = false
+    ) = BookmarkListItem(
+        id = id,
+        href = "https://example.com/api/bookmarks/$id",
+        url = "https://example.com/$id",
+        title = "Bookmark $id",
+        siteName = "Example Site",
+        type = Bookmark.Type.Article,
+        isMarked = isMarked,
+        isArchived = isArchived,
+        labels = emptyList(),
+        isRead = false,
+        readProgress = 0,
+        thumbnailSrc = "",
+        iconSrc = "",
+        imageSrc = "",
+        readingTime = null,
+        created = kotlinx.datetime.Clock.System.now()
+            .toLocalDateTime(kotlinx.datetime.TimeZone.currentSystemDefault()),
+        wordCount = null,
+        published = null
+    )
+
     private val bookmarks = listOf(
         BookmarkListItem(
             id = "1",

--- a/app/src/test/java/com/mydeck/app/ui/list/BookmarkListViewModelTest.kt
+++ b/app/src/test/java/com/mydeck/app/ui/list/BookmarkListViewModelTest.kt
@@ -1574,7 +1574,7 @@ class BookmarkListViewModelTest {
             )
         }
         assertEquals(MultiSelectState(), viewModel.multiSelectState.value)
-        assertEquals(listOf(BatchActionSnackbarEvent.FavoritesAdded(2)), events)
+        assertEquals(listOf(BatchActionSnackbarEvent.FavoritesAdded(2, listOf("not-favorite"))), events)
         job.cancel()
     }
 
@@ -1603,7 +1603,7 @@ class BookmarkListViewModelTest {
         advanceUntilIdle()
 
         coVerify(exactly = 0) { updateBookmarkUseCase.updateBookmarks(any()) }
-        assertEquals(listOf(BatchActionSnackbarEvent.FavoritesAdded(2)), events)
+        assertEquals(listOf(BatchActionSnackbarEvent.FavoritesAdded(2, emptyList())), events)
         job.cancel()
     }
 
@@ -1642,7 +1642,7 @@ class BookmarkListViewModelTest {
                 )
             )
         }
-        assertEquals(listOf(BatchActionSnackbarEvent.FavoritesRemoved(3)), events)
+        assertEquals(listOf(BatchActionSnackbarEvent.FavoritesRemoved(3, listOf("fav-a", "fav-b"))), events)
         job.cancel()
     }
 
@@ -1678,7 +1678,7 @@ class BookmarkListViewModelTest {
             )
         }
         assertEquals(MultiSelectState(), viewModel.multiSelectState.value)
-        assertEquals(listOf(BatchActionSnackbarEvent.Archived(2)), events)
+        assertEquals(listOf(BatchActionSnackbarEvent.Archived(2, listOf("not-archived"))), events)
         job.cancel()
     }
 
@@ -1715,7 +1715,7 @@ class BookmarkListViewModelTest {
                 )
             )
         }
-        assertEquals(listOf(BatchActionSnackbarEvent.Unarchived(2)), events)
+        assertEquals(listOf(BatchActionSnackbarEvent.Unarchived(2, listOf("a-a", "a-b"))), events)
         job.cancel()
     }
 
@@ -1893,6 +1893,162 @@ class BookmarkListViewModelTest {
 
         assertFalse(viewModel.multiSelectState.value.active)
         assertEquals(emptySet<String>(), viewModel.multiSelectState.value.selectedIds)
+    }
+
+    @Test
+    fun `onDeleteSelectedBookmarks stages all selected ids, exits selection, and emits Deleted without deleting`() = runTest {
+        val visibleBookmarks = listOf(
+            bookmarkListItem("del-1"),
+            bookmarkListItem("del-2"),
+            bookmarkListItem("keep")
+        )
+        every {
+            bookmarkRepository.observeFilteredBookmarkListItems(
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any()
+            )
+        } returns flowOf(visibleBookmarks)
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        val events = mutableListOf<BatchActionSnackbarEvent>()
+        val job = launch { viewModel.batchActionSnackbarEvent.toList(events) }
+
+        viewModel.onEnterMultiSelectMode()
+        viewModel.onToggleBookmarkSelected("del-1")
+        viewModel.onToggleBookmarkSelected("del-2")
+        viewModel.onDeleteSelectedBookmarks()
+        advanceUntilIdle()
+
+        assertEquals(setOf("del-1", "del-2"), viewModel.pendingBatchDeletionBookmarkIds.value)
+        assertEquals(MultiSelectState(), viewModel.multiSelectState.value)
+        assertEquals(listOf<BatchActionSnackbarEvent>(BatchActionSnackbarEvent.Deleted(2)), events)
+        coVerify(exactly = 0) { updateBookmarkUseCase.deleteBookmarks(any()) }
+        job.cancel()
+    }
+
+    @Test
+    fun `onConfirmBatchDeletion deletes all staged ids once and clears pending`() = runTest {
+        val visibleBookmarks = listOf(bookmarkListItem("del-1"), bookmarkListItem("del-2"))
+        every {
+            bookmarkRepository.observeFilteredBookmarkListItems(
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any()
+            )
+        } returns flowOf(visibleBookmarks)
+        coEvery { updateBookmarkUseCase.deleteBookmarks(any()) } returns UpdateBookmarkUseCase.Result.Success
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onEnterMultiSelectMode()
+        viewModel.onToggleBookmarkSelected("del-1")
+        viewModel.onToggleBookmarkSelected("del-2")
+        viewModel.onDeleteSelectedBookmarks()
+        advanceUntilIdle()
+
+        viewModel.onConfirmBatchDeletion()
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) {
+            updateBookmarkUseCase.deleteBookmarks(match { it.toSet() == setOf("del-1", "del-2") })
+        }
+        assertEquals(emptySet<String>(), viewModel.pendingBatchDeletionBookmarkIds.value)
+    }
+
+    @Test
+    fun `onCancelBatchDeletion clears staged ids without enqueuing any delete`() = runTest {
+        val visibleBookmarks = listOf(bookmarkListItem("del-1"), bookmarkListItem("del-2"))
+        every {
+            bookmarkRepository.observeFilteredBookmarkListItems(
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any()
+            )
+        } returns flowOf(visibleBookmarks)
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onEnterMultiSelectMode()
+        viewModel.onToggleBookmarkSelected("del-1")
+        viewModel.onToggleBookmarkSelected("del-2")
+        viewModel.onDeleteSelectedBookmarks()
+        advanceUntilIdle()
+
+        viewModel.onCancelBatchDeletion()
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { updateBookmarkUseCase.deleteBookmarks(any()) }
+        assertEquals(emptySet<String>(), viewModel.pendingBatchDeletionBookmarkIds.value)
+    }
+
+    @Test
+    fun `onUndoBatchAction on Deleted event cancels staged batch delete`() = runTest {
+        val visibleBookmarks = listOf(bookmarkListItem("del-1"), bookmarkListItem("del-2"))
+        every {
+            bookmarkRepository.observeFilteredBookmarkListItems(
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any()
+            )
+        } returns flowOf(visibleBookmarks)
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onEnterMultiSelectMode()
+        viewModel.onToggleBookmarkSelected("del-1")
+        viewModel.onToggleBookmarkSelected("del-2")
+        viewModel.onDeleteSelectedBookmarks()
+        advanceUntilIdle()
+
+        viewModel.onUndoBatchAction(BatchActionSnackbarEvent.Deleted(2))
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { updateBookmarkUseCase.deleteBookmarks(any()) }
+        assertEquals(emptySet<String>(), viewModel.pendingBatchDeletionBookmarkIds.value)
+    }
+
+    @Test
+    fun `onUndoBatchAction reverts only changed favorite items to their prior state`() = runTest {
+        coEvery { updateBookmarkUseCase.updateBookmarks(any()) } returns UpdateBookmarkUseCase.Result.Success
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onUndoBatchAction(BatchActionSnackbarEvent.FavoritesAdded(3, listOf("changed-a", "changed-b")))
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) {
+            updateBookmarkUseCase.updateBookmarks(
+                listOf(
+                    BookmarkBatchUpdate(bookmarkId = "changed-a", isFavorite = false),
+                    BookmarkBatchUpdate(bookmarkId = "changed-b", isFavorite = false)
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `onUndoBatchAction reverts only changed archive items to their prior state`() = runTest {
+        coEvery { updateBookmarkUseCase.updateBookmarks(any()) } returns UpdateBookmarkUseCase.Result.Success
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onUndoBatchAction(BatchActionSnackbarEvent.Unarchived(1, listOf("changed-x")))
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) {
+            updateBookmarkUseCase.updateBookmarks(
+                listOf(BookmarkBatchUpdate(bookmarkId = "changed-x", isArchived = true))
+            )
+        }
+    }
+
+    @Test
+    fun `onUndoBatchAction with no changed favorite items does not touch the repository`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onUndoBatchAction(BatchActionSnackbarEvent.FavoritesAdded(2, emptyList()))
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { updateBookmarkUseCase.updateBookmarks(any()) }
     }
 
     private fun bookmarkListItem(

--- a/app/src/test/java/com/mydeck/app/ui/list/BookmarkListViewModelTest.kt
+++ b/app/src/test/java/com/mydeck/app/ui/list/BookmarkListViewModelTest.kt
@@ -2077,6 +2077,87 @@ class BookmarkListViewModelTest {
         coVerify(exactly = 0) { updateBookmarkUseCase.updateBookmarks(any()) }
     }
 
+    @Test
+    fun `onLabelsPicked applies labels to captured selection, stays in mode, and emits LabelsAdded`() = runTest {
+        val visibleBookmarks = listOf(bookmarkListItem("a"), bookmarkListItem("b"), bookmarkListItem("c"))
+        every {
+            bookmarkRepository.observeFilteredBookmarkListItems(
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any()
+            )
+        } returns flowOf(visibleBookmarks)
+        coEvery { updateBookmarkUseCase.addLabelsToBookmarks(any(), any()) } returns
+            mapOf("a" to emptyList())
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        val events = mutableListOf<BatchActionSnackbarEvent>()
+        val job = launch { viewModel.batchActionSnackbarEvent.toList(events) }
+
+        viewModel.onEnterMultiSelectMode()
+        viewModel.onToggleBookmarkSelected("a")
+        viewModel.onToggleBookmarkSelected("b")
+        viewModel.onAddLabelsToSelection()
+        assertTrue(viewModel.showAddLabelsPicker.value)
+
+        viewModel.onLabelsPicked(setOf("work"))
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) {
+            updateBookmarkUseCase.addLabelsToBookmarks(
+                match { it.toSet() == setOf("a", "b") },
+                listOf("work")
+            )
+        }
+        assertFalse(viewModel.showAddLabelsPicker.value)
+        assertTrue(viewModel.multiSelectState.value.active)
+        assertEquals(setOf("a", "b"), viewModel.multiSelectState.value.selectedIds)
+        assertEquals(
+            listOf<BatchActionSnackbarEvent>(
+                BatchActionSnackbarEvent.LabelsAdded(2, mapOf("a" to emptyList()))
+            ),
+            events
+        )
+        job.cancel()
+    }
+
+    @Test
+    fun `onLabelsPicked with empty chosen is a no-op`() = runTest {
+        val visibleBookmarks = listOf(bookmarkListItem("a"))
+        every {
+            bookmarkRepository.observeFilteredBookmarkListItems(
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any()
+            )
+        } returns flowOf(visibleBookmarks)
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onEnterMultiSelectMode()
+        viewModel.onToggleBookmarkSelected("a")
+        viewModel.onAddLabelsToSelection()
+        viewModel.onLabelsPicked(emptySet())
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { updateBookmarkUseCase.addLabelsToBookmarks(any(), any()) }
+        assertFalse(viewModel.showAddLabelsPicker.value)
+        // Selection is preserved when the picker is cancelled with no labels.
+        assertEquals(setOf("a"), viewModel.multiSelectState.value.selectedIds)
+    }
+
+    @Test
+    fun `onUndoBatchAction on LabelsAdded restores captured prior labels`() = runTest {
+        coEvery { updateBookmarkUseCase.restoreBookmarkLabels(any()) } just Runs
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        val prior = mapOf("a" to listOf("home"), "b" to emptyList())
+        viewModel.onUndoBatchAction(BatchActionSnackbarEvent.LabelsAdded(2, prior))
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { updateBookmarkUseCase.restoreBookmarkLabels(prior) }
+    }
+
     private fun bookmarkListItem(
         id: String,
         isMarked: Boolean = false,

--- a/app/src/test/java/com/mydeck/app/ui/list/BookmarkListViewModelTest.kt
+++ b/app/src/test/java/com/mydeck/app/ui/list/BookmarkListViewModelTest.kt
@@ -1543,7 +1543,7 @@ class BookmarkListViewModelTest {
     }
 
     @Test
-    fun `batch favorite toggles from captured selected bookmark state`() = runTest {
+    fun `onFavoriteSelectedBookmarks sets favorited on items that need it and emits snackbar with selected count`() = runTest {
         val visibleBookmarks = listOf(
             bookmarkListItem("not-favorite", isMarked = false),
             bookmarkListItem("favorite", isMarked = true),
@@ -1559,25 +1559,95 @@ class BookmarkListViewModelTest {
         viewModel = createViewModel()
         advanceUntilIdle()
 
+        val events = mutableListOf<BatchActionSnackbarEvent>()
+        val job = launch { viewModel.batchActionSnackbarEvent.toList(events) }
+
         viewModel.onEnterMultiSelectMode()
         viewModel.onToggleBookmarkSelected("not-favorite")
         viewModel.onToggleBookmarkSelected("favorite")
         viewModel.onFavoriteSelectedBookmarks()
         advanceUntilIdle()
 
-        coVerify {
+        coVerify(exactly = 1) {
             updateBookmarkUseCase.updateBookmarks(
-                listOf(
-                    BookmarkBatchUpdate(bookmarkId = "not-favorite", isFavorite = true),
-                    BookmarkBatchUpdate(bookmarkId = "favorite", isFavorite = false)
-                )
+                listOf(BookmarkBatchUpdate(bookmarkId = "not-favorite", isFavorite = true))
             )
         }
         assertEquals(MultiSelectState(), viewModel.multiSelectState.value)
+        assertEquals(listOf(BatchActionSnackbarEvent.FavoritesAdded(2)), events)
+        job.cancel()
     }
 
     @Test
-    fun `batch archive toggles from captured selected bookmark state`() = runTest {
+    fun `onFavoriteSelectedBookmarks emits snackbar even when no DB updates are needed`() = runTest {
+        val visibleBookmarks = listOf(
+            bookmarkListItem("fav-a", isMarked = true),
+            bookmarkListItem("fav-b", isMarked = true)
+        )
+        every {
+            bookmarkRepository.observeFilteredBookmarkListItems(
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any()
+            )
+        } returns flowOf(visibleBookmarks)
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        val events = mutableListOf<BatchActionSnackbarEvent>()
+        val job = launch { viewModel.batchActionSnackbarEvent.toList(events) }
+
+        viewModel.onEnterMultiSelectMode()
+        viewModel.onToggleBookmarkSelected("fav-a")
+        viewModel.onToggleBookmarkSelected("fav-b")
+        viewModel.onFavoriteSelectedBookmarks()
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { updateBookmarkUseCase.updateBookmarks(any()) }
+        assertEquals(listOf(BatchActionSnackbarEvent.FavoritesAdded(2)), events)
+        job.cancel()
+    }
+
+    @Test
+    fun `onUnfavoriteSelectedBookmarks sets unfavorited on items that need it and emits snackbar`() = runTest {
+        val visibleBookmarks = listOf(
+            bookmarkListItem("fav-a", isMarked = true),
+            bookmarkListItem("fav-b", isMarked = true),
+            bookmarkListItem("not-favorite", isMarked = false)
+        )
+        every {
+            bookmarkRepository.observeFilteredBookmarkListItems(
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any()
+            )
+        } returns flowOf(visibleBookmarks)
+        coEvery { updateBookmarkUseCase.updateBookmarks(any()) } returns UpdateBookmarkUseCase.Result.Success
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        val events = mutableListOf<BatchActionSnackbarEvent>()
+        val job = launch { viewModel.batchActionSnackbarEvent.toList(events) }
+
+        viewModel.onEnterMultiSelectMode()
+        viewModel.onToggleBookmarkSelected("fav-a")
+        viewModel.onToggleBookmarkSelected("fav-b")
+        viewModel.onToggleBookmarkSelected("not-favorite")
+        viewModel.onUnfavoriteSelectedBookmarks()
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) {
+            updateBookmarkUseCase.updateBookmarks(
+                listOf(
+                    BookmarkBatchUpdate(bookmarkId = "fav-a", isFavorite = false),
+                    BookmarkBatchUpdate(bookmarkId = "fav-b", isFavorite = false)
+                )
+            )
+        }
+        assertEquals(listOf(BatchActionSnackbarEvent.FavoritesRemoved(3)), events)
+        job.cancel()
+    }
+
+    @Test
+    fun `onArchiveSelectedBookmarks sets archived on items that need it and emits snackbar`() = runTest {
         val visibleBookmarks = listOf(
             bookmarkListItem("not-archived", isArchived = false),
             bookmarkListItem("archived", isArchived = true),
@@ -1593,21 +1663,236 @@ class BookmarkListViewModelTest {
         viewModel = createViewModel()
         advanceUntilIdle()
 
+        val events = mutableListOf<BatchActionSnackbarEvent>()
+        val job = launch { viewModel.batchActionSnackbarEvent.toList(events) }
+
         viewModel.onEnterMultiSelectMode()
         viewModel.onToggleBookmarkSelected("not-archived")
         viewModel.onToggleBookmarkSelected("archived")
         viewModel.onArchiveSelectedBookmarks()
         advanceUntilIdle()
 
-        coVerify {
+        coVerify(exactly = 1) {
             updateBookmarkUseCase.updateBookmarks(
-                listOf(
-                    BookmarkBatchUpdate(bookmarkId = "not-archived", isArchived = true),
-                    BookmarkBatchUpdate(bookmarkId = "archived", isArchived = false)
-                )
+                listOf(BookmarkBatchUpdate(bookmarkId = "not-archived", isArchived = true))
             )
         }
         assertEquals(MultiSelectState(), viewModel.multiSelectState.value)
+        assertEquals(listOf(BatchActionSnackbarEvent.Archived(2)), events)
+        job.cancel()
+    }
+
+    @Test
+    fun `onUnarchiveSelectedBookmarks sets unarchived on items that need it and emits snackbar`() = runTest {
+        val visibleBookmarks = listOf(
+            bookmarkListItem("a-a", isArchived = true),
+            bookmarkListItem("a-b", isArchived = true)
+        )
+        every {
+            bookmarkRepository.observeFilteredBookmarkListItems(
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any()
+            )
+        } returns flowOf(visibleBookmarks)
+        coEvery { updateBookmarkUseCase.updateBookmarks(any()) } returns UpdateBookmarkUseCase.Result.Success
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        val events = mutableListOf<BatchActionSnackbarEvent>()
+        val job = launch { viewModel.batchActionSnackbarEvent.toList(events) }
+
+        viewModel.onEnterMultiSelectMode()
+        viewModel.onToggleBookmarkSelected("a-a")
+        viewModel.onToggleBookmarkSelected("a-b")
+        viewModel.onUnarchiveSelectedBookmarks()
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) {
+            updateBookmarkUseCase.updateBookmarks(
+                listOf(
+                    BookmarkBatchUpdate(bookmarkId = "a-a", isArchived = false),
+                    BookmarkBatchUpdate(bookmarkId = "a-b", isArchived = false)
+                )
+            )
+        }
+        assertEquals(listOf(BatchActionSnackbarEvent.Unarchived(2)), events)
+        job.cancel()
+    }
+
+    @Test
+    fun `multiSelectTargets reflects mixed selection as no uniform state`() = runTest {
+        val visibleBookmarks = listOf(
+            bookmarkListItem("fav", isMarked = true, isArchived = false),
+            bookmarkListItem("arc", isMarked = false, isArchived = true)
+        )
+        every {
+            bookmarkRepository.observeFilteredBookmarkListItems(
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any()
+            )
+        } returns flowOf(visibleBookmarks)
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onEnterMultiSelectMode()
+        viewModel.onToggleBookmarkSelected("fav")
+        viewModel.onToggleBookmarkSelected("arc")
+        advanceUntilIdle()
+
+        val targets = viewModel.multiSelectTargets.value
+        assertFalse(targets.selectedAllFavorited)
+        assertFalse(targets.selectedAllUnfavorited)
+        assertFalse(targets.selectedAllArchived)
+        assertFalse(targets.selectedAllUnarchived)
+    }
+
+    @Test
+    fun `multiSelectTargets reflects all-favorited selection`() = runTest {
+        val visibleBookmarks = listOf(
+            bookmarkListItem("a", isMarked = true),
+            bookmarkListItem("b", isMarked = true),
+            bookmarkListItem("c", isMarked = false)
+        )
+        every {
+            bookmarkRepository.observeFilteredBookmarkListItems(
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any()
+            )
+        } returns flowOf(visibleBookmarks)
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onEnterMultiSelectMode()
+        viewModel.onToggleBookmarkSelected("a")
+        viewModel.onToggleBookmarkSelected("b")
+        advanceUntilIdle()
+
+        val targets = viewModel.multiSelectTargets.value
+        assertTrue(targets.selectedAllFavorited)
+        assertFalse(targets.selectedAllUnfavorited)
+        // archive axis is independent: both items are not archived
+        assertFalse(targets.selectedAllArchived)
+        assertTrue(targets.selectedAllUnarchived)
+    }
+
+    @Test
+    fun `multiSelectTargets reflects all-archived selection`() = runTest {
+        val visibleBookmarks = listOf(
+            bookmarkListItem("a", isArchived = true),
+            bookmarkListItem("b", isArchived = true)
+        )
+        every {
+            bookmarkRepository.observeFilteredBookmarkListItems(
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any()
+            )
+        } returns flowOf(visibleBookmarks)
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onEnterMultiSelectMode()
+        viewModel.onToggleBookmarkSelected("a")
+        viewModel.onToggleBookmarkSelected("b")
+        advanceUntilIdle()
+
+        val targets = viewModel.multiSelectTargets.value
+        assertTrue(targets.selectedAllArchived)
+        assertFalse(targets.selectedAllUnarchived)
+        // favorite axis is independent: neither is favorited
+        assertFalse(targets.selectedAllFavorited)
+        assertTrue(targets.selectedAllUnfavorited)
+    }
+
+    @Test
+    fun `multiSelectTargets returns false on all uniformity flags when selection is empty`() = runTest {
+        val visibleBookmarks = listOf(bookmarkListItem("a", isMarked = true, isArchived = true))
+        every {
+            bookmarkRepository.observeFilteredBookmarkListItems(
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any()
+            )
+        } returns flowOf(visibleBookmarks)
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onEnterMultiSelectMode()
+        advanceUntilIdle()
+
+        val targets = viewModel.multiSelectTargets.value
+        assertFalse(targets.selectedAllFavorited)
+        assertFalse(targets.selectedAllUnfavorited)
+        assertFalse(targets.selectedAllArchived)
+        assertFalse(targets.selectedAllUnarchived)
+    }
+
+    @Test
+    fun `select all toggles between selecting all visible and clearing`() = runTest {
+        val visibleBookmarks = listOf(
+            bookmarkListItem("a"),
+            bookmarkListItem("b"),
+            bookmarkListItem("c")
+        )
+        every {
+            bookmarkRepository.observeFilteredBookmarkListItems(
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any()
+            )
+        } returns flowOf(visibleBookmarks)
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onEnterMultiSelectMode()
+        viewModel.onToggleSelectAllBookmarks()
+        advanceUntilIdle()
+
+        assertEquals(setOf("a", "b", "c"), viewModel.multiSelectState.value.selectedIds)
+        assertTrue(viewModel.multiSelectTargets.value.allVisibleSelected)
+
+        viewModel.onToggleSelectAllBookmarks()
+        advanceUntilIdle()
+        assertEquals(emptySet<String>(), viewModel.multiSelectState.value.selectedIds)
+        assertFalse(viewModel.multiSelectTargets.value.allVisibleSelected)
+    }
+
+    @Test
+    fun `select all from partial selection completes to all visible`() = runTest {
+        val visibleBookmarks = listOf(
+            bookmarkListItem("a"),
+            bookmarkListItem("b"),
+            bookmarkListItem("c")
+        )
+        every {
+            bookmarkRepository.observeFilteredBookmarkListItems(
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any()
+            )
+        } returns flowOf(visibleBookmarks)
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onEnterMultiSelectMode()
+        viewModel.onToggleBookmarkSelected("a")
+        viewModel.onToggleSelectAllBookmarks()
+
+        assertEquals(setOf("a", "b", "c"), viewModel.multiSelectState.value.selectedIds)
+    }
+
+    @Test
+    fun `select all is a no-op when multi-select is not active`() = runTest {
+        val visibleBookmarks = listOf(bookmarkListItem("a"))
+        every {
+            bookmarkRepository.observeFilteredBookmarkListItems(
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any()
+            )
+        } returns flowOf(visibleBookmarks)
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onToggleSelectAllBookmarks()
+
+        assertFalse(viewModel.multiSelectState.value.active)
+        assertEquals(emptySet<String>(), viewModel.multiSelectState.value.selectedIds)
     }
 
     private fun bookmarkListItem(

--- a/app/src/test/java/com/mydeck/app/ui/list/BookmarkListViewModelTest.kt
+++ b/app/src/test/java/com/mydeck/app/ui/list/BookmarkListViewModelTest.kt
@@ -1543,6 +1543,30 @@ class BookmarkListViewModelTest {
     }
 
     @Test
+    fun `visible list refresh exits selection mode when all selected ids disappear`() = runTest {
+        val bookmarkFlow = MutableStateFlow(
+            listOf(bookmarkListItem("bookmark-1"), bookmarkListItem("bookmark-2"))
+        )
+        every {
+            bookmarkRepository.observeFilteredBookmarkListItems(
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any()
+            )
+        } returns bookmarkFlow
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onEnterMultiSelectMode()
+        viewModel.onToggleBookmarkSelected("bookmark-1")
+        viewModel.onToggleBookmarkSelected("bookmark-2")
+
+        bookmarkFlow.value = listOf(bookmarkListItem("bookmark-3"))
+        advanceUntilIdle()
+
+        assertEquals(MultiSelectState(), viewModel.multiSelectState.value)
+    }
+
+    @Test
     fun `onFavoriteSelectedBookmarks sets favorited on items that need it and emits snackbar with selected count`() = runTest {
         val visibleBookmarks = listOf(
             bookmarkListItem("not-favorite", isMarked = false),
@@ -1573,7 +1597,8 @@ class BookmarkListViewModelTest {
                 listOf(BookmarkBatchUpdate(bookmarkId = "not-favorite", isFavorite = true))
             )
         }
-        assertEquals(MultiSelectState(), viewModel.multiSelectState.value)
+        assertTrue(viewModel.multiSelectState.value.active)
+        assertEquals(setOf("not-favorite", "favorite"), viewModel.multiSelectState.value.selectedIds)
         assertEquals(listOf(BatchActionSnackbarEvent.FavoritesAdded(2, listOf("not-favorite"))), events)
         job.cancel()
     }
@@ -1677,7 +1702,8 @@ class BookmarkListViewModelTest {
                 listOf(BookmarkBatchUpdate(bookmarkId = "not-archived", isArchived = true))
             )
         }
-        assertEquals(MultiSelectState(), viewModel.multiSelectState.value)
+        assertTrue(viewModel.multiSelectState.value.active)
+        assertEquals(setOf("not-archived", "archived"), viewModel.multiSelectState.value.selectedIds)
         assertEquals(listOf(BatchActionSnackbarEvent.Archived(2, listOf("not-archived"))), events)
         job.cancel()
     }

--- a/docs/specs/list-multi-select-actions-spec.md
+++ b/docs/specs/list-multi-select-actions-spec.md
@@ -1,13 +1,15 @@
 # List Multi-Select Actions — Feasibility and Design Specification
 
-Status: Draft for implementation. Phase 1 (selection mode plus batch favorite/archive) is implemented on branch `feat/multi-select-phase-1`. A Phase 1 follow-up on the same branch lands the batch favorite/archive UX as **explicit dual actions with contextual elevation** (MD3 Pattern B, refined):
+Status: Implemented on branch `feat/multi-select-phase-1`. Phase 1 (selection mode plus batch favorite/archive) shipped first; a follow-up on the same branch landed the batch favorite/archive UX as **explicit dual actions with contextual elevation** (MD3 Pattern B, refined); Phase 3 (§6.7 batch delete + Undo, plus Undo on the favorite/archive Snackbars) completed the feature.
+
+The contextual-elevation design:
 
 - Each of the two action axes — favorite and archive — is computed independently from the current selection. For each axis the system promotes the single most useful action to the top app bar; the inverse goes into the overflow menu, greyed-out when it would be a no-op.
   - **All selected are already in the target state** → the inverse action (Remove favorite / Unarchive) is elevated to the bar with the Outlined icon variant. The overflow holds the matching Add action, disabled.
   - **None or some are in the target state** → the additive action (Add favorite / Archive) sits on the bar with the Filled icon variant. The overflow holds the Remove/Unarchive action, enabled iff at least one selected item is in the matching state.
 - Terminology is aligned with the Reading-view overflow: **Add favorite**, **Remove favorite**, **Archive**, **Unarchive**.
 - Select all / Deselect all is a single toggle item in the overflow that swaps label and leading icon based on whether all visible bookmarks are selected.
-- Every batch action emits a confirmation Snackbar describing the post-state of the full selection using a uniform "N set/unset as X" copy pattern: "%d set as favorite(s)", "%d unset as favorite(s)", "%d set as archived", "%d unset as archived" (plurals from `multi_select_set_as_*` / `multi_select_unset_as_*`). The count is the selected count.
+- Every batch action emits a confirmation Snackbar describing the post-state of the full selection using a uniform "N set/unset as X" copy pattern: "%d set as favorites", "%d unset as favorites", "%d set as archived", "%d unset as archived". These are **flat `%1$d`-format strings** (`multi_select_set_as_*` / `multi_select_unset_as_*`), not Android `<plurals>` — an earlier plurals approach was reverted as a regression. The count is the selected count.
 - DB writes only go to items whose state would actually change; the Snackbar fires regardless, so a uniform-state tap still confirms the user's intent landed.
 
 The favorite/archive icons on each card remain visible in select mode as **non-interactive state indicators** at 38% alpha so the user can see per-card state at a glance.
@@ -256,10 +258,10 @@ Behavior:
   target state get no DB write and no sync churn.
 - Always emit a Snackbar describing the post-state of the **full selection**,
   using "set/unset as X" copy and the selected count:
-  - After Add favorite → `multi_select_set_as_favorite` ("%d set as
-    favorite" / "%d set as favorites").
-  - After Remove favorite → `multi_select_unset_as_favorite` ("%d unset as
-    favorite" / "%d unset as favorites").
+  - After Add favorite → `multi_select_set_as_favorite` (flat string
+    "%1$d set as favorites").
+  - After Remove favorite → `multi_select_unset_as_favorite` (flat string
+    "%1$d unset as favorites").
 - Reset the list to non-multi-select mode after the action is accepted.
 
 ### 6.6 Batch Archive (Contextual Elevation)
@@ -544,8 +546,10 @@ Likely strings:
 - `confirm`
 - `cancel` if not already available
 
-Use Android plural resources if the project already uses them. If not, add
-plurals only if needed for clean count handling.
+Use flat `%1$d`-format strings, **not** Android `<plurals>`. A plurals approach
+was tried and reverted as a regression; all count-bearing multi-select copy
+("%1$d set as favorites", "%1$d bookmarks deleted", etc.) uses flat strings with
+English placeholders across all ten locale files.
 
 ## 15. User Guide Updates
 

--- a/docs/specs/list-multi-select-actions-spec.md
+++ b/docs/specs/list-multi-select-actions-spec.md
@@ -1,6 +1,6 @@
 # List Multi-Select Actions — Feasibility and Design Specification
 
-Status: Draft for implementation  
+Status: Draft for implementation. Phase 1 (selection mode plus batch favorite/archive) is implemented on branch `feat/multi-select-phase-1`; Phase 2 (delete/undo plus confirmation) remains.
 Date: 2026-05-12
 
 ## 1. Purpose

--- a/docs/specs/list-multi-select-actions-spec.md
+++ b/docs/specs/list-multi-select-actions-spec.md
@@ -1,6 +1,22 @@
 # List Multi-Select Actions — Feasibility and Design Specification
 
-Status: Draft for implementation. Phase 1 (selection mode plus batch favorite/archive) is implemented on branch `feat/multi-select-phase-1`; Phase 2 (delete/undo plus confirmation) remains.
+Status: Draft for implementation. Phase 1 (selection mode plus batch favorite/archive) is implemented on branch `feat/multi-select-phase-1`. A Phase 1 follow-up on the same branch lands the batch favorite/archive UX as **explicit dual actions with contextual elevation** (MD3 Pattern B, refined):
+
+- Each of the two action axes — favorite and archive — is computed independently from the current selection. For each axis the system promotes the single most useful action to the top app bar; the inverse goes into the overflow menu, greyed-out when it would be a no-op.
+  - **All selected are already in the target state** → the inverse action (Remove favorite / Unarchive) is elevated to the bar with the Outlined icon variant. The overflow holds the matching Add action, disabled.
+  - **None or some are in the target state** → the additive action (Add favorite / Archive) sits on the bar with the Filled icon variant. The overflow holds the Remove/Unarchive action, enabled iff at least one selected item is in the matching state.
+- Terminology is aligned with the Reading-view overflow: **Add favorite**, **Remove favorite**, **Archive**, **Unarchive**.
+- Select all / Deselect all is a single toggle item in the overflow that swaps label and leading icon based on whether all visible bookmarks are selected.
+- Every batch action emits a confirmation Snackbar describing the post-state of the full selection using a uniform "N set/unset as X" copy pattern: "%d set as favorite(s)", "%d unset as favorite(s)", "%d set as archived", "%d unset as archived" (plurals from `multi_select_set_as_*` / `multi_select_unset_as_*`). The count is the selected count.
+- DB writes only go to items whose state would actually change; the Snackbar fires regardless, so a uniform-state tap still confirms the user's intent landed.
+
+The favorite/archive icons on each card remain visible in select mode as **non-interactive state indicators** at 38% alpha so the user can see per-card state at a glance.
+
+Phase 3 remains. It bundles two related workstreams that both touch the bookmark-list top app bar and should land together to avoid two consecutive bar reshuffles for users:
+
+1. **Batch delete + Snackbar Undo** (this spec, §6.7) — extends the delete path to the batch case and adds Undo affordances to the favorite/archive/delete Snackbars. The Snackbar+Undo pattern supersedes the previously-planned "Confirm multi-select actions" Settings switch — §7 is no longer planned.
+2. **List view top app bar overflow refactor** — relocates the multi-select entry icon from a dedicated bar slot into a list-view top app bar overflow menu and addresses the current label-mode bar gap. Specified in [`list-top-app-bar-overflow-spec.md`](./list-top-app-bar-overflow-spec.md). Selection-mode bar contents (X, count, primary actions, selection-mode overflow) are unaffected by that refactor.
+
 Date: 2026-05-12
 
 ## 1. Purpose
@@ -82,8 +98,12 @@ Multi-select mode is list-local and transient. It should reset when:
 - No replacement of existing per-card single actions in normal mode.
 - No change to bookmark filters, sorting, labels, or detail navigation behavior
   outside multi-select mode.
-- No "select all" action in v1.
 - No long-press entry point in v1.
+
+A Phase 1 follow-up adds a **Select all / Deselect all** toggle in the
+selection-mode overflow menu. It applies only to the reversible
+favorite/archive actions; select-all-for-delete is deferred to Phase 3 along
+with the Undo design.
 
 ## 5. Material Design and Android Pattern Alignment
 
@@ -124,6 +144,11 @@ Preferred icon:
 - Although the visual is a circle, this must behave as a multi-select control,
   not a radio button.
 
+> **Phase 3 follow-on:** the multi-select entry point relocates from a
+> dedicated bar icon into a list-view top app bar overflow menu. See
+> `list-top-app-bar-overflow-spec.md`. Selection-mode bar contents (X, count,
+> primary actions, selection-mode overflow) are unaffected.
+
 Top app bar action ordering in normal mode:
 
 - Preserve existing actions.
@@ -140,15 +165,33 @@ When selected:
 
 ### 6.2 Multi-select top app bar
 
-When multi-select mode is active:
+When multi-select mode is active (Phase 1 follow-up — **explicit dual actions with contextual elevation**):
 
 - Left navigation icon becomes `X`.
 - Title becomes the selected count, initially `0`.
-- If no cards are selected, no batch action icons are shown on the right.
-- When one or more cards are selected, show right-side action icons:
-  - Favorite
-  - Archive
-  - Delete
+- A 3-dot **overflow** menu (`MoreVert`) is always shown on the right and
+  contains, at minimum, **Select all / Deselect all** (a single toggle item
+  whose label and leading icon swap between the two states based on whether all
+  visible items are already selected).
+- When one or more cards are selected, the bar gains two action icons (one per
+  axis) and the overflow gains two corresponding items (the inverse per axis).
+  Each axis is computed independently from the current selection:
+  - **Favorite axis**:
+    - If every selected item is already favorited → bar = **Remove favorite**
+      (`Icons.Outlined.FavoriteBorder`, cd `action_remove_from_favorites`).
+      Overflow entry = **Add favorite** (`Icons.Filled.Favorite`), disabled.
+    - Otherwise → bar = **Add favorite** (`Icons.Filled.Favorite`, cd
+      `action_add_to_favorites`). Overflow entry = **Remove favorite**
+      (`Icons.Outlined.FavoriteBorder`), enabled iff at least one selected item
+      is currently favorited.
+  - **Archive axis**: mirrors favorite, using `Icons.Filled.Inventory2` /
+    `Icons.Outlined.Inventory2`, `action_add_to_archive` /
+    `action_remove_from_archive`.
+  - Delete remains on the bar (Phase 3 will add Undo to its Snackbar).
+
+The promotion logic guarantees one-tap reversal for uniform-state selections
+(you don't have to dig into the overflow to undo a uniform state) while keeping
+mixed-state selections additive-by-default and reversible via the overflow.
 
 The `X` action exits multi-select mode and clears the selection.
 
@@ -159,7 +202,12 @@ string. Prefer the shortest form that fits compact phones.
 
 When multi-select mode is active:
 
-- Per-card action icons are hidden.
+- Per-card interactive action icons (overflow/delete/open URL) are hidden.
+- The favorite and archive icons on each card remain visible as
+  **non-interactive state indicators** at 38% alpha (Phase 1 follow-up): the
+  filled/outline variant reflects each bookmark's current favorite/archive
+  state, and the content description announces state (e.g. "Favorited" / "Not
+  favorited") rather than an action. They are not tappable in select mode.
 - The far-right action slot where Delete normally appears is replaced by the
   multi-select indicator.
 - Tapping anywhere on a card toggles selection for that card.
@@ -189,30 +237,42 @@ matches the requested initial-count behavior.
 Batch actions are hidden or disabled until at least one card is selected. Prefer
 hidden to reduce clutter, matching the requested behavior.
 
-### 6.5 Batch Favorite
+### 6.5 Batch Favorite (Contextual Elevation)
 
-When Favorite is selected:
+Two explicit actions, surfaced according to the selection's current favorite
+uniformity (computed independently from archive):
 
-- For each selected bookmark, toggle its current favorite state.
-- A favorite bookmark becomes not favorite.
-- A non-favorite bookmark becomes favorite.
-- Apply the action to the selected bookmark snapshot captured at action time.
+- **Add favorite** (Filled heart) sets `isMarked = true` on every selected
+  item. It lives on the bar by default and slides into the overflow (disabled)
+  when every selected item is already favorited.
+- **Remove favorite** (Outlined heart) sets `isMarked = false`. It lives in
+  the overflow and is promoted to the bar when every selected item is already
+  favorited.
+
+Behavior:
+
+- Filter the selection to items whose current state differs from the target;
+  issue a single batch DB update for that subset only. Items already in the
+  target state get no DB write and no sync churn.
+- Always emit a Snackbar describing the post-state of the **full selection**,
+  using "set/unset as X" copy and the selected count:
+  - After Add favorite → `multi_select_set_as_favorite` ("%d set as
+    favorite" / "%d set as favorites").
+  - After Remove favorite → `multi_select_unset_as_favorite` ("%d unset as
+    favorite" / "%d unset as favorites").
 - Reset the list to non-multi-select mode after the action is accepted.
 
-Important:
+### 6.6 Batch Archive (Contextual Elevation)
 
-- Do not apply a single uniform favorite value to all selected items unless a
-  future design explicitly changes this behavior.
+Mirrors §6.5 on the archive axis using `Icons.Filled.Inventory2` /
+`Icons.Outlined.Inventory2`. **Archive** is the additive default;
+**Unarchive** lives in the overflow until every selected item is already
+archived, at which point it is promoted to the bar. The Snackbar uses
+`multi_select_set_as_archived` ("%d set as archived") or
+`multi_select_unset_as_archived` ("%d unset as archived").
 
-### 6.6 Batch Archive
-
-When Archive is selected:
-
-- For each selected bookmark, toggle its current archived state.
-- An archived bookmark becomes unarchived.
-- An unarchived bookmark becomes archived.
-- Apply the action to the selected bookmark snapshot captured at action time.
-- Reset the list to non-multi-select mode after the action is accepted.
+Favorite and archive uniformity are computed independently — promoting one axis
+to its inverse does not affect the other axis's slot.
 
 List removal should be controlled by existing filters:
 
@@ -222,6 +282,13 @@ List removal should be controlled by existing filters:
   current filter.
 
 ### 6.7 Batch Delete
+
+> **Phase 3 bundling:** this section is one of two Phase 3 workstreams that
+> reshape the bookmark-list top app bar. The companion refactor —
+> [`list-top-app-bar-overflow-spec.md`](./list-top-app-bar-overflow-spec.md) —
+> relocates the multi-select entry icon into a normal-mode overflow menu and
+> closes the current label-mode bar gap. Ship the two together so users see a
+> single bar reshuffle, not two.
 
 When Delete is selected:
 
@@ -251,40 +318,23 @@ Recommended snackbar copy:
 - Multiple items: `N bookmarks deleted`.
 - Action: `Undo`.
 
-## 7. Confirmation Setting
+## 7. Confirmation — Snackbar, Not a Setting
 
-Add a setting under User Interface:
+_Originally a "Confirm multi-select actions" Settings toggle. Superseded
+during the Phase 1 follow-up by the MD3 Snackbar + Undo pattern._
 
-- Label: `Confirm multi-select actions`
-- Type: switch
-- Default: off
+Every batch action — favorite, unfavorite, archive, unarchive, delete —
+displays an MD3 Snackbar on completion summarizing the operation. The Snackbar
+text reflects the post-state of the full selection sized by the selected count
+(e.g. "Added 3 to favorites", "Moved 5 to My List", "3 bookmarks deleted").
 
-When enabled, selecting any multi-select batch action opens a confirmation
-bottom sheet before mutation.
+The Snackbar is the confirmation surface: explicit, low-friction, reversible
+via Undo (Phase 3 for favorite/archive; already implemented for single-item
+delete). No pre-action confirmation dialog or bottom sheet is shown.
 
-The bottom sheet should include:
-
-- Action-specific title.
-- Count of selected bookmarks.
-- Clear confirm and cancel actions.
-- Destructive styling for Delete confirmation.
-
-Recommended copy examples:
-
-- Favorite: `Toggle favorite for N bookmarks?`
-- Archive: `Toggle archive for N bookmarks?`
-- Delete: `Delete N bookmarks?`
-- Helper for Delete: `You can undo this from the snackbar.`
-
-Cancel:
-
-- Dismisses the bottom sheet.
-- Keeps multi-select mode and current selection.
-
-Confirm:
-
-- Performs the chosen action.
-- Resets multi-select mode after the action is accepted.
+This eliminates the need for a Settings toggle: there is nothing for the user
+to configure, because every action provides immediate visible feedback and
+(eventually) an undo path.
 
 ## 8. State Model
 
@@ -572,10 +622,24 @@ Resolved for this spec:
   yes.
 - Disable long press in multi-select mode: yes.
 - Disable swipe in multi-select mode: yes.
+- Select-all (favorite/archive only) included in Phase 1 follow-up: yes;
+  lives in the overflow menu as a single toggle item.
+- Batch favorite/archive UX: **explicit dual actions with contextual
+  elevation** (Phase 1 follow-up). Each axis (favorite, archive) independently
+  promotes the most useful action to the bar; the inverse lives in the
+  overflow and is greyed-out when it would be a no-op. The bar icon swaps
+  Filled↔Outlined to reflect which action is currently elevated.
+- Favorite/archive remain visible on cards in select mode as dimmed,
+  non-interactive state indicators: yes (Phase 1 follow-up).
+- Batch favorite/archive show a completion Snackbar (Phase 1 follow-up).
+  Snackbar uses the uniform **"N set/unset as X"** copy pattern with the
+  selected count, reflecting the post-state of the full selection, not the
+  diff.
+- Settings-based confirmation switch: **dropped**. Superseded by the
+  Snackbar + Undo pattern (Phase 3 will add Undo).
 
 Remaining implementation choices:
 
 - Whether selected count uses a bare number or localized "N selected" text.
-- Whether v1 includes a Select All overflow action.
-- Whether batch Favorite/Archive show a completion snackbar. This spec does not
-  require one.
+- Whether select-all applies to batch delete in Phase 3 — pending the undo
+  design.

--- a/docs/specs/list-multi-select-add-labels-addendum.md
+++ b/docs/specs/list-multi-select-add-labels-addendum.md
@@ -1,0 +1,240 @@
+# List Multi-Select — Batch Add Labels (Addendum)
+
+Status: Draft for implementation. Addendum to
+[`list-multi-select-actions-spec.md`](./list-multi-select-actions-spec.md);
+extends that spec's §6 action set with a fourth batch action. Depends on
+multi-select Phase 3 (batch delete + Undo) having landed on
+`feat/multi-select-phase-1`, since it reuses that branch's unified
+Snackbar + Undo machinery.
+
+Date: 2026-06-01
+
+## 1. Purpose & Scope
+
+Add a **batch "Add labels"** action to selection mode: pick one or more labels
+and apply them additively to every selected bookmark, with a confirming
+Snackbar and Undo — consistent with the favorite/archive/delete batch actions.
+
+**In scope:** additively *adding* labels to a selection (union per bookmark);
+creating brand-new labels from the picker; Undo.
+
+**Out of scope (explicitly deferred):** batch *removing* labels. Removal
+requires showing the selection's current (mixed) label state in the picker,
+which is materially more complex. See §11.
+
+## 2. Why This Is Low-Risk
+
+Most of the machinery already exists:
+
+- **Picker UI is reusable.** `LabelPickerBottomSheet`
+  ([LabelsBottomSheet.kt](../../app/src/main/java/com/mydeck/app/ui/list/LabelsBottomSheet.kt))
+  has a `LabelPickerMode.MultiSelect(initialSelection: Set<String>, onDone: (Set<String>) -> Unit)`
+  mode, is not coupled to a single-bookmark ViewModel, and can create a new
+  label from search text. We use it as-is with an **empty** initial selection.
+- **Multi-bookmark label mutation has precedent.** `renameLabel` /
+  `deleteLabel`
+  ([BookmarkRepositoryImpl.kt:1131-1181](../../app/src/main/java/com/mydeck/app/domain/BookmarkRepositoryImpl.kt#L1131-L1181))
+  already iterate affected bookmarks in a `database.performTransaction { }`,
+  compute a per-bookmark updated label list, write it via
+  `bookmarkDao.updateLabels(id, json)`, and `upsertPendingAction(id,
+  ActionType.UPDATE_LABELS, LabelsPayload(updatedLabels))`. Batch add follows
+  the identical structure.
+- **Sync path exists.** `ActionType.UPDATE_LABELS` is applied at
+  [BookmarkRepositoryImpl.kt:1027-1030](../../app/src/main/java/com/mydeck/app/domain/BookmarkRepositoryImpl.kt#L1027-L1030)
+  as `editBookmark(id, EditBookmarkDto(labels = payload.labels))` — a full-list
+  replace. No new ActionType or DTO field is required.
+
+## 3. User Experience
+
+### 3.1 Entry point
+
+The selection bar already carries Favorite, Archive, and Delete icons (plus the
+✕/count and overflow). To avoid crowding in phone portrait, **"Add labels" is a
+selection-mode overflow item**, not a fourth bar icon. Leading icon: a
+label/tag glyph (e.g. `Icons.AutoMirrored.Outlined.Label`),
+`contentDescription = null`. It is enabled whenever the selection is non-empty.
+
+### 3.2 Picker
+
+Tapping **Add labels** opens `LabelPickerBottomSheet` in `MultiSelect` mode:
+
+- `initialSelection = emptySet()` — the action is "which labels to **add**",
+  not "edit this selection's labels". Starting empty deliberately sidesteps any
+  mixed-state display across the selection.
+- `labels` map comes from the existing `observeAllLabelsWithCounts()`.
+- The user may pick existing labels and/or create new ones from search text
+  (existing picker behavior).
+- `onDone(chosen: Set<String>)`:
+  - `chosen.isEmpty()` → dismiss, no action, no Snackbar.
+  - otherwise → apply (§3.3).
+- Dismissing the picker without **Done** cancels with no change.
+
+The selected bookmark ids are captured when the picker opens, so selection mode
+state changes don't affect the pending apply.
+
+### 3.3 Apply, Snackbar, Undo
+
+On Done with a non-empty `chosen` set:
+
+1. Apply additively to each selected bookmark (§4), capturing each **changed**
+   bookmark's prior label list.
+2. **Stay in selection mode** (consistent with favorite/archive, which are also
+   non-destructive immediate actions). The selection is preserved so the user can
+   run further actions on the same set. Auto-exit-on-empty still applies if the
+   add removes the last visible item from the current view.
+3. Show a Snackbar: **"Labels added to N bookmarks"**, where N is the number of
+   bookmarks that **actually changed** (a bookmark that already had every chosen
+   label is a no-op and is not counted). If N is 0, still show a Snackbar
+   confirming the tap landed (e.g. same string with 0), or suppress — pick one
+   and note it; recommend showing it for parity with favorite/archive's
+   "fires regardless" behavior.
+4. The Snackbar carries **Undo**. Labels apply immediately (like
+   favorite/archive, not deferred like delete). Undo restores each changed
+   bookmark's captured prior label list (§4). Bookmarks that didn't change are
+   never touched.
+
+## 4. Semantics
+
+**Additive union, full-replace persistence.** For each selected bookmark:
+
+```kotlin
+val merged = (existing.labels + chosen).distinct()
+if (merged.size != existing.labels.size) {
+    // changed: record prior, write merged
+}
+```
+
+- Labels already present are preserved; duplicates collapse.
+- A bookmark whose label set is unchanged (already had all chosen labels) gets
+  **no DB write, no pending action, and is excluded from the changed count**.
+- Persistence reuses the existing **full-list** `UPDATE_LABELS` path
+  (`LabelsPayload(merged)`), exactly like `renameLabel`/`deleteLabel`. We do
+  **not** introduce a new `ADD_LABELS` action type (see §7 for why, and the
+  server-side `add_labels` option).
+
+**Undo is symmetric.** Because persistence is full-list-replace, undo simply
+re-applies each changed bookmark's captured prior list via the same
+`UPDATE_LABELS` path. No set-difference computation is needed, and labels that
+were already present before the action are correctly retained.
+
+## 5. Data Layer
+
+Add to `BookmarkRepository` / `BookmarkRepositoryImpl`, modeled directly on
+`renameLabel` ([:1131](../../app/src/main/java/com/mydeck/app/domain/BookmarkRepositoryImpl.kt#L1131)):
+
+```kotlin
+/** Adds [labels] to each bookmark, returning the prior label list of every
+ *  bookmark that actually changed (for Undo). */
+suspend fun addLabelsToBookmarks(
+    ids: List<String>,
+    labels: List<String>
+): Map<String, List<String>>   // changedId -> priorLabels
+
+/** Restores the captured prior label lists (Undo). */
+suspend fun restoreBookmarkLabels(priorByBookmark: Map<String, List<String>>)
+```
+
+Both run in a single `database.performTransaction { }`, write via
+`bookmarkDao.updateLabels`, `upsertPendingAction(id, UPDATE_LABELS,
+LabelsPayload(...))`, then `syncScheduler.scheduleActionSync()`. Expose
+matching methods on `UpdateBookmarkUseCase`.
+
+## 6. State Model & Wiring (`BookmarkListViewModel`)
+
+Extend the Phase 3 `BatchActionSnackbarEvent` family with:
+
+```kotlin
+data class LabelsAdded(
+    override val count: Int,
+    val priorLabelsByBookmark: Map<String, List<String>>
+) : BatchActionSnackbarEvent()
+```
+
+- Add UI state to open the label picker from selection mode and to hold the
+  captured selected ids while it is open (e.g.
+  `_pendingLabelTargetIds: StateFlow<List<String>>` + a
+  `showAddLabelsPicker` flag).
+- `onAddLabelsToSelection()` — capture `selectedIds`, open picker.
+- `onLabelsPicked(chosen: Set<String>)` — if empty, dismiss; else call
+  `addLabelsToBookmarks`, keep the selection active, `trySend(LabelsAdded(...))`.
+- Route through the **existing** unified Snackbar collector: `LabelsAdded`
+  uses `SnackbarDuration.Long`, `actionLabel = action_undo`,
+  `ActionPerformed → onUndoBatchAction`. In `onUndoBatchAction`, the
+  `LabelsAdded` branch calls `restoreBookmarkLabels(priorLabelsByBookmark)`.
+  No confirm-on-dismiss branch (labels are not deferred, unlike delete).
+
+## 7. Sync (and a deliberate non-choice)
+
+Reuses `ActionType.UPDATE_LABELS` (full-list replace). The local optimistic DB
+write already computes the union, so there is nothing to gain locally from a
+delta action.
+
+**Server-side `add_labels` — noted, not used here.** The Readeck PATCH endpoint
+supports `add_labels` (openapi-spec.json:735-739) and `EditBookmarkDto` already
+exposes it. Using it would make sync robust against a concurrent server-side
+label change in the window between local read and sync (full-replace is
+last-writer-wins per field). We **defer** that hardening because:
+
+- It would need a new `ADD_LABELS` action type with accumulate-on-upsert
+  semantics and a superseded-by-`UPDATE_LABELS` rule — more moving parts.
+- The existing `renameLabel`/`deleteLabel` already accept the same small
+  full-replace race, so this introduces no new risk relative to today.
+
+If label-edit races are observed in practice, migrating add to server-side
+`add_labels` is a self-contained follow-up.
+
+## 8. Strings & Localization
+
+One new flat `%1$d` string (no `<plurals>`), added to all ten
+`values*/strings.xml` with English placeholders per `CLAUDE.md`:
+
+```xml
+<string name="multi_select_labels_added">Labels added to %1$d bookmarks</string>
+```
+
+Reuse `action_undo` and `action_select_bookmarks`. The overflow item label can
+reuse the existing `add_labels` string.
+
+## 9. Tests
+
+ViewModel / repository (mockk + `runTest`):
+
+- Union preserves existing labels and collapses duplicates.
+- Bookmarks already carrying all chosen labels are excluded from the changed
+  set and the count.
+- `addLabelsToBookmarks` returns correct prior-label snapshots only for changed
+  bookmarks; `restoreBookmarkLabels` reverts exactly those.
+- Empty `chosen` is a no-op (no event, no DB write).
+- `LabelsAdded` undo invokes `restoreBookmarkLabels` with the carried map.
+
+Compose:
+
+- Selection-mode overflow shows **Add labels** when a selection exists and
+  invoking it opens the picker.
+
+## 10. Documentation
+
+- `your-bookmarks.md` → "Selecting Multiple Bookmarks": add "Add labels" to the
+  set of batch actions and the Undo description (labels apply immediately; Undo
+  restores prior labels on the bookmarks that changed).
+- `organizing.md` → "Labels": add a multi-select add note mirroring the
+  Favorites/Archive multi-select paragraphs.
+
+## 11. Out of Scope — Batch Remove
+
+Removing labels in batch needs the picker to represent the selection's *current*
+labels — which differ per bookmark (present-on-all vs. present-on-some vs.
+absent). That tri-state UI, plus `remove_labels` semantics and a more involved
+Undo, is a separate effort and is intentionally not specified here.
+
+## 12. Effort Estimate
+
+- Data layer (`addLabelsToBookmarks` + `restoreBookmarkLabels`): **small** —
+  near-copy of `renameLabel`.
+- ViewModel event + picker wiring: **small–moderate**.
+- Undo: **small** (symmetric full-list restore).
+- Strings (×10) + tests + docs: **small**.
+
+Overall **moderate-but-modest**, lighter than batch delete was, because the
+picker, the multi-bookmark label transaction pattern, and the unified
+Snackbar/Undo collector all already exist.

--- a/docs/specs/list-multi-select-phase-4-spec.md
+++ b/docs/specs/list-multi-select-phase-4-spec.md
@@ -1,0 +1,311 @@
+# List Multi-Select — Phase 4 Refinements Specification
+
+Status: Draft for implementation on the existing `feat/multi-select-phase-1`
+branch (Phase 3 shipped on the same branch; this work continues there).
+
+Date: 2026-06-02
+
+## 1. Purpose
+
+Refine the shipped multi-select UX based on hands-on tester feedback. The
+core issues:
+
+1. The selection-mode 3-dot overflow is **un-discoverable**. Users can't tell
+   what is inside before entering select mode, and once in select mode the
+   relationship between the bar icons and the overflow items is not obvious.
+2. The current bar↔overflow **opposite-action pair** (Favorite on the bar /
+   Remove favorite in overflow, swapped when all-favorited) is clever but
+   requires several uses to internalize.
+3. Every batch action **exits select mode**, so reversing a wrong tap or
+   chaining a follow-on action requires re-selecting from scratch.
+4. **Delete** sits on the bar next to Favorite/Archive, inviting mis-taps
+   on a destructive action.
+
+Phase 4 keeps the Phase 1/3 architecture (single-screen CAB in the existing
+top app bar, dimmed per-card state indicators, Snackbar+Undo) and changes
+only the selection-mode bar layout, action-method post-behavior, and one
+ViewModel auto-exit rule. No new domain or repository surface.
+
+## 2. Out of Scope
+
+- Bottom action bar (`BottomAppBar`) for selection mode. Considered and
+  rejected: bigger UI surface change, breaks consistency with the rest of
+  the app's top-bar chrome, the rest of this spec captures most of the same
+  ergonomic wins.
+- **Batch label assignment.** Deferred to Phase 5 (separate spec). Phase 4
+  leaves room in the overflow ordering for the Phase 5 Label item to slot
+  in without further reshuffling.
+- Selection-mode entry point (still the bookmark-list top-bar overflow's
+  "Select bookmarks" item per the bar refactor spec).
+- Long-press entry (still unavailable; long-press is bound to per-card
+  context menu, mirroring Readeck).
+
+## 3. Current State (Phase 3, shipped)
+
+Selection-mode top app bar, left to right:
+
+1. **X** (exit selection mode).
+2. Title: "N selected".
+3. **Favorite slot** — `Icons.Filled.Favorite` (Add) when any selected item
+   is not favorited, otherwise `Icons.Outlined.FavoriteBorder` (Remove).
+4. **Archive slot** — `Icons.Filled.Inventory2` (Archive) when any selected
+   item is not archived, otherwise `Icons.Outlined.Inventory2` (Unarchive).
+5. **Delete** — `Icons.Filled.Delete`.
+6. **Overflow** (`MoreVert`) containing:
+   - The opposite of whatever the Favorite slot is currently showing,
+     greyed-out when no-op.
+   - The opposite of whatever the Archive slot is currently showing,
+     greyed-out when no-op.
+   - **Select all / Deselect all** (toggle item).
+
+After any of Favorite / Unfavorite / Archive / Unarchive / Delete, the
+selection clears and select mode exits. A Snackbar describing the post-state
+appears with an Undo button that reverts exactly the `changedIds` from
+that action.
+
+## 4. Target Design (Phase 4)
+
+### 4.1 Selection-mode bar shape
+
+Left to right:
+
+1. **X** (unchanged).
+2. Title: "N selected" (unchanged).
+3. **Archive slot** — single context-aware icon. Same swap rule as Phase 3:
+   - If `selectedAllArchived` → `Icons.Outlined.Inventory2`, cd
+     `action_remove_from_archive` ("Unarchive"), tap calls
+     `onUnarchiveSelectedBookmarks`.
+   - Otherwise → `Icons.Filled.Inventory2`, cd `action_add_to_archive`
+     ("Archive"), tap calls `onArchiveSelectedBookmarks`.
+4. **Favorite slot** — single context-aware icon. Same swap rule:
+   - If `selectedAllFavorited` → `Icons.Outlined.FavoriteBorder`, cd
+     `action_remove_from_favorites` ("Remove favorite"), tap calls
+     `onUnfavoriteSelectedBookmarks`.
+   - Otherwise → `Icons.Filled.Favorite`, cd `action_add_to_favorites`
+     ("Add favorite"), tap calls `onFavoriteSelectedBookmarks`.
+5. **Overflow** (`MoreVert`).
+
+Net change vs Phase 3:
+
+- **Archive moves to position 3** (was position 4). Archive-first matches
+  the read-later workflow primacy in MyDeck.
+- **Favorite moves to position 4** (was position 3).
+- **Delete moves off the bar** and into the overflow (was position 5).
+- The **opposite-action overflow entries are removed** entirely. The
+  context-aware bar icons are the sole entry point for Favorite/Unfavorite
+  and Archive/Unarchive; with stay-in-mode (§4.3) the icons flip in place
+  after each tap and reversal is a single tap.
+
+### 4.2 Overflow contents (with selection)
+
+Top-down order:
+
+1. **Delete** — `Icons.Filled.Delete`, cd `action_delete`, tap calls
+   `onDeleteSelectedBookmarks`.
+2. *(Phase 5 slot — Label batch action goes here.)*
+3. **Select all / Deselect all** (toggle item, leading icon swaps
+   `Icons.Filled.SelectAll` ↔ `Icons.Filled.Deselect`, label swaps
+   `action_select_all` ↔ `action_deselect_all`).
+
+When the selection is empty, only **Select all** is shown (matches Phase 3
+behavior; the bar's Archive and Favorite slots are also hidden when there's
+no selection).
+
+### 4.3 Stay-in-select-mode after Favorite/Unfavorite/Archive/Unarchive
+
+The four reversible favorite/archive batch actions **no longer clear the
+selection or exit select mode**. The bar's context-aware icons re-evaluate
+against the post-action selection state and swap accordingly on the next
+frame. The Snackbar still fires with the same copy and Undo button.
+
+Concretely in `BookmarkListViewModel`: drop the `clearMultiSelectState()`
+call from `applyBatchFavorite` and `applyBatchArchive`.
+
+User benefit: chaining a follow-on action (e.g. Favorite-all then
+Unfavorite-all to test) and recovering from a wrong tap no longer requires
+re-selecting from scratch. With one icon that flips state in place after a
+tap, the swap is observable and the next tap is the reverse.
+
+**Delete still exits select mode.** Batch delete stages items to the
+batch-pending set and removes them from the list (greyed out); after the
+Snackbar resolves it confirms the delete. There is no productive
+"stay in mode" state for delete — the items are either on their way out or
+about to be restored via Undo, and re-acting on them in selection mode
+between those states would be confusing. Phase 3 behavior preserved.
+
+### 4.4 Auto-exit when selection becomes empty
+
+Add a rule: when `_multiSelectState.active` is true and the visible-bookmark
+intersection of `selectedIds` becomes empty, auto-exit select mode.
+
+This already partially happens via `dropSelectedIdsMissingFrom` — which
+prunes invisible IDs from `selectedIds`. Phase 4 just adds the explicit
+follow-on: if pruning leaves `selectedIds` empty, also flip `active = false`.
+
+Why it matters:
+
+- **Archive in My List** removes the selected items from the current view.
+  The `dropSelectedIdsMissingFrom` rule then empties the selection. Without
+  auto-exit, the bar would show "0 selected" with no actions visible — dead
+  state. Auto-exit cleans up.
+- **Unarchive in Archive view** — same dynamic.
+- **Filter/preset/label changes** already clear multi-select via separate
+  rules; this addition doesn't conflict.
+- **Favorite in My List** does not remove items from view; selection
+  remains non-empty; no exit.
+
+## 5. Snackbar Behavior
+
+Unchanged from Phase 3:
+
+- Plural-free flat copy via `action_batch_set_as_favorite` /
+  `action_batch_unset_as_favorite` / `action_batch_set_as_archived` /
+  `action_batch_unset_as_archived` with `%1$d` substitution, plus
+  `batch_delete_count` for Delete.
+- Undo button reverts exactly `changedIds` for favorite/archive, or the
+  batch-pending set for Delete.
+
+**New consequence to call out in the spec:** because the user can fire
+multiple actions in quick succession without leaving select mode, each new
+Snackbar dismisses the previous one (standard `SnackbarHostState` behavior).
+The Undo on a superseded Snackbar is lost. This matches Gmail's behavior and
+is acceptable — users who want a definitive reversal should tap Undo before
+acting again.
+
+## 6. Strings and Localization
+
+No new user-facing strings. All strings reused unchanged:
+
+- `action_add_to_favorites`, `action_remove_from_favorites`
+- `action_add_to_archive`, `action_remove_from_archive`
+- `action_delete`
+- `action_select_all`, `action_deselect_all`
+- `more_options`
+- The `action_batch_*_as_*` snackbar strings and `batch_delete_count`
+
+No locale-file edits required.
+
+## 7. Tests
+
+### ViewModel (`BookmarkListViewModelTest`)
+
+Update existing assertions to reflect stay-in-mode:
+
+- `onFavoriteSelectedBookmarks` test: assert selection **preserved** post
+  action (was: `MultiSelectState()` empty).
+- `onUnfavoriteSelectedBookmarks` test: same.
+- `onArchiveSelectedBookmarks` test: same.
+- `onUnarchiveSelectedBookmarks` test: same.
+- Snackbar event + `changedIds` assertions stay valid.
+- Add: auto-exit when post-action visible intersection is empty (simulate
+  the `bookmarkRepository` flow dropping the selected items after archive in
+  My List, advance, assert `active = false` and `selectedIds` empty).
+
+Existing Delete tests: no change. Delete still clears selection / exits mode
+as part of the batch-pending staging.
+
+### Compose / UI
+
+- In select mode with selection present, the bar contains: X, "N selected"
+  title, Archive icon, Favorite icon, Overflow. **No bar Delete icon.**
+- In select mode with no selection, the bar contains: X, "0 selected", just
+  the Overflow (no Archive, no Favorite).
+- Overflow with selection: Delete, Select all / Deselect all (in that
+  order, no opposite-action entries).
+- Overflow without selection: only Select all.
+- Tapping the bar's Favorite icon when not all are favorited: the action
+  fires, the bar's Favorite icon switches to the Outlined variant, the
+  selection remains intact, Snackbar appears.
+- Tapping the bar's Favorite icon a second time (now Outlined) reverses
+  the action with selection still intact.
+- Tapping Delete in the overflow: select mode exits (per Phase 3 batch
+  delete staging).
+- Auto-exit: when post-action item removal empties the selection, select
+  mode exits.
+
+`BookmarkCardSelectionTest`: unchanged (per-card dimmed indicators don't
+move).
+
+## 8. Migration Notes
+
+Files affected:
+
+- `app/src/main/java/com/mydeck/app/ui/list/BookmarkListViewModel.kt` —
+  remove `clearMultiSelectState()` from `applyBatchFavorite` and
+  `applyBatchArchive`; extend the post-`dropSelectedIdsMissingFrom` check
+  to also flip `active = false` when the resulting set is empty (one
+  small helper or inline `update {}` block).
+- `app/src/main/java/com/mydeck/app/ui/list/BookmarkListScreen.kt` —
+  reorder the bar actions (Archive before Favorite); delete the bar's
+  Delete `IconButton`; remove the favorite/archive opposite-action
+  `DropdownMenuItem` blocks from the overflow; add a new Delete
+  `DropdownMenuItem` to the overflow (above Select all).
+- `app/src/test/java/com/mydeck/app/ui/list/BookmarkListViewModelTest.kt`
+  — flip selection-preservation assertions, add auto-exit-on-empty test.
+
+No string, locale, layout, or schema changes.
+
+## 9. User Guide Updates
+
+Update English guide passages that describe the selection-mode bar:
+
+- `app/src/main/assets/guide/en/your-bookmarks.md` — selection-mode section:
+  describe the new bar order (Archive, Favorite, Overflow), note that
+  Delete now lives in the overflow, and document the stay-in-mode behavior
+  ("Tap Archive or Favorite as many times as you need — you stay in
+  selection mode until you tap X or until all your selected items leave
+  the list").
+- `app/src/main/assets/guide/en/organizing.md` — Favorites and Archive
+  sections: keep the contextual-icon explanation (the icon swap is what
+  remains the user-visible behavior), drop references to the "overflow
+  holds the opposite action" pattern.
+
+## 10. Phase 5 Forward-Pointer
+
+Phase 5 will add **batch label assignment** as a new overflow item placed
+between Delete and Select all (per the order in §4.2). That spec is
+maintained separately; it covers reusing the existing per-card
+`LabelsBottomSheet` against a batch ID set. Phase 4 reserves the slot but
+does not ship a placeholder/stub item — the slot is purely a documented
+ordering decision, not a UI element to render now.
+
+## 11. Verification
+
+Standard:
+
+```sh
+./gradlew :app:assembleDebugAll
+./gradlew :app:testDebugUnitTestAll
+./gradlew :app:lintDebugAll
+```
+
+Manual on-device (Pixel 9, `./scripts/install-phone.sh`):
+
+1. Enter select mode, select 3 items (mixed favorite state). Bar shows
+   Archive then Favorite, plus Overflow. Tap Favorite → all 3 become
+   favorited, Favorite icon swaps to Outlined, **selection preserved**,
+   Snackbar appears.
+2. Tap (now-Outlined) Favorite again → all 3 unfavorited, icon swaps back
+   to Filled, selection still preserved, new Snackbar.
+3. Tap Archive → items leave My List view, selection auto-empties,
+   **select mode auto-exits**, Snackbar with Undo appears.
+4. Open overflow → only **Delete** and **Select all** are listed (no
+   favorite/archive opposite entries).
+5. Tap Delete in overflow → items grey out, select mode exits, Snackbar
+   with Undo appears (Phase 3 behavior preserved).
+
+## 12. Open Decisions
+
+None blocking. Considered and resolved during spec drafting:
+
+- **Bottom action bar instead of top CAB**: no (out of scope per §2).
+- **Delete on bar vs in overflow**: overflow (destructive + lower
+  frequency).
+- **Select all in overflow vs on bar**: overflow (lowest-frequency
+  meta-action, fine at bottom of overflow).
+- **Label slot rendered now as disabled placeholder**: no (no dead UI;
+  reserved only as ordering decision).
+- **Auto-exit when selection empties**: yes (avoids dead "0 selected"
+  state).
+- **Stay-in-mode for Delete**: no (Phase 3 batch staging + Undo flow
+  doesn't benefit from staying in selection between stage and confirm).

--- a/docs/specs/list-top-app-bar-overflow-spec.md
+++ b/docs/specs/list-top-app-bar-overflow-spec.md
@@ -1,8 +1,8 @@
 # List View Top App Bar — Overflow Refactor Specification
 
-Status: Draft for Phase 3 implementation. Depends on multi-select Phase 1
-follow-up landing first (`feat/multi-select-phase-1`) since that branch
-introduces the selection-mode app bar that this spec leaves untouched.
+Status: Implemented on `feat/multi-select-phase-1` (alongside multi-select
+Phase 3). The selection-mode app bar introduced on that branch is left
+untouched, as specified.
 
 Date: 2026-06-01
 

--- a/docs/specs/list-top-app-bar-overflow-spec.md
+++ b/docs/specs/list-top-app-bar-overflow-spec.md
@@ -1,0 +1,209 @@
+# List View Top App Bar — Overflow Refactor Specification
+
+Status: Draft for Phase 3 implementation. Depends on multi-select Phase 1
+follow-up landing first (`feat/multi-select-phase-1`) since that branch
+introduces the selection-mode app bar that this spec leaves untouched.
+
+Date: 2026-06-01
+
+## 1. Purpose
+
+Reduce action-icon density in the bookmark-list top app bar by consolidating
+infrequent actions into a 3-dot overflow menu, while keeping the highest-value
+controls one tap away. Resolve the current label-mode UX gap where the
+multi-select entry icon sits awkwardly to the right of the overflow.
+
+Out of scope:
+
+- Anything inside selection-mode (the multi-select spec governs that bar).
+- Search surfacing changes (Search currently lives only inside the Filter
+  sheet; this spec does not promote it).
+
+## 2. Current State
+
+Normal-mode bar (non-label), left to right after the drawer hamburger and
+title:
+
+1. **Layout** — `Icons.Filled.Apps` / `Icons.AutoMirrored.Filled.List` /
+   `Icons.Filled.GridView` (icon reflects current mode). Opens a 3-item
+   dropdown.
+2. **Sort** — `Icons.Filled.SwapVert`. Opens a per-category dropdown with
+   direction arrows.
+3. **Filter** — `Icons.Filled.FilterList`. Opens the `FilterBottomSheet`.
+4. **Multi-select** — `Icons.Filled.RadioButtonUnchecked`. Enters
+   selection mode.
+
+Label-mode variation:
+
+- Filter is replaced by a 3-dot **Overflow** containing Rename label /
+  Delete label.
+- Multi-select **stays to the right of** the overflow icon, producing the
+  unusual sequence Layout / Sort / Overflow / Multi-select. This is the
+  current design gap.
+
+## 3. Target Design
+
+Normal-mode bar (non-label):
+
+1. **Layout** — unchanged position, icon, behavior.
+2. **Sort** — unchanged position, icon, behavior.
+3. **Overflow** (`Icons.Filled.MoreVert`) — new in this position. Contains:
+   - **Filter** (`Icons.Filled.FilterList`) — opens `FilterBottomSheet`.
+   - **Select bookmarks** (`Icons.Filled.RadioButtonUnchecked`) — enters
+     multi-select mode.
+
+Label-mode variation:
+
+1. **Layout** — unchanged.
+2. **Sort** — unchanged.
+3. **Overflow** (`Icons.Filled.MoreVert`) — contents in this order:
+   - **Rename label** (icon: `Icons.Outlined.Edit` — see §6).
+   - **Delete label** (icon: `Icons.Outlined.Delete` — see §6).
+   - Visual divider.
+   - **Select bookmarks** (`Icons.Filled.RadioButtonUnchecked`).
+   - (No Filter item — label is itself the filter; matches current behavior
+     of hiding Filter in label mode.)
+
+The bar shape is identical between normal and label modes: drawer hamburger,
+title, Layout, Sort, Overflow. Only the overflow contents differ. The
+"multi-select-to-the-right-of-overflow" anti-pattern is eliminated.
+
+## 4. Why These Choices
+
+- **Layout and Sort stay on the bar** because their dropdowns make them
+  effectively two-tap actions even from the bar, so any extra wrapping (e.g.
+  Overflow → Layout → option) would be three taps for a routine choice.
+  Their icons also reflect current state (current layout glyph, current sort
+  direction arrow), so the bar slot doubles as a status indicator.
+- **Filter moves to overflow** despite being a high-frequency action because
+  it is two taps regardless of placement (the FilterBottomSheet is the second
+  tap) and because the `FilterBar` chip surface below the app bar already
+  surfaces the active filter state and provides a path to reopen the sheet
+  by tapping a chip. Consolidating it into the overflow trades one tap of
+  bar prominence for visual calm in the bar's steady state.
+- **Multi-select moves to overflow** because (a) it is a
+  low-to-medium-frequency action that does not need permanent bar real
+  estate, and (b) long-press entry to selection mode is unavailable in
+  MyDeck (long-press is already bound to the per-card context menu, mirroring
+  Readeck). The overflow placement becomes the discoverable secondary entry
+  rather than a primary affordance.
+- **Rename / Delete label move to the top of the overflow** in label mode
+  because they are label-scope actions and conceptually outrank generic list
+  actions. Putting them above a divider, with Multi-select below, mirrors
+  Android's "primary/destructive item, then list-scoped items" grouping
+  pattern.
+
+## 5. Behavioral Notes
+
+- The overflow icon (`MoreVert`) is **always present** in both modes. This
+  is a deliberate change from the current behavior, where the overflow
+  appears only in label mode. Always-present keeps bar shape stable.
+- Filter is **hidden in label mode** (unchanged behavior; the label acts as
+  the filter).
+- Existing `FilterBar` chip surface below the app bar is unaffected by this
+  refactor. Chips remain the visible state of active filters and the
+  one-tap-to-edit affordance.
+- The selection-mode bar (X / count / favorite / archive / overflow) is
+  governed by `list-multi-select-actions-spec.md`. This spec leaves it
+  unchanged. The selection-mode overflow uses the same `MoreVert` icon —
+  unifying the two overflow surfaces visually.
+- Drawer hamburger position and behavior unchanged.
+
+## 6. Icons for Rename / Delete Label
+
+The Rename and Delete label items in label-mode overflow currently render
+text-only — they have no leading icons. This is a current gap relative to
+MD3 convention. This spec adopts:
+
+- **Rename label** — `Icons.Outlined.Edit` (already imported elsewhere in
+  the screen).
+- **Delete label** — `Icons.Outlined.Delete` (already imported via the
+  card delete path; verify in the import block before adding).
+
+Both leading icons render with `contentDescription = null` since the item's
+text label is the accessible label.
+
+## 7. Strings and Localization
+
+No new user-facing strings are introduced by this refactor. All actions
+already have localized strings:
+
+- `action_select_bookmarks` — used unchanged for the new overflow item.
+- `filter_bookmarks` — used unchanged for the new overflow item.
+- `rename_label`, `delete_label` — used unchanged.
+- `more_options` — used for the overflow icon's contentDescription
+  (already used in the selection-mode overflow added in Phase 1
+  follow-up).
+
+No locale-file edits are required.
+
+## 8. Tests
+
+ViewModel:
+
+- No new ViewModel surface — purely a UI reshuffle. Existing
+  `onOpenFilterSheet`, `onEnterMultiSelectMode`, `onRenameLabel`,
+  `onDeleteLabel` paths are reused. No ViewModel test changes required.
+
+Compose / UI:
+
+- In normal (non-label) mode the bar contains exactly Layout, Sort,
+  Overflow (in that order, after the navigation icon and title).
+- In normal mode, the overflow menu contains Filter and Select bookmarks,
+  in that order.
+- In label mode the bar contains exactly Layout, Sort, Overflow.
+- In label mode, the overflow menu contains Rename label, Delete label,
+  Select bookmarks (with a divider between the label-scoped items and the
+  list-scoped item).
+- Tapping the overflow Filter item opens `FilterBottomSheet`.
+- Tapping the overflow Select bookmarks item enters multi-select mode.
+- The selection-mode bar is unaffected and matches the multi-select spec.
+
+## 9. Migration Notes
+
+- This refactor lands on its own branch (Phase 3) and replaces the
+  normal-mode `Filter` icon and `Multi-select` icon in
+  `BookmarkListScreen.kt`. The corresponding icon imports
+  (`Icons.Filled.FilterList`, `Icons.Filled.RadioButtonUnchecked`) move
+  inline into the overflow `DropdownMenuItem` blocks; they remain imported.
+- The existing label-mode `Box { IconButton + DropdownMenu }` block becomes
+  the **only** overflow block in the screen, parameterized by mode rather
+  than duplicated. The current "Filter button (non-label mode only)" branch
+  and the trailing always-on Multi-select `IconButton` block are deleted.
+- Update the user guide (`your-bookmarks.md`) sections that describe the bar
+  in normal/label modes to reflect the new shape.
+- No data, schema, or settings changes.
+
+## 10. Verification
+
+Run the standard verification tasks:
+
+```sh
+./gradlew :app:assembleDebugAll
+./gradlew :app:testDebugUnitTestAll
+./gradlew :app:lintDebugAll
+```
+
+Manual on-device sanity (Pixel 9):
+
+- Phone portrait, normal mode → bar shows Layout, Sort, Overflow only.
+- Tap overflow → Filter and Select bookmarks listed.
+- Open a label from the drawer → bar shape unchanged; overflow now shows
+  Rename, Delete, divider, Select bookmarks. Verify icons render on the
+  Rename and Delete items.
+- Enter and exit selection mode from the overflow — verify selection-mode
+  bar replaces the normal bar and exits cleanly to the new bar shape.
+
+## 11. Open Decisions
+
+None blocking. Considered and resolved:
+
+- Whether to put Layout in the overflow → no; submenu cost + status-icon
+  value justify the bar slot.
+- Whether Filter belongs in the overflow → yes; FilterBar chips compensate
+  for the lost bar prominence.
+- Whether long-press should be the primary multi-select entry → no;
+  long-press is already bound to per-card context (mirrors Readeck). The
+  overflow entry is the discoverable secondary affordance.
+- Whether the overflow should appear only when it has more than one item →
+  no; always-present overflow keeps bar shape stable across mode changes.


### PR DESCRIPTION
## Summary

Adds full multi-select mode to the bookmark list and reworks the list top app bar into an overflow menu. Covers selection, batch favorite/archive/delete, batch add-labels, and the bar consolidation — the complete multi-select scope.

## What's included

**Multi-select mode**
- Enter selection mode from the top-bar overflow; tap cards to select. Selection-mode bar shows **X / count / Archive / Favorite / Overflow**; the overflow holds **Delete**, **Add labels**, and **Select All / Deselect All**.
- **Select All** toggles selection across the full filtered list.
- **Single context-aware action icons.** Favorite and Archive each show one icon reflecting what the tap will do across the whole selection: if every selected item is already favorited/archived the icon is the "remove" variant (and the tap removes for all); otherwise it's the "add" variant. Writes skip no-op items.
- Favorite, Archive, and Add labels **keep the selection active** so several actions can run in a row; selection mode **auto-exits** when an action leaves nothing selected.
- In selection mode, each card's favorite/archive icons stay **visible but dimmed** (~38% alpha) as non-interactive state indicators.

**Batch add labels**
- Additive "Add labels" applies one or more labels (union per bookmark) to the whole selection via the existing label picker and `UPDATE_LABELS` sync path. Bookmarks already carrying all chosen labels are skipped. Snackbar confirms with an Undo that restores prior labels. (Batch *removing* labels is out of scope.)

**Batch delete + Undo**
- Delete stages items optimistically (no DB write), exits selection mode, and surfaces a Snackbar with Undo.
- A single Snackbar + Undo is the confirmation surface for **all** multi-select changes — delete, favorite/archive, and add-labels. Undo reverts only the items actually changed (`changedIds`); delete uses `Indefinite` duration, the reversible actions use `Long`.
- Repository `deleteBookmarks(ids)` performs one transaction (soft-delete + clear stale pending actions + one DELETE pending action per id) and schedules sync **once**. Batch-pending delete state is kept separate from single-item delete so confirm/cancel is atomic.

**Top app bar overflow refactor**
- Normal mode: Layout / Sort / always-present `MoreVert` overflow (Filter + Select bookmarks).
- Label mode: same bar shape; overflow holds Rename label / Delete label / divider / Select bookmarks. Eliminates the previous "multi-select icon to the right of the overflow" gap.

**Docs / conventions**
- New specs `list-top-app-bar-overflow-spec.md` and `list-multi-select-phase-4-spec.md`; `list-multi-select-actions-spec.md` updated (Snackbar+Undo confirmation, no settings toggle). User guide (`your-bookmarks.md`, `organizing.md`) updated.
- Snackbar copy uses flat strings across all 10 locales (no `<plurals>`), per project convention.
- CLAUDE.md: added "copyable deliverables as raw markdown" instruction (unrelated housekeeping carried on this branch).

## Out of scope
- A settings-level confirmation toggle (dropped — the Snackbar+Undo supersedes it).
- Batch *removing* labels.

## Test plan
- [x] `./gradlew :app:assembleDebugAll`
- [x] `./gradlew :app:testDebugUnitTestAll`
- [x] `./gradlew :app:lintDebugAll`
- [x] On-device (Pixel 9): select/deselect, Select All, batch favorite/archive (context-aware icon + keep-selection + auto-exit), dimmed card icons, batch add-labels + Undo, batch delete + Undo, normal- and label-mode overflow contents.
