### PR TITLE
Fix: "With errors" filter + error/no-content card badges

### DIFF
--- a/app/src/main/assets/guide/en/your-bookmarks.md
+++ b/app/src/main/assets/guide/en/your-bookmarks.md
@@ -83,7 +83,12 @@ All three layouts show whether a bookmark's content has been downloaded for offl
 - **Filled download icon** — the bookmark is fully available offline, downloaded automatically by your offline settings
 - **Filled download icon in a highlight colour** — the bookmark is fully available offline because you saved it yourself (by opening it while offline reading is on); these hand-picked items are kept and aren't removed by routine offline maintenance
 
-In **Grid** and **Compact** layouts, the download icon appears on the site-info row, next to the site name and reading time. In **Mosaic** layout, it appears on the title row near the top-right area of the card.
+The same slot also surfaces two status badges, which take priority over the download icon:
+
+- **Error icon** — your Readeck server reported a problem with this bookmark (for example, it couldn't extract the content). These are the same bookmarks matched by the **With errors** filter; open the bookmark to see the details. The badge appears once a metadata sync has run, without needing the content to be downloaded.
+- **Circle-slash icon** — there is no readable content to download; opening the card takes you to the original page.
+
+In **Grid** and **Compact** layouts, this icon appears on the site-info row, next to the site name and reading time. In **Mosaic** layout, it appears on the title row near the top-right area of the card.
 
 ## Card Actions
 

--- a/app/src/main/java/com/mydeck/app/domain/BookmarkRepository.kt
+++ b/app/src/main/java/com/mydeck/app/domain/BookmarkRepository.kt
@@ -42,6 +42,14 @@ interface BookmarkRepository {
 
     suspend fun insertBookmarks(bookmarks: List<Bookmark>)
     suspend fun replaceServerErrorFlags(bookmarkIds: Set<String>)
+
+    /**
+     * Fetch the set of bookmarks the server currently flags with extraction errors
+     * (`GET /bookmarks?has_errors=true`) and reconcile the local `hasServerErrors` flag — setting it
+     * on errored rows and clearing it on all others. The list summary never carries the `errors`
+     * array, so this dedicated query is the only way the metadata sync can populate the flag.
+     */
+    suspend fun refreshServerErrorFlags()
     suspend fun getBookmarkById(id: String): Bookmark
     fun observeBookmark(id: String): Flow<Bookmark?>
     suspend fun deleteAllBookmarks()

--- a/app/src/main/java/com/mydeck/app/domain/BookmarkRepositoryImpl.kt
+++ b/app/src/main/java/com/mydeck/app/domain/BookmarkRepositoryImpl.kt
@@ -62,6 +62,9 @@ import javax.inject.Inject
 // prior add is treated as the same add — effectively a rapid double-add, which is benign.
 private const val RECONCILE_SKEW_MARGIN_MS = 2 * 60_000L
 
+// Safety guard for the paginated has_errors=true scan in refreshServerErrorFlags().
+private const val MAX_ERROR_FLAG_PAGES = 1000
+
 class BookmarkRepositoryImpl @Inject constructor(
     private val database: MyDeckDatabase,
     private val bookmarkDao: BookmarkDao,
@@ -279,7 +282,9 @@ class BookmarkRepositoryImpl @Inject constructor(
             wordCount = wordCount,
             published = published?.toLocalDateTime(kotlinx.datetime.TimeZone.currentSystemDefault()),
             offlineState = deriveOfflineState(contentState, hasResources, source),
-            offlineEligible = deriveOfflineEligible(hasArticle, type, contentState)
+            offlineEligible = deriveOfflineEligible(hasArticle, type, contentState),
+            hasError = hasServerErrors || state == BookmarkEntity.State.ERROR,
+            hasNoContent = contentState == BookmarkEntity.ContentState.PERMANENT_NO_CONTENT
         )
 
     // Offline eligibility (pinnability) — same gate as LoadContentPackageUseCase: has article
@@ -396,6 +401,57 @@ class BookmarkRepositoryImpl @Inject constructor(
 
     override suspend fun replaceServerErrorFlags(bookmarkIds: Set<String>) {
         bookmarkDao.replaceServerErrorFlags(bookmarkIds.toList())
+    }
+
+    override suspend fun refreshServerErrorFlags() {
+        try {
+            val pageSize = 50
+            var offset = 0
+            var hasMorePages = true
+            var pagesFetched = 0
+            val serverErrorIds = mutableSetOf<String>()
+
+            while (hasMorePages) {
+                if (pagesFetched >= MAX_ERROR_FLAG_PAGES) {
+                    Timber.w("refreshServerErrorFlags: reached MAX_ERROR_FLAG_PAGES=$MAX_ERROR_FLAG_PAGES guard; aborting")
+                    break
+                }
+                val response = readeckApi.getBookmarks(
+                    limit = pageSize,
+                    offset = offset,
+                    updatedSince = null,
+                    sortOrder = ReadeckApi.SortOrder(ReadeckApi.Sort.Created),
+                    hasErrors = true
+                )
+
+                if (!response.isSuccessful || response.body() == null) {
+                    Timber.w("Skipping server error flag refresh: [code=${response.code()}]")
+                    return
+                }
+
+                serverErrorIds += (response.body() ?: emptyList()).map { it.id }
+                pagesFetched++
+
+                val totalPagesHeader = response.headers()[ReadeckApi.Header.TOTAL_PAGES]
+                val currentPageHeader = response.headers()[ReadeckApi.Header.CURRENT_PAGE]
+                if (totalPagesHeader == null || currentPageHeader == null) {
+                    Timber.w("Skipping server error flag refresh due to missing pagination headers")
+                    return
+                }
+
+                if (currentPageHeader.toInt() < totalPagesHeader.toInt()) {
+                    offset += pageSize
+                } else {
+                    hasMorePages = false
+                }
+            }
+
+            replaceServerErrorFlags(serverErrorIds)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.w(e, "Failed to refresh server error flags")
+        }
     }
 
     override suspend fun getBookmarkById(id: String): Bookmark {
@@ -942,6 +998,12 @@ class BookmarkRepositoryImpl @Inject constructor(
 
             val deleted = bookmarkDao.removeDeletedBookmars(syncRunId)
             Timber.i("Deleted bookmarks: $deleted")
+
+            // The list summary never carries the errors array, so full sync alone leaves
+            // hasServerErrors=false on every row. Reconcile it from the dedicated has_errors query
+            // here so a fresh install / periodic full sync flags errored bookmarks without needing a
+            // content download. Failures are swallowed internally and never fail the sync.
+            refreshServerErrorFlags()
 
             Timber.i("Full sync complete: inserted $totalInserted bookmarks, deleted $deleted")
             BookmarkRepository.SyncResult.Success(countDeleted = deleted, countUpdated = totalInserted)

--- a/app/src/main/java/com/mydeck/app/domain/model/BookmarkListItem.kt
+++ b/app/src/main/java/com/mydeck/app/domain/model/BookmarkListItem.kt
@@ -27,7 +27,18 @@ data class BookmarkListItem(
      * picture, and isn't PERMANENT_NO_CONTENT. Lets multi-select decide the Pin/Unpin toggle from
      * only the *pinnable* items, so a no-content item in the selection doesn't block Unpin.
      */
-    val offlineEligible: Boolean = false
+    val offlineEligible: Boolean = false,
+    /**
+     * The server reported an extraction problem, or the bookmark is in the hard ERROR state — the same
+     * "with errors" bucket the filter matches (`hasServerErrors = 1 OR state = ERROR`). Drives the card
+     * error badge (highest priority in the download-icon slot).
+     */
+    val hasError: Boolean = false,
+    /**
+     * The server confirmed there is nothing to extract (`PERMANENT_NO_CONTENT`). Drives the card's
+     * no-content badge ("opens the original page") when the bookmark isn't already flagged as an error.
+     */
+    val hasNoContent: Boolean = false
 ) {
     enum class OfflineState {
         NOT_DOWNLOADED,

--- a/app/src/main/java/com/mydeck/app/domain/usecase/LoadBookmarksUseCase.kt
+++ b/app/src/main/java/com/mydeck/app/domain/usecase/LoadBookmarksUseCase.kt
@@ -5,19 +5,15 @@ import com.mydeck.app.domain.mapper.toDomain
 import com.mydeck.app.domain.sync.OfflinePolicyEvaluator
 import com.mydeck.app.domain.sync.SyncScheduler
 import com.mydeck.app.io.prefs.SettingsDataStore
-import com.mydeck.app.io.rest.ReadeckApi
-import com.mydeck.app.io.rest.model.BookmarkDto
 import com.mydeck.app.io.rest.sync.MultipartSyncClient
 import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant
 import timber.log.Timber
 import javax.inject.Inject
-import kotlin.coroutines.cancellation.CancellationException
 
 class LoadBookmarksUseCase @Inject constructor(
     private val bookmarkRepository: BookmarkRepository,
-    private val readeckApi: ReadeckApi,
     private val multipartSyncClient: MultipartSyncClient,
     private val settingsDataStore: SettingsDataStore,
     private val policyEvaluator: OfflinePolicyEvaluator,
@@ -104,7 +100,7 @@ class LoadBookmarksUseCase @Inject constructor(
                     Timber.i("Saved last bookmark timestamp: [utc=$maxUpdatedCursor]")
                 }
 
-                refreshServerErrorFlags(DEFAULT_PAGE_SIZE)
+                bookmarkRepository.refreshServerErrorFlags()
                 if (enqueueContentSyncAfterLoad) {
                     enqueueContentSyncIfNeeded()
                 }
@@ -139,61 +135,7 @@ class LoadBookmarksUseCase @Inject constructor(
 
     companion object {
         const val DEFAULT_PAGE_SIZE = 50
-        private const val MAX_PAGES = 1000
     }
 
     private fun Instant.truncateToSyncCursor(): Instant = Instant.fromEpochSeconds(epochSeconds)
-
-    private suspend fun refreshServerErrorFlags(pageSize: Int) {
-        try {
-            var offset = 0
-            var hasMorePages = true
-            var pagesFetched = 0
-            val serverErrorIds = mutableSetOf<String>()
-
-            while (hasMorePages) {
-                if (pagesFetched >= MAX_PAGES) {
-                    Timber.w("refreshServerErrorFlags: reached MAX_PAGES=$MAX_PAGES guard; aborting")
-                    break
-                }
-                val response = readeckApi.getBookmarks(
-                    limit = pageSize,
-                    offset = offset,
-                    updatedSince = null,
-                    sortOrder = ReadeckApi.SortOrder(ReadeckApi.Sort.Created),
-                    hasErrors = true
-                )
-
-                if (!response.isSuccessful || response.body() == null) {
-                    Timber.w("Skipping server error flag refresh: [code=${response.code()}]")
-                    return
-                }
-
-                val bookmarkDtos = response.body() ?: emptyList()
-                serverErrorIds += bookmarkDtos.map { it.id }
-                pagesFetched++
-
-                val totalPagesHeader = response.headers()[ReadeckApi.Header.TOTAL_PAGES]
-                val currentPageHeader = response.headers()[ReadeckApi.Header.CURRENT_PAGE]
-                if (totalPagesHeader == null || currentPageHeader == null) {
-                    Timber.w("Skipping server error flag refresh due to missing pagination headers")
-                    return
-                }
-
-                val totalPages = totalPagesHeader.toInt()
-                val currentPage = currentPageHeader.toInt()
-                if (currentPage < totalPages) {
-                    offset += pageSize
-                } else {
-                    hasMorePages = false
-                }
-            }
-
-            bookmarkRepository.replaceServerErrorFlags(serverErrorIds)
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            Timber.w(e, "Failed to refresh server error flags")
-        }
-    }
 }

--- a/app/src/main/java/com/mydeck/app/io/db/dao/BookmarkDao.kt
+++ b/app/src/main/java/com/mydeck/app/io/db/dao/BookmarkDao.kt
@@ -390,6 +390,8 @@ interface BookmarkDao {
             b.published,
             b.hasArticle,
             b.contentState,
+            b.hasServerErrors,
+            b.state,
             cp.hasResources,
             cp.source
             """)
@@ -590,7 +592,7 @@ interface BookmarkDao {
             b.readProgress, b.icon_src AS iconSrc, b.image_src AS imageSrc,
             b.labels, b.thumbnail_src AS thumbnailSrc, b.type,
             b.readingTime, b.created, b.wordCount, b.published,
-            b.hasArticle, b.contentState, cp.hasResources, cp.source
+            b.hasArticle, b.contentState, b.hasServerErrors, b.state, cp.hasResources, cp.source
             FROM bookmarks b
             LEFT JOIN content_package cp ON cp.bookmarkId = b.id
             WHERE b.isLocalDeleted = 0""")
@@ -669,7 +671,7 @@ interface BookmarkDao {
             b.readProgress, b.icon_src AS iconSrc, b.image_src AS imageSrc,
             b.labels, b.thumbnail_src AS thumbnailSrc, b.type,
             b.readingTime, b.created, b.wordCount, b.published,
-            b.hasArticle, b.contentState, cp.hasResources, cp.source
+            b.hasArticle, b.contentState, b.hasServerErrors, b.state, cp.hasResources, cp.source
             FROM bookmarks b
             LEFT JOIN content_package cp ON cp.bookmarkId = b.id
             WHERE b.isLocalDeleted = 0""")

--- a/app/src/main/java/com/mydeck/app/io/db/model/BookmarkListItemEntity.kt
+++ b/app/src/main/java/com/mydeck/app/io/db/model/BookmarkListItemEntity.kt
@@ -33,6 +33,10 @@ data class BookmarkListItemEntity(
     /** Server's article-content flag; with type/contentState drives offline eligibility (pinnability). */
     val hasArticle: Boolean,
     val contentState: BookmarkEntity.ContentState,
+    /** Server-reported extraction error flag (errors array non-empty), reconciled by the metadata sync. */
+    val hasServerErrors: Boolean,
+    /** Loaded/error/loading state; [BookmarkEntity.State.ERROR] is the hard-error case the badge also covers. */
+    val state: BookmarkEntity.State,
     /**
      * Whether this bookmark has downloaded resources (images).
      *

--- a/app/src/main/java/com/mydeck/app/ui/list/BookmarkCard.kt
+++ b/app/src/main/java/com/mydeck/app/ui/list/BookmarkCard.kt
@@ -40,6 +40,7 @@ import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.DownloadForOffline
+import androidx.compose.material.icons.filled.ErrorOutline
 import androidx.compose.material.icons.filled.PushPin
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Image
@@ -47,6 +48,7 @@ import androidx.compose.material.icons.filled.Inventory2
 import androidx.compose.material.icons.filled.Language
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Movie
+import androidx.compose.material.icons.outlined.Block
 import androidx.compose.material.icons.outlined.CheckCircle
 import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.DownloadForOffline
@@ -514,7 +516,9 @@ fun BookmarkMosaicCard(
                         BookmarkDownloadStatusIndicator(
                             offlineState = bookmark.offlineState,
                             modifier = Modifier.padding(top = 2.dp),
-                            isMosaic = true
+                            isMosaic = true,
+                            hasError = bookmark.hasError,
+                            hasNoContent = bookmark.hasNoContent
                         )
                     }
 
@@ -908,7 +912,9 @@ private fun BookmarkGridCardMobilePortrait(
                         }
                         BookmarkDownloadStatusIndicator(
                             offlineState = bookmark.offlineState,
-                            modifier = Modifier.padding(start = 4.dp)
+                            modifier = Modifier.padding(start = 4.dp),
+                            hasError = bookmark.hasError,
+                            hasNoContent = bookmark.hasNoContent
                         )
                     }
 
@@ -1201,7 +1207,9 @@ private fun BookmarkGridCardNarrow(
                     }
                     BookmarkDownloadStatusIndicator(
                         offlineState = bookmark.offlineState,
-                        modifier = Modifier.padding(start = 4.dp)
+                        modifier = Modifier.padding(start = 4.dp),
+                        hasError = bookmark.hasError,
+                        hasNoContent = bookmark.hasNoContent
                     )
                 }
 
@@ -1422,7 +1430,9 @@ private fun BookmarkGridCardWide(
                     }
                     BookmarkDownloadStatusIndicator(
                         offlineState = bookmark.offlineState,
-                        modifier = Modifier.padding(start = 4.dp)
+                        modifier = Modifier.padding(start = 4.dp),
+                        hasError = bookmark.hasError,
+                        hasNoContent = bookmark.hasNoContent
                     )
                 }
 
@@ -1497,33 +1507,58 @@ private fun BookmarkGridCardWide(
 private fun BookmarkDownloadStatusIndicator(
     offlineState: BookmarkListItem.OfflineState,
     modifier: Modifier = Modifier,
-    isMosaic: Boolean = false
+    isMosaic: Boolean = false,
+    hasError: Boolean = false,
+    hasNoContent: Boolean = false
 ) {
-    if (offlineState == BookmarkListItem.OfflineState.NOT_DOWNLOADED) return
-    val isPinned = offlineState == BookmarkListItem.OfflineState.PINNED
-    val isFull = offlineState == BookmarkListItem.OfflineState.DOWNLOADED_FULL
-    Icon(
-        imageVector = when {
-            isPinned -> Icons.Filled.PushPin
-            isFull -> Icons.Filled.DownloadForOffline
-            else -> Icons.Outlined.DownloadForOffline
-        },
-        contentDescription = stringResource(
-            when {
-                isPinned -> R.string.bookmark_card_pinned
-                isFull -> R.string.bookmark_card_available_offline
-                else -> R.string.bookmark_card_text_available
-            }
-        ),
-        modifier = modifier.size(BookmarkDownloadIconSize),
-        tint = if (isPinned) {
-            MaterialTheme.colorScheme.primary
-        } else if (isMosaic) {
-            Color.White.copy(alpha = 0.6f)
-        } else {
-            MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+    // A single indicator in the download-icon slot, chosen by priority:
+    //   1. error      → the bookmark is in the "with errors" bucket (server errors or hard ERROR state)
+    //   2. no content → the server confirmed nothing to extract; the card opens the original page
+    //   3. else       → the normal download / offline-state icon
+    val mutedTint = if (isMosaic) {
+        Color.White.copy(alpha = 0.6f)
+    } else {
+        MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+    }
+
+    when {
+        hasError -> Icon(
+            imageVector = Icons.Filled.ErrorOutline,
+            contentDescription = stringResource(R.string.bookmark_card_has_error),
+            modifier = modifier.size(BookmarkDownloadIconSize),
+            tint = MaterialTheme.colorScheme.error
+        )
+
+        hasNoContent -> Icon(
+            imageVector = Icons.Outlined.Block,
+            contentDescription = stringResource(R.string.bookmark_card_no_content),
+            modifier = modifier.size(BookmarkDownloadIconSize),
+            tint = mutedTint
+        )
+
+        offlineState == BookmarkListItem.OfflineState.NOT_DOWNLOADED -> Unit
+
+        else -> {
+            val isPinned = offlineState == BookmarkListItem.OfflineState.PINNED
+            val isFull = offlineState == BookmarkListItem.OfflineState.DOWNLOADED_FULL
+            Icon(
+                imageVector = when {
+                    isPinned -> Icons.Filled.PushPin
+                    isFull -> Icons.Filled.DownloadForOffline
+                    else -> Icons.Outlined.DownloadForOffline
+                },
+                contentDescription = stringResource(
+                    when {
+                        isPinned -> R.string.bookmark_card_pinned
+                        isFull -> R.string.bookmark_card_available_offline
+                        else -> R.string.bookmark_card_text_available
+                    }
+                ),
+                modifier = modifier.size(BookmarkDownloadIconSize),
+                tint = if (isPinned) MaterialTheme.colorScheme.primary else mutedTint
+            )
         }
-    )
+    }
 }
 
 @Composable
@@ -1695,7 +1730,9 @@ private fun BookmarkCompactCardNarrow(
                 }
                 BookmarkDownloadStatusIndicator(
                     offlineState = bookmark.offlineState,
-                    modifier = Modifier.padding(start = 4.dp)
+                    modifier = Modifier.padding(start = 4.dp),
+                    hasError = bookmark.hasError,
+                    hasNoContent = bookmark.hasNoContent
                 )
             }
 
@@ -2010,7 +2047,9 @@ private fun BookmarkCompactCardWide(
                 }
                 BookmarkDownloadStatusIndicator(
                     offlineState = bookmark.offlineState,
-                    modifier = Modifier.padding(start = 4.dp)
+                    modifier = Modifier.padding(start = 4.dp),
+                    hasError = bookmark.hasError,
+                    hasNoContent = bookmark.hasNoContent
                 )
 
                 // Labels inline after site name, single-line horizontal scroll

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -540,6 +540,8 @@ other{}
     <string name="bookmark_card_text_available">Text available</string>
     <string name="bookmark_card_available_offline">Available offline</string>
     <string name="bookmark_card_pinned">Pinned offline</string>
+    <string name="bookmark_card_has_error">Has extraction errors</string>
+    <string name="bookmark_card_no_content">No readable content; opens original page</string>
     <string name="action_share_image">Bild teilen</string>
     <string name="image_url_copied">Bild-URL kopiert</string>
     <string name="image_copied">Bild kopiert</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -496,6 +496,8 @@ other{}
     <string name="bookmark_card_text_available">Text available</string>
     <string name="bookmark_card_available_offline">Available offline</string>
     <string name="bookmark_card_pinned">Pinned offline</string>
+    <string name="bookmark_card_has_error">Has extraction errors</string>
+    <string name="bookmark_card_no_content">No readable content; opens original page</string>
     <string name="action_share_image">Compartir imagen</string>
     <string name="image_url_copied">URL de la imagen copiada</string>
     <string name="image_copied">Imagen copiada</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -394,6 +394,8 @@
     <string name="bookmark_card_text_available">Text available</string>
     <string name="bookmark_card_available_offline">Available offline</string>
     <string name="bookmark_card_pinned">Pinned offline</string>
+    <string name="bookmark_card_has_error">Has extraction errors</string>
+    <string name="bookmark_card_no_content">No readable content; opens original page</string>
     <string name="action_share_image">Share image</string>
     <string name="image_url_copied">Image URL copied</string>
     <string name="image_copied">Image copied</string>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -462,6 +462,8 @@ other{}
     <string name="bookmark_card_text_available">Text available</string>
     <string name="bookmark_card_available_offline">Available offline</string>
     <string name="bookmark_card_pinned">Pinned offline</string>
+    <string name="bookmark_card_has_error">Has extraction errors</string>
+    <string name="bookmark_card_no_content">No readable content; opens original page</string>
     <string name="action_share_image">Share image</string>
     <string name="image_url_copied">Image URL copied</string>
     <string name="image_copied">Image copied</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -394,6 +394,8 @@
     <string name="bookmark_card_text_available">Text available</string>
     <string name="bookmark_card_available_offline">Available offline</string>
     <string name="bookmark_card_pinned">Pinned offline</string>
+    <string name="bookmark_card_has_error">Has extraction errors</string>
+    <string name="bookmark_card_no_content">No readable content; opens original page</string>
     <string name="action_share_image">Share image</string>
     <string name="image_url_copied">Image URL copied</string>
     <string name="image_copied">Image copied</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -394,6 +394,8 @@
     <string name="bookmark_card_text_available">Text available</string>
     <string name="bookmark_card_available_offline">Available offline</string>
     <string name="bookmark_card_pinned">Pinned offline</string>
+    <string name="bookmark_card_has_error">Has extraction errors</string>
+    <string name="bookmark_card_no_content">No readable content; opens original page</string>
     <string name="action_share_image">Share image</string>
     <string name="image_url_copied">Image URL copied</string>
     <string name="image_copied">Image copied</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -394,6 +394,8 @@
     <string name="bookmark_card_text_available">Text available</string>
     <string name="bookmark_card_available_offline">Available offline</string>
     <string name="bookmark_card_pinned">Pinned offline</string>
+    <string name="bookmark_card_has_error">Has extraction errors</string>
+    <string name="bookmark_card_no_content">No readable content; opens original page</string>
     <string name="action_share_image">Share image</string>
     <string name="image_url_copied">Image URL copied</string>
     <string name="image_copied">Image copied</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -394,6 +394,8 @@
     <string name="bookmark_card_text_available">Text available</string>
     <string name="bookmark_card_available_offline">Available offline</string>
     <string name="bookmark_card_pinned">Pinned offline</string>
+    <string name="bookmark_card_has_error">Has extraction errors</string>
+    <string name="bookmark_card_no_content">No readable content; opens original page</string>
     <string name="action_share_image">Share image</string>
     <string name="image_url_copied">Image URL copied</string>
     <string name="image_copied">Image copied</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -488,6 +488,8 @@
     <string name="bookmark_card_text_available">Text available</string>
     <string name="bookmark_card_available_offline">Available offline</string>
     <string name="bookmark_card_pinned">Pinned offline</string>
+    <string name="bookmark_card_has_error">Has extraction errors</string>
+    <string name="bookmark_card_no_content">No readable content; opens original page</string>
     <string name="action_share_image">Share image</string>
     <string name="image_url_copied">Image URL copied</string>
     <string name="image_copied">Image copied</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -708,6 +708,8 @@ other{}
     <string name="bookmark_card_text_available">Text available</string>
     <string name="bookmark_card_available_offline">Available offline</string>
     <string name="bookmark_card_pinned">Pinned offline</string>
+    <string name="bookmark_card_has_error">Has extraction errors</string>
+    <string name="bookmark_card_no_content">No readable content; opens original page</string>
     <string name="action_share_image">Share image</string>
     <string name="image_url_copied">Image URL copied</string>
     <string name="image_copied">Image copied</string>

--- a/app/src/test/java/com/mydeck/app/domain/BookmarkRepositoryImplTest.kt
+++ b/app/src/test/java/com/mydeck/app/domain/BookmarkRepositoryImplTest.kt
@@ -47,6 +47,7 @@ import okhttp3.Headers
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -116,6 +117,18 @@ class BookmarkRepositoryImplTest {
         
         // Standard mocks for BookmarkDao batch operations
         coEvery { bookmarkDao.getBookmarksByIds(any()) } returns emptyList()
+
+        // performFullSync reconciles server-error flags via a has_errors=true scan; default it to an
+        // empty page so the broader full-sync tests don't need to stub it individually.
+        coEvery {
+            readeckApi.getBookmarks(any(), any(), any(), any(), hasErrors = true)
+        } returns Response.success(
+            emptyList(),
+            Headers.headersOf(
+                ReadeckApi.Header.TOTAL_PAGES, "1",
+                ReadeckApi.Header.CURRENT_PAGE, "1"
+            )
+        )
 
         bookmarkRepositoryImpl = BookmarkRepositoryImpl(
             database = database,
@@ -1426,6 +1439,55 @@ class BookmarkRepositoryImplTest {
         assertEquals("item-1", emission[0].id)
     }
 
+    @Test
+    fun `refreshServerErrorFlags reconciles flags from the has_errors scan`() = runTest {
+        val captured = mutableListOf<List<String>>()
+        coEvery {
+            readeckApi.getBookmarks(any(), any(), any(), any(), hasErrors = true)
+        } returns Response.success(
+            listOf(bookmarkDto.copy(id = "e1"), bookmarkDto.copy(id = "e2")),
+            Headers.headersOf(
+                ReadeckApi.Header.TOTAL_PAGES, "1",
+                ReadeckApi.Header.CURRENT_PAGE, "1"
+            )
+        )
+        coEvery { bookmarkDao.replaceServerErrorFlags(capture(captured)) } just runs
+
+        bookmarkRepositoryImpl.refreshServerErrorFlags()
+
+        coVerify { readeckApi.getBookmarks(any(), any(), any(), any(), hasErrors = true) }
+        assertEquals(setOf("e1", "e2"), captured.single().toSet())
+    }
+
+    @Test
+    fun `list item maps server-error and no-content signals into hasError and hasNoContent`() = runTest {
+        val serverError = bookmarkListItemEntity.copy(id = "err", hasServerErrors = true)
+        val hardError = bookmarkListItemEntity.copy(id = "hard", state = BookmarkEntity.State.ERROR)
+        val noContent = bookmarkListItemEntity.copy(
+            id = "empty",
+            hasArticle = false,
+            contentState = BookmarkEntity.ContentState.PERMANENT_NO_CONTENT
+        )
+        val clean = bookmarkListItemEntity.copy(id = "clean")
+        every {
+            bookmarkDao.getFilteredBookmarkListItems(
+                searchQuery = any(), title = any(), author = any(), site = any(),
+                types = any(), progressFilters = any(), isArchived = any(),
+                isFavorite = any(), label = any(), fromDate = any(), toDate = any(),
+                isLoaded = any(), withLabels = any(), withErrors = any(), orderBy = any()
+            )
+        } returns flowOf(listOf(serverError, hardError, noContent, clean))
+
+        val emission = bookmarkRepositoryImpl.observeFilteredBookmarkListItems().first().associateBy { it.id }
+
+        assertTrue(emission.getValue("err").hasError)
+        assertTrue(emission.getValue("hard").hasError)
+        assertFalse(emission.getValue("empty").hasError)
+        assertTrue(emission.getValue("empty").hasNoContent)
+        assertFalse(emission.getValue("clean").hasError)
+        assertFalse(emission.getValue("clean").hasNoContent)
+    }
+
     private val bookmarkListItemEntity = BookmarkListItemEntity(
         id = "item-1",
         href = "https://example.com/item-1",
@@ -1446,6 +1508,8 @@ class BookmarkRepositoryImplTest {
         published = null,
         hasArticle = true,
         contentState = BookmarkEntity.ContentState.NOT_ATTEMPTED,
+        hasServerErrors = false,
+        state = BookmarkEntity.State.LOADED,
         hasResources = null,
         source = null
     )

--- a/app/src/test/java/com/mydeck/app/domain/usecase/LoadBookmarksUseCaseTest.kt
+++ b/app/src/test/java/com/mydeck/app/domain/usecase/LoadBookmarksUseCaseTest.kt
@@ -5,7 +5,6 @@ import com.mydeck.app.domain.sync.SyncScheduler
 import com.mydeck.app.domain.mapper.toDomain
 import com.mydeck.app.domain.sync.OfflinePolicyEvaluator
 import com.mydeck.app.io.prefs.SettingsDataStore
-import com.mydeck.app.io.rest.ReadeckApi
 import com.mydeck.app.io.rest.model.BookmarkDto
 import com.mydeck.app.io.rest.model.ImageResource
 import com.mydeck.app.io.rest.model.Resource
@@ -17,16 +16,13 @@ import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.Instant
-import okhttp3.Headers
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
-import retrofit2.Response
 
 class LoadBookmarksUseCaseTest {
 
     private lateinit var bookmarkRepository: BookmarkRepository
-    private lateinit var readeckApi: ReadeckApi
     private lateinit var multipartSyncClient: MultipartSyncClient
     private lateinit var settingsDataStore: SettingsDataStore
     private lateinit var policyEvaluator: OfflinePolicyEvaluator
@@ -36,7 +32,6 @@ class LoadBookmarksUseCaseTest {
     @Before
     fun setUp() {
         bookmarkRepository = mockk(relaxed = true)
-        readeckApi = mockk()
         multipartSyncClient = mockk(relaxed = true)
         settingsDataStore = mockk(relaxed = true)
         policyEvaluator = mockk(relaxed = true)
@@ -44,7 +39,6 @@ class LoadBookmarksUseCaseTest {
         coEvery { policyEvaluator.shouldAutoFetchContent() } returns false
         loadBookmarksUseCase = LoadBookmarksUseCase(
             bookmarkRepository,
-            readeckApi,
             multipartSyncClient,
             settingsDataStore,
             policyEvaluator,
@@ -59,13 +53,6 @@ class LoadBookmarksUseCaseTest {
         coEvery { bookmarkRepository.insertBookmarks(any()) } returns Unit
         coEvery { settingsDataStore.getLastBookmarkTimestamp() } returns null
         coEvery { settingsDataStore.saveLastBookmarkTimestamp(any()) } returns Unit
-        coEvery { readeckApi.getBookmarks(any(), any(), any(), any(), any()) } returns Response.success(
-            emptyList(),
-            Headers.headersOf(
-                ReadeckApi.Header.TOTAL_PAGES, "1",
-                ReadeckApi.Header.CURRENT_PAGE, "1"
-            )
-        )
 
         // Execute the use case
         val result = loadBookmarksUseCase.execute(updatedIds = listOf("2"), pageSize = 10, initialOffset = 0)
@@ -75,6 +62,8 @@ class LoadBookmarksUseCaseTest {
         assertTrue(result is LoadBookmarksUseCase.UseCaseResult.Success<*>)
         coVerify { multipartSyncClient.fetchMetadata(listOf("2")) }
         coVerify { bookmarkRepository.insertBookmarks(match { it.size == 1 && it.first().id == "2" }) }
+        // The metadata sync delegates server-error reconciliation to the repository.
+        coVerify { bookmarkRepository.refreshServerErrorFlags() }
     }
 
     @Test
@@ -127,13 +116,6 @@ class LoadBookmarksUseCaseTest {
         coEvery { settingsDataStore.getLastBookmarkTimestamp() } returns null
         coEvery { settingsDataStore.saveLastBookmarkTimestamp(any()) } returns Unit
         coEvery { bookmarkRepository.insertBookmarks(any()) } returns Unit
-        coEvery { readeckApi.getBookmarks(any(), any(), any(), any(), any()) } returns Response.success(
-            emptyList(),
-            Headers.headersOf(
-                ReadeckApi.Header.TOTAL_PAGES, "1",
-                ReadeckApi.Header.CURRENT_PAGE, "1"
-            )
-        )
 
         loadBookmarksUseCase.execute(updatedIds = listOf("2", "1"), pageSize = 10, initialOffset = 0)
 

--- a/app/src/test/java/com/mydeck/app/io/db/BookmarkDaoTest.kt
+++ b/app/src/test/java/com/mydeck/app/io/db/BookmarkDaoTest.kt
@@ -27,6 +27,7 @@ import kotlinx.datetime.atStartOfDayIn
 import kotlinx.datetime.plus
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -571,6 +572,20 @@ class BookmarkDaoTest {
             assertTrue(list.none { it.id == "test-19" })
             assertTrue(list.none { it.id == "test-27" })
             assertTrue(list.none { it.id == "test-29" })
+        }
+
+        @Test
+        fun `list projection surfaces hasServerErrors and state from the table`() = runTest(testDispatcher) {
+            val byId = bookmarkDao.getFilteredBookmarkListItems().first().associateBy { it.id }
+
+            // hasServerErrors mirrors the persisted column (set on 7/17/27 in the fixture).
+            assertTrue(byId.getValue("test-7").hasServerErrors)
+            assertFalse(byId.getValue("test-8").hasServerErrors)
+
+            // state is projected so the badge/filter can also catch hard ERROR rows (9/19/29).
+            assertEquals(BookmarkEntity.State.ERROR, byId.getValue("test-9").state)
+            assertEquals(BookmarkEntity.State.LOADING, byId.getValue("test-8").state)
+            assertEquals(BookmarkEntity.State.LOADED, byId.getValue("test-0").state)
         }
     }
 

--- a/docs/porting/with-errors-sync-port.md
+++ b/docs/porting/with-errors-sync-port.md
@@ -1,0 +1,47 @@
+# Port checklist — "With errors" filter + error/no-content badges
+
+**SOURCE = Readeck for Android · TARGET = MyDeck (`com.mydeck.app`).**
+Harness: [`mydeck-readeck-port.md`](./mydeck-readeck-port.md) — read it; this is the §8 per-feature checklist that plugs into it. Implementation detail & rationale (only if you need the "why"): the SOURCE repo's [`docs/specs/with-errors-sync-fix-spec.md`](../specs/with-errors-sync-fix-spec.md).
+
+## Source change
+
+One squash commit on Readeck `main`: **`c91cc3f`** — "Fix: \"With errors\" filter + error/no-content card badges (#13)". `git show c91cc3f` in the Readeck checkout is the authoritative diff. Files touched (all under the shared `com.mydeck.app` root; none branding-related):
+
+- **Logic/data:** `domain/BookmarkRepository.kt`, `domain/BookmarkRepositoryImpl.kt`, `domain/usecase/LoadBookmarksUseCase.kt`, `domain/model/BookmarkListItem.kt`, `io/db/dao/BookmarkDao.kt`, `io/db/model/BookmarkListItemEntity.kt`
+- **UI:** `ui/list/BookmarkCard.kt` (badge in the download-icon slot + removal of two dead indicator composables)
+- **Strings:** `res/values/strings.xml` + 9 locale folders — keys `bookmark_card_has_error`, `bookmark_card_no_content`
+- **Guide:** `assets/guide/en/your-bookmarks.md` (Download Status badge note)
+- **Tests:** `domain/BookmarkRepositoryImplTest.kt`, `io/db/BookmarkDaoTest.kt`, `domain/usecase/LoadBookmarksUseCaseTest.kt`
+
+What it does, in one line: reconcile `hasServerErrors` on **full** sync (it previously ran only on the incremental path) by centralizing the `has_errors=true` scan in `BookmarkRepository.performFullSync()`; project the error / no-content signals onto the list item; show an error / no-content badge in the card's download-icon slot. `BookmarkDto`, `BookmarkMapper`, and `ReadeckApi` are **not** touched.
+
+## Approach — cherry-pick / patch, not re-development (harness §4)
+
+The two apps share the codebase (identical `com.mydeck.app` package root; only `applicationId`, branding, some config, and CI diverge). Every file in `c91cc3f` **except the strings and the guide** is shared, branding-free code that ports **directly** — this is a file-level patch, not a re-implementation:
+
+1. Determine cherry-pick viability from shared history (`git merge-base` against the Readeck remote, or by comparing the files). If history is shared, **cherry-pick / `git apply` `c91cc3f`**; otherwise copy the change **hunk-by-hunk** per file.
+2. `git -C <readeck> diff c91cc3f^ c91cc3f -- <file>` gives the exact hunks. Before any wholesale file copy, diff SOURCE against MyDeck for that file to confirm it's otherwise identical, so a copy can't clobber a MyDeck-only line. (For these files they should differ only by this change.)
+
+## Divergence handling for this port (harness §3/§6) — only two items
+
+1. **Strings** — insert `bookmark_card_has_error` / `bookmark_card_no_content` (English placeholder text) **surgically** into MyDeck's `values/strings.xml` and each MyDeck locale folder. Confirm MyDeck's locale set (SOURCE has 9: `de-rDE, es-rES, fr, gl-rES, pl, pt-rPT, ru, uk, zh-rCN`). **Never** whole-file copy strings.xml (clobbers independently-added keys — harness §7).
+2. **Guide** — port the `your-bookmarks.md` badge note into MyDeck's guide, in MyDeck's wording.
+
+No other divergence-map axis is exercised: no migration (below), no notification channel ids, no flavor/variant names, no manifest changes, no branding strings/assets.
+
+## No migration (harness §5 — N/A, confirm)
+
+`hasServerErrors` and `state` are added to the **list projection only** (the SELECT builders + projection POJO); both are **pre-existing columns** on the `bookmarks` table (`BookmarkEntity`). Confirm MyDeck's `BookmarkEntity` already has both — if so, there is no schema/migration work. (If a column were genuinely absent, that would be a real migration → follow harness §5: renumber, regenerate schema JSON, register, migration test.)
+
+## Verify (harness §7)
+
+- MyDeck's gate green: `./scripts/ci-verify.sh` (or `:app:assembleDebugAll` / `:app:testDebugUnitTestAll` / `:app:lintDebugAll` — task names are identical to SOURCE per the divergence map); lint within baseline.
+- On device (Pixel 9 via `scripts/install-phone.sh`): fresh sign-in with offline reading **off** → **Filter → With errors → Yes** lists the errored bookmarks straight after metadata sync; errored / no-content cards show the badge; no restart.
+
+## Pre-flight
+
+- [ ] MyDeck on up-to-date `main`; Readeck checkout reachable as SOURCE with `c91cc3f` present.
+- [ ] Cherry-pick vs hunk-by-hunk decided from a shared-history check (§4).
+- [ ] MyDeck doesn't already carry `c91cc3f`'s change (don't double-apply).
+- [ ] `BookmarkEntity` has `hasServerErrors` + `state` columns (→ no migration).
+- [ ] MyDeck locale set confirmed.

--- a/docs/specs/with-errors-sync-fix-spec.md
+++ b/docs/specs/with-errors-sync-fix-spec.md
@@ -1,0 +1,209 @@
+# "With errors" filter + error/no-content badges — issue & fix spec
+
+**Status:** ✅ **Implemented** on `fix/with-errors-sync` (branched off `main`). Verified by the reporter:
+a known no-content/errored bookmark shows the error badge, and a from-scratch sign-in with offline
+reading disabled returns the correct rows under **Filter → With errors → Yes** straight after the
+metadata sync — no content download or restart required.
+
+> **Note:** parts of the analysis below were written before the fix and turned out to be stale —
+> the incremental path already populated the flag, and `BookmarkListItem` had been refactored. See
+> [Resolution — what actually shipped](#resolution--what-actually-shipped) for the authoritative
+> account of the change; the sections above it are kept as the original investigation record.
+
+**NOT** part of `feature/rc3-enhancements`. This file was created untracked on the rc3 working tree and
+committed on the fix branch alongside the change.
+
+**Reported by:** project owner, confirmed by reproduction (see below).
+
+---
+
+## Symptom
+
+- Filtering bookmarks by **With errors → Yes** returns **nothing**, even when the server has errored
+  bookmarks (repro account: ~200 bookmarks, 29 errored, mostly older).
+- Opening one of those bookmarks shows **no extraction-error box** in Details.
+- **Long-standing** — reproduces back to MyDeck v0.14.2 across two server versions. It is **not** a
+  regression in `feature/rc3-enhancements`: every file in the error path
+  (`BookmarkDao`, `BookmarkMapper`, `Bookmark`, `BookmarkDto`, `BookmarkEntity`, `BookmarkRepositoryImpl`
+  write/merge, `FilterFormState`, `FilterBottomSheet`, `FilterBar`, the Room DB) is byte-identical to
+  the rc2 tag (`2cc8f97`), and the `withErrors` DAO test passes.
+
+## Root cause (confirmed)
+
+- The Readeck **list** endpoint `GET /bookmarks` returns `bookmarkSummary` objects. Per
+  `docs/openapi-spec.json`, `bookmarkSummary` has `state`, `loaded`, `has_article`, … but **no `errors`
+  array and no `has_errors` flag**.
+- `io/rest/model/BookmarkDto.kt` declares `errors: List<String> = emptyList()`, so on list sync it
+  always deserializes empty. `domain/mapper/BookmarkMapper.kt` (~line 66) sets
+  `hasServerErrors = errors.isNotEmpty()` → **always `false` from the metadata sync**.
+- Readeck encodes a **loaded-but-extraction-failed** bookmark as **`state = 0` (LOADED) with a
+  non-empty `errors` array** — *not* `state = 1`. The filter query in `io/db/dao/BookmarkDao.kt` is
+  `AND (b.state = 1 OR b.hasServerErrors = 1)`, so such bookmarks match **neither** clause → 0 results,
+  and Details has no error box (the local row carries no `errors`).
+- The `errors` array only arrives via the **content/detail fetch** (`GET /bookmarks/{id}` and the
+  offline content sync), which populates `hasServerErrors`. That path is **offline-policy-limited**
+  (newest-first), so older errored bookmarks are never flagged → the inconsistency the reporter saw.
+- **Evidence:** a debug export of one such bookmark shows the live server `apiResponse` as
+  `state = 0`, `errors = ["could not extract content"]`, `has_article = false`, while the stored
+  `localState`/`bookmarkMetadata` has `state = LOADED` and no error flag. `BookmarkDebugExporter` makes
+  a *direct* `getBookmarkById` API call for `apiResponse`; the repo's `getBookmarkById` reads the
+  **local DB**, which is why opening a bookmark shows no error.
+
+## Reproduction (confirmed by reporter)
+
+Account with ~200 bookmarks, 29 errored (mostly older), offline reading **off**:
+
+1. Clear app data / fresh install → sign in → let the bookmark (metadata) sync finish.
+2. **Filter → With errors → Yes** → ~0 results. *(the broken state)*
+3. Open a known-errored bookmark → Details shows **no** error box.
+4. **Enable offline reading** with a policy covering all ~200 (Storage limit high, or Most recent ≥ 200)
+   → wait for content sync. **Filter → With errors → Yes** → now shows the 29; Details shows the box.
+   - A *narrow* offline policy only flags the errored bookmarks inside its window (reproducing
+     "some but not all"; older errors stay hidden).
+
+**Reactivity gap (important):** after the content download populated the flag, the **filter and Details
+still did not reflect it until the app was closed and reopened.** The fix must ensure the list query and
+Details refresh on the flag write (Room `@Query` Flows should invalidate on the table write — verify the
+content-sync write goes through normal invalidation / that the filtered query observes it).
+
+Captured artifacts available from the reporter: a debug JSON export and app logs from the repro.
+
+## Content vs error: the model + badge decision
+
+Two **orthogonal** list-level axes:
+
+- **Content** — readable extracted content present? (`has_article` / local `contentState`, where
+  `PERMANENT_NO_CONTENT` already means "nothing to read"). *Already in the list projection.*
+- **Error** — server reported a problem? (`errors` non-empty → `hasServerErrors`, or `state = 1`).
+  *Not in the list projection today.*
+
+| Content | Error | Meaning |
+|---|---|---|
+| has article | none | normal |
+| has article | **error** | extracted with non-fatal issues (content exists *and* has an error) |
+| **no content** | **error** | extraction failed — the common case; **both** axes true |
+| no content | none | no article, nothing flagged (rare for articles) |
+
+**Decision (agreed):** a **single** indicator in the download-icon slot, chosen by priority — not two
+competing badges:
+
+1. **Error** (`hasServerErrors` or `state = 1`) → **error badge** (wins; covers failed-extraction, which
+   is also no-content, and the content-with-errors row).
+2. else **no content** (`has_article = false` / `PERMANENT_NO_CONTENT`, no error) → **no-content badge**
+   (circle-slash; signals "opens the original page"). A no-content bookmark has nothing to download
+   offline, so replacing the download glyph here is appropriate.
+3. else → the normal **download / offline-state** icon.
+
+**Out of scope (agreed):** distinguishing error *kinds* at the list level (e.g. "could not extract"
+vs HTTP 4xx/5xx). The list summary can't convey it; the kind lives only in the `errors` **message
+strings**, which Details already surfaces when the bookmark is opened. Do not try to surface error type
+on cards.
+
+## Proposed solution
+
+1. **Populate `hasServerErrors` from the metadata sync** using the existing `has_errors=true` list query
+   (`ReadeckApi.getBookmarks(hasErrors = …)` already exists). During sync, fetch the errored IDs and set
+   `hasServerErrors = true` on those / `false` otherwise. No content fetch required. There are already
+   `UPDATE bookmarks SET hasServerErrors = …` statements in `BookmarkDao.kt` to build on.
+2. **Add `hasServerErrors` to the list projection** — `BookmarkListItemEntity`, the projection SQL in
+   `BookmarkDao` (the hand-written `SELECT b.…` builders), the `toBookmarkListItem()` mapper, and
+   `BookmarkListItem`. (`hasArticle` / `contentState` are already projected, so the **no-content** signal
+   needs no new field.)
+3. **Reactivity** — ensure the filtered list and Details reflect the flag without an app restart
+   (the observed gap above).
+4. **Card badge** — implement the error > no-content > download priority in the download-icon slot in
+   `BookmarkCard.kt`. **Sequence this after `feature/rc3-enhancements` merges** — that branch rewrote
+   `BookmarkCard.kt`, so the badge UI is the *only* part of this work that would conflict. The
+   data/sync work (items 1–3) does **not** touch `BookmarkCard.kt`.
+5. **Details** — error messages on open already work once the flag/row is correct; no list-level error
+   type. (The reporter is fine with detailed error info + any extract-log link appearing only on open.)
+
+## Validation
+
+- `has_errors=true` list query returns reliably across server versions (tested by reporter: `0.22.3`
+  and `0.22.3-117-g3b0e80b1`).
+- Incremental sync (`updated_since`): the flag must be **cleared** when an error resolves, not just set.
+- `state = 1` hard errors are still caught.
+- Filter + Details update **without** an app restart.
+- Fresh-install repro returns to a clean, fully-flagged state.
+
+## Scope / file overlap
+
+**Data/sync fix (items 1–3): zero overlap with `feature/rc3-enhancements`.** Files —
+`io/rest/model/BookmarkDto.kt`, `domain/mapper/BookmarkMapper.kt`, `io/db/dao/BookmarkDao.kt`,
+`io/db/model/BookmarkListItemEntity.kt`, `io/rest/ReadeckApi.kt` (param already present),
+`domain/BookmarkRepositoryImpl.kt`, `domain/model/BookmarkListItem.kt`, and the sync use-cases/workers
+(`FullSyncUseCase`, `LoadBookmarksUseCase`, `io/rest/sync/*`). None are modified by the rc3 branch.
+
+**Card badge (item 4): overlaps `BookmarkCard.kt`** (rewritten in rc3) → do after rc3 merges.
+
+Recommended sequence: rc3 merges → `fix/with-errors-sync` (data/sync, items 1–3) → card badges (item 4).
+
+---
+
+## Resolution — what actually shipped
+
+Implemented on `fix/with-errors-sync` in four commits (spec → data/sync → badge → tests). The codebase
+had moved on since this spec was drafted, so several assumptions above were stale. The corrections:
+
+### 1. The real Item 1 bug was the **full-sync** path, not "never populated"
+
+`refreshServerErrorFlags()` (the `GET /bookmarks?has_errors=true` scan) **already existed** and already
+ran — but only on the **incremental / multipart** path (`LoadBookmarksUseCase.executeMultipart`). The
+**full sync** that bootstraps a fresh install (`BookmarkRepositoryImpl.performFullSync()`, driven by the
+workers) **never** reconciled the flag. So the repro (clear data → sign in → full sync) left every row
+`hasServerErrors = false` and the filter matched nothing — exactly the symptom.
+
+**Fix:** the reconciliation was **centralized** as `BookmarkRepository.refreshServerErrorFlags()` and is
+now called at the end of `performFullSync()` (success path). That single call site covers **every**
+full-sync entry point — fresh install, periodic full sync, and the delta-sync→full-sync fallback inside
+`FullSyncWorker` (a worker-level call would have missed that fallback, since it returns no `updatedIds`).
+`LoadBookmarksUseCase` now **delegates** to the repository method instead of owning a private copy; its
+now-unused `readeckApi` dependency was removed.
+
+> The "clear when an error resolves" requirement is satisfied by `replaceServerErrorFlags()` (clear-all
+> then set), which both full and incremental paths funnel through. Note `insertBookmarks()` *preserves*
+> an existing flag (`existing.hasServerErrors || incoming…`), so `replaceServerErrorFlags` is the only
+> authoritative reset — which is why running it after full sync is correct.
+
+### 2. `BookmarkListItem` had been refactored — the projected fields are different
+
+The spec assumed `BookmarkMapper.toBookmarkListItem()` set `hasServerErrors` and that `hasArticle` /
+`contentState` were on `BookmarkListItem`. In reality:
+
+- The list mapper is `BookmarkRepositoryImpl.toBookmarkListItem()` (not `BookmarkMapper`), and
+  `BookmarkListItem` had been reworked to an `offlineState` enum + `offlineEligible` — it no longer
+  carried `hasArticle` / `contentState`.
+- So Item 2 surfaced **new** signals: `hasServerErrors` **and** `state` were added to
+  `BookmarkListItemEntity` and to the **three** hand-written `SELECT b.…` projection builders in
+  `BookmarkDao` (there were three, not two). The mapper folds them into two domain booleans:
+  - **`hasError`** = `hasServerErrors || state == State.ERROR` — the combined "with errors" bucket, matching
+    the filter's `b.state = 1 OR b.hasServerErrors = 1` (the enum is `State.ERROR(1)`; there is no
+    `LOADED_WITH_ERRORS`).
+  - **`hasNoContent`** = `contentState == PERMANENT_NO_CONTENT`.
+
+  `BookmarkDto.errors` / `BookmarkMapper` were **not** touched — they were already correct.
+
+### 3. Item 3 (reactivity) needed no code change
+
+The filtered-list `@RawQuery` already declares `observedEntities = [BookmarkEntity, ContentPackageEntity]`,
+so the `UPDATE bookmarks SET hasServerErrors …` write invalidates it; Details already reads via
+`observeBookmark()` (a Room-backed Flow). Both update without a restart — verified, not modified.
+
+### 4. Item 4 badge — one shared indicator
+
+`OfflineStateIndicator` / `CompactOfflineStateIndicator` were **dead code** (no call sites) and have been
+**deleted**; all card variants (Grid, Compact, Mosaic) render through the single
+`BookmarkDownloadStatusIndicator`. It now selects one icon by priority: `hasError` → error badge (error
+tint) > `hasNoContent` → `Icons.Outlined.Block` circle-slash > existing download/offline-state icon. New content-description strings `bookmark_card_has_error` /
+`bookmark_card_no_content` were added (English placeholders in all nine translated files), and both badges
+are documented in `guide/en/your-bookmarks.md`.
+
+### Files actually changed
+
+`domain/BookmarkRepository.kt`, `domain/BookmarkRepositoryImpl.kt`, `domain/usecase/LoadBookmarksUseCase.kt`,
+`domain/model/BookmarkListItem.kt`, `io/db/dao/BookmarkDao.kt`, `io/db/model/BookmarkListItemEntity.kt`,
+`ui/list/BookmarkCard.kt`, `res/values*/strings.xml`, `guide/en/your-bookmarks.md`, and the three test
+files (`BookmarkRepositoryImplTest`, `BookmarkDaoTest`, `LoadBookmarksUseCaseTest`). `BookmarkDto.kt`,
+`BookmarkMapper.kt`, and `ReadeckApi.kt` were **not** modified. Verified with `./scripts/ci-verify.sh`
+(assemble-all + unit tests + lint, all green).


### PR DESCRIPTION
## Fix: "With errors" filter + error/no-content card badges

Port of Readeck for Android `c91cc3f`.

### Problem

**Filter → With errors → Yes** returned no results on a fresh install, even when the server had errored bookmarks. Root cause: `refreshServerErrorFlags()` (the `GET /bookmarks?has_errors=true` scan) only ran on the incremental sync path — full sync (fresh sign-in, periodic, delta-fallback) never reconciled the flag, leaving every row at `hasServerErrors = false`.

### Changes

- **Full-sync reconciliation** — centralized `refreshServerErrorFlags()` in `BookmarkRepository` and call it at the end of `performFullSync()`. One call site now covers every full-sync entry point. `LoadBookmarksUseCase` delegates to it (its unused `readeckApi` dependency dropped).
- **List projection** — added `hasServerErrors` + `state` to `BookmarkListItemEntity` and the three `SELECT b.…` builders. The mapper exposes `hasError` and `hasNoContent` on `BookmarkListItem`.
- **Card badge** — `BookmarkDownloadStatusIndicator` picks one icon by priority: error badge → circle-slash no-content badge → existing download/offline icon. Two dead indicator composables removed.
- **Strings** — `bookmark_card_has_error` / `bookmark_card_no_content` content descriptions added to `values/strings.xml` and all 9 locale files (English placeholders).
- **Guide** — Download Status section updated with error/no-content badge descriptions.

### Not changed

No Room migration — `hasServerErrors` and `state` are pre-existing `bookmarks` columns. `BookmarkDto`, `BookmarkMapper`, and `ReadeckApi` untouched. Reactivity needed no work (the filtered `@RawQuery` already observes the `bookmarks` table).

### Verification

- `assembleDebugAll` / `testDebugUnitTestAll` / `lintDebugAll` → green (within baseline)
- On device (Pixel 9): errored bookmark shows error badge; fresh sign-in with offline reading off → **Filter → With errors → Yes** returns the correct rows immediately after metadata sync, no content download or restart required