### PR TITLE
Add yellow corner badge to snapshot launcher icons



### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -182,6 +182,8 @@ android {
 
     sourceSets {
         getByName("debug").assets.srcDirs(files("$projectDir/schemas"))
+        getByName("githubSnapshot").res.srcDir("src/snapshotShared/res")
+        getByName("githubSnapshotHttp").res.srcDir("src/snapshotShared/res")
     }
 
     lint {

--- a/app/src/snapshotShared/res/drawable/ic_launcher_badge_snapshot.xml
+++ b/app/src/snapshotShared/res/drawable/ic_launcher_badge_snapshot.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="36dp"
+    android:height="36dp"
+    android:viewportWidth="36"
+    android:viewportHeight="36">
+    <path
+        android:fillColor="@color/ic_launcher_badge_snapshot_stroke"
+        android:pathData="M18,0 a18,18 0 1,0 0,36 a18,18 0 1,0 0,-36 Z" />
+    <path
+        android:fillColor="@color/ic_launcher_badge_snapshot_fill"
+        android:pathData="M18,2 a16,16 0 1,0 0,32 a16,16 0 1,0 0,-32 Z" />
+</vector>

--- a/app/src/snapshotShared/res/drawable/ic_launcher_foreground_snapshot.xml
+++ b/app/src/snapshotShared/res/drawable/ic_launcher_foreground_snapshot.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@mipmap/ic_launcher_foreground" />
+    <item
+        android:gravity="bottom|end"
+        android:bottom="27dp"
+        android:right="27dp"
+        android:width="18dp"
+        android:height="18dp"
+        android:drawable="@drawable/ic_launcher_badge_snapshot" />
+</layer-list>

--- a/app/src/snapshotShared/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/snapshotShared/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground_snapshot" />
+</adaptive-icon>

--- a/app/src/snapshotShared/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/snapshotShared/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground_snapshot" />
+</adaptive-icon>

--- a/app/src/snapshotShared/res/values/colors.xml
+++ b/app/src/snapshotShared/res/values/colors.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="ic_launcher_badge_snapshot_fill">#FFEB3B</color>
+    <color name="ic_launcher_badge_snapshot_stroke">#1A1A1A</color>
+</resources>

--- a/docs/specs/launcher-build-variant-icon-badges-spec.md
+++ b/docs/specs/launcher-build-variant-icon-badges-spec.md
@@ -2,8 +2,9 @@
 
 ## Status
 
-Draft. Keep untracked until the native reader footer branch is merged and this
-work is ready to branch from `main`.
+Implemented on branch `feat/launcher-snapshot-badge` (commit `dc54313f`).
+First pass covers adaptive icons only; legacy density fallbacks for
+API 24-25 deferred.
 
 ## Context
 
@@ -69,24 +70,33 @@ as text inside the icon.
 
 ## Resource Strategy
 
-### Minimal snapshot-only version
+### Shared snapshot source set (as implemented)
 
-Add adaptive icon overrides for snapshot flavors:
+To avoid duplicating badge assets in both snapshot flavor dirs, the resources
+live in a single shared source set wired into both `githubSnapshot` and
+`githubSnapshotHttp` via `sourceSets`:
 
-```text
-app/src/githubSnapshot/res/mipmap-anydpi-v26/ic_launcher.xml
-app/src/githubSnapshot/res/mipmap-anydpi-v26/ic_launcher_round.xml
-app/src/githubSnapshot/res/drawable/ic_launcher_foreground_snapshot.xml
-app/src/githubSnapshot/res/drawable/ic_launcher_badge_snapshot.xml
-
-app/src/githubSnapshotHttp/res/mipmap-anydpi-v26/ic_launcher.xml
-app/src/githubSnapshotHttp/res/mipmap-anydpi-v26/ic_launcher_round.xml
-app/src/githubSnapshotHttp/res/drawable/ic_launcher_foreground_snapshot.xml
-app/src/githubSnapshotHttp/res/drawable/ic_launcher_badge_snapshot.xml
+```kotlin
+// app/build.gradle.kts
+sourceSets {
+    getByName("debug").assets.srcDirs(files("$projectDir/schemas"))
+    getByName("githubSnapshot").res.srcDir("src/snapshotShared/res")
+    getByName("githubSnapshotHttp").res.srcDir("src/snapshotShared/res")
+}
 ```
 
-The snapshot adaptive icon XML can keep the existing background and swap only
-the foreground:
+Files:
+
+```text
+app/src/snapshotShared/res/values/colors.xml
+app/src/snapshotShared/res/drawable/ic_launcher_badge_snapshot.xml
+app/src/snapshotShared/res/drawable/ic_launcher_foreground_snapshot.xml
+app/src/snapshotShared/res/mipmap-anydpi-v26/ic_launcher.xml
+app/src/snapshotShared/res/mipmap-anydpi-v26/ic_launcher_round.xml
+```
+
+The snapshot adaptive icon XML keeps the existing background and swaps only the
+foreground:
 
 ```xml
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
@@ -95,25 +105,30 @@ the foreground:
 </adaptive-icon>
 ```
 
-`ic_launcher_foreground_snapshot.xml` can be a layer-list that combines the
-existing foreground with a badge drawable:
+`ic_launcher_foreground_snapshot.xml` is a layer-list combining the existing
+foreground with the badge drawable:
 
 ```xml
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:drawable="@mipmap/ic_launcher_foreground" />
     <item
-        android:bottom="12dp"
-        android:drawable="@drawable/ic_launcher_badge_snapshot"
         android:gravity="bottom|end"
-        android:right="12dp"
-        android:width="36dp"
-        android:height="36dp" />
+        android:bottom="27dp"
+        android:right="27dp"
+        android:width="18dp"
+        android:height="18dp"
+        android:drawable="@drawable/ic_launcher_badge_snapshot" />
 </layer-list>
 ```
 
-This keeps the base asset shared and makes the badge easy to inspect in review.
-Before implementing, verify the layer-list renders correctly inside adaptive
-icons on API 26+ and through Android Studio's Image Asset preview.
+The badge is a small yellow (`#FFEB3B`) filled circle with a thin dark
+(`#1A1A1A`) stroke, sized 18dp at 27dp insets so its center sits at (72, 72)
+on the 108dp adaptive canvas and the whole shape stays inside the 66dp safe
+zone across all launcher mask shapes.
+
+The original 36dp/12dp sizing from the initial draft was too large in
+on-device review; halving to 18dp and re-centering on the same point
+produced a cleaner notification-dot read at launcher icon size.
 
 ### Legacy fallback assets
 
@@ -161,11 +176,18 @@ downloads or nonstandard local tools.
    - `./gradlew :app:testDebugUnitTestAll`
    - `./gradlew :app:lintDebugAll`
 
-## Open Questions
+## Resolved Decisions
 
-- Should `githubSnapshotHttp` use exactly the same snapshot badge as
-  `githubSnapshot`, relying on the app label for HTTP?
-- Should API 24-25 fallback icons be badged in the first pass?
-- Should debug builds get a visual treatment, or is snapshot/release enough?
-- What badge color best contrasts with the current icon while still fitting
-  MyDeck's visual identity?
+- **Shared badge across both snapshot flavors.** `githubSnapshotHttp` uses the
+  same badge as `githubSnapshot`; the app label disambiguates HTTP. Enforced
+  structurally via the shared `snapshotShared/res` source set, so the two
+  flavors cannot drift.
+- **API 24-25 fallbacks deferred.** Legacy density `mipmap-*/ic_launcher.webp`
+  overrides not added in the first pass. Current testing targets (Pixel 9) do
+  not need them. Revisit if older devices enter the testing rotation.
+- **No separate debug treatment.** Snapshot vs release is the meaningful
+  visual distinction; adding a debug badge would be noise.
+- **Badge color: yellow `#FFEB3B`.** High contrast against the deep teal
+  (`#1E5F5E`) background, no overlap with the existing icon palette. A thin
+  `#1A1A1A` stroke keeps it legible against light wallpapers and themed-icon
+  surfaces.

--- a/docs/specs/launcher-build-variant-icon-badges-spec.md
+++ b/docs/specs/launcher-build-variant-icon-badges-spec.md
@@ -1,0 +1,171 @@
+# Mini Spec: Launcher Build Variant Icon Badges
+
+## Status
+
+Draft. Keep untracked until the native reader footer branch is merged and this
+work is ready to branch from `main`.
+
+## Context
+
+MyDeck currently uses one launcher icon resource for every build:
+
+- Manifest: `android:icon="@mipmap/ic_launcher"`
+- Adaptive icon XML:
+  - `app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml`
+  - `app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml`
+- Density fallback assets:
+  - `app/src/main/res/mipmap-*/ic_launcher.webp`
+  - `app/src/main/res/mipmap-*/ic_launcher_round.webp`
+
+The build already has four product flavors:
+
+- `githubRelease` - label `MyDeck`
+- `githubReleaseHttp` - label `MyDeck HTTP`
+- `githubSnapshot` - label `MyDeck Snapshot`
+- `githubSnapshotHttp` - label `MyDeck HTTP Snapshot`
+
+The labels and application IDs distinguish installed variants in settings and
+app info, but the launcher grid can still show visually similar icons. The main
+need is to make snapshot builds distinguishable from release builds at a glance.
+
+## Goals
+
+- Keep the release icon unchanged.
+- Make snapshot builds visually distinct in the Android launcher.
+- Prefer a design that remains legible at launcher icon size.
+- Avoid runtime code. Launcher icons are build-time resources.
+- Keep the first implementation small and reviewable.
+
+## Non-goals
+
+- Rebranding the base MyDeck icon.
+- Changing notification small icons.
+- Changing app labels, package names, signing, or update behavior.
+- Building a full icon-generation pipeline unless multiple combined overlays
+  become necessary.
+
+## Recommendation
+
+Start with source-set resource overrides for snapshot flavors only:
+
+- `app/src/githubSnapshot/res/...`
+- `app/src/githubSnapshotHttp/res/...`
+
+Use the same resource names as `main` so Android resource merging selects the
+snapshot icon automatically for snapshot variants. This avoids manifest or
+Gradle logic for the first version.
+
+The snapshot visual treatment should be simple:
+
+- Add a filled corner badge, dot, or ribbon.
+- Use one high-contrast color that is not part of the normal release icon.
+- Avoid small text such as `SNAPSHOT`; it will not read reliably.
+- A single large `S` is possible, but a shape/color cue is more robust.
+
+HTTP-specific icon treatment should be deferred unless testing shows the label
+alone is not enough. If added later, use a second broad cue such as a different
+badge color or background treatment. Avoid encoding both `SNAPSHOT` and `HTTP`
+as text inside the icon.
+
+## Resource Strategy
+
+### Minimal snapshot-only version
+
+Add adaptive icon overrides for snapshot flavors:
+
+```text
+app/src/githubSnapshot/res/mipmap-anydpi-v26/ic_launcher.xml
+app/src/githubSnapshot/res/mipmap-anydpi-v26/ic_launcher_round.xml
+app/src/githubSnapshot/res/drawable/ic_launcher_foreground_snapshot.xml
+app/src/githubSnapshot/res/drawable/ic_launcher_badge_snapshot.xml
+
+app/src/githubSnapshotHttp/res/mipmap-anydpi-v26/ic_launcher.xml
+app/src/githubSnapshotHttp/res/mipmap-anydpi-v26/ic_launcher_round.xml
+app/src/githubSnapshotHttp/res/drawable/ic_launcher_foreground_snapshot.xml
+app/src/githubSnapshotHttp/res/drawable/ic_launcher_badge_snapshot.xml
+```
+
+The snapshot adaptive icon XML can keep the existing background and swap only
+the foreground:
+
+```xml
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground_snapshot" />
+</adaptive-icon>
+```
+
+`ic_launcher_foreground_snapshot.xml` can be a layer-list that combines the
+existing foreground with a badge drawable:
+
+```xml
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@mipmap/ic_launcher_foreground" />
+    <item
+        android:bottom="12dp"
+        android:drawable="@drawable/ic_launcher_badge_snapshot"
+        android:gravity="bottom|end"
+        android:right="12dp"
+        android:width="36dp"
+        android:height="36dp" />
+</layer-list>
+```
+
+This keeps the base asset shared and makes the badge easy to inspect in review.
+Before implementing, verify the layer-list renders correctly inside adaptive
+icons on API 26+ and through Android Studio's Image Asset preview.
+
+### Legacy fallback assets
+
+MyDeck has `minSdk = 24`, so API 24-25 devices use the density-specific legacy
+launcher assets instead of adaptive icons. There are two reasonable options:
+
+- Generate snapshot `mipmap-*/ic_launcher.webp` and
+  `mipmap-*/ic_launcher_round.webp` assets for complete API 24-25 coverage.
+- Accept that API 24-25 launcher icons remain unbadged in the first pass.
+
+Given current device targets, complete fallback coverage is better but not
+strictly required for the Pixel 9/manual snapshot testing path.
+
+## Optional Future: Generated Icons
+
+If MyDeck later needs separate visual states for `snapshot`, `http`, and
+`debug`, hand-maintaining every combination will get noisy. At that point, add
+a small checked-in script or Gradle task that generates icon assets from:
+
+- the base release icon,
+- a snapshot badge definition,
+- an HTTP badge/background definition,
+- an optional debug badge definition.
+
+Generated assets should be deterministic and committed, or generated as part of
+the build with clear verification. Do not make the build depend on network
+downloads or nonstandard local tools.
+
+## Implementation Outline
+
+1. Branch from freshly pulled `main`.
+2. Choose final snapshot badge shape and color.
+3. Add snapshot flavor resource overrides.
+4. If supporting API 24-25 fully, add matching density fallback assets.
+5. Build at least:
+   - `./gradlew :app:assembleGithubSnapshotDebug`
+   - `./gradlew :app:assembleGithubReleaseDebug`
+6. Inspect APK resources or install both variants and verify:
+   - release launcher icon is unchanged,
+   - snapshot launcher icon has the badge,
+   - HTTP snapshot uses the intended treatment,
+   - notification small icon is unchanged.
+7. Run normal UI/resource verification:
+   - `./gradlew :app:assembleDebugAll`
+   - `./gradlew :app:testDebugUnitTestAll`
+   - `./gradlew :app:lintDebugAll`
+
+## Open Questions
+
+- Should `githubSnapshotHttp` use exactly the same snapshot badge as
+  `githubSnapshot`, relying on the app label for HTTP?
+- Should API 24-25 fallback icons be badged in the first pass?
+- Should debug builds get a visual treatment, or is snapshot/release enough?
+- What badge color best contrasts with the current icon while still fitting
+  MyDeck's visual identity?


### PR DESCRIPTION
Distinguishes githubSnapshot and githubSnapshotHttp builds from release
variants at a glance on the launcher. Both snapshot flavors share a
single resource set via src/snapshotShared/res wired in through
sourceSets, so the badge is defined once. The release icon is untouched.

The badge is a small yellow filled circle with a thin dark stroke,
positioned in the bottom-right corner of the adaptive-icon foreground
inside the 66dp safe zone so it stays fully visible across launcher
mask shapes.

