### PR TITLE
chore(release): bump version to 0.14.2

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,8 +30,8 @@ android {
         applicationId = "com.mydeck.app"
         minSdk = 24
         targetSdk = 35
-        versionCode = 14001
-        versionName = "0.14.1"
+        versionCode = 14002
+        versionName = "0.14.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/metadata/en-US/changelogs/14002.txt
+++ b/metadata/en-US/changelogs/14002.txt
@@ -1,0 +1,11 @@
+<b>Added</b>
+- Offline pinning: pin articles to keep them offline and protected from cleanup, from multi-select or the reader menu
+
+<b>Changed</b>
+- More reliable, complete offline downloads with images; opened articles become managed content you can pin to keep
+- Offline content sync now shows a notification
+
+<b>Fixed</b>
+- Added articles now download with their images
+- "Clear All Offline Content" now clears everything
+- More reliable sync on flaky networks; no duplicate bookmarks


### PR DESCRIPTION
Release v0.14.2: offline content rework + Offline Pinning (Pin/Unpin), merged in #203.

Bumps versionCode 14001 -> 14002 / versionName 0.14.2 and adds the release changelog (metadata/en-US/changelogs/14002.txt).