### PR TITLE
chore(release): bump version to 0.14.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.3] - 2026-06-27
+
+### Added
+
+- User Interface Settings are now organized into clear sections: Appearance, Bookmark List, Reading, and Sharing.
+- Internal browser toggle: choose whether a bookmark's original web page opens in the in-app viewer or your device's external browser.
+- Label search options: match the start of a label or anywhere within it, and sort labels alphabetically or by most used.
+- Show or hide the add-bookmark (+) button in the bookmark list.
+- Show or hide website source icons in the Compact layout.
+- "With errors" filter to find bookmarks whose content could not be extracted, plus card badges marking bookmarks with extraction errors or no readable content.
+
+### Changed
+
+- Label picker: in "Add" mode the on-screen Enter key now shows a checkmark and commits or creates the typed label; filter mode keeps the search action.
+- Bookmarks with no readable content now show their title and description with a "No content available" note and a button to open the original page.
+
+### Fixed
+
+- The "With errors" filter now correctly returns bookmarks that failed extraction.
+
 ## [0.14.2] - 2026-06-19
 
 ### Added

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,8 +30,8 @@ android {
         applicationId = "com.mydeck.app"
         minSdk = 24
         targetSdk = 35
-        versionCode = 14002
-        versionName = "0.14.2"
+        versionCode = 14003
+        versionName = "0.14.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/metadata/en-US/changelogs/14003.txt
+++ b/metadata/en-US/changelogs/14003.txt
@@ -1,0 +1,8 @@
+<b>Added</b>
+- Settings reorganized into sections, with new toggles for the add-bookmark button and compact source icons
+- Choose how original web pages open: in-app browser or your external browser
+- Label search: match the start or anywhere, sort A–Z or by most used
+- "With errors" filter and card badges for bookmarks that failed to extract
+
+<b>Changed</b>
+- Label picker "Add" mode: Enter now commits the typed label (checkmark)


### PR DESCRIPTION
- versionCode 14002 -> 14003, versionName 0.14.2 -> 0.14.3
- CHANGELOG.md: add [0.14.3] entry (settings sections, internal-browser toggle, label search options, add-button/source-icon toggles, "With errors" filter + card badges, label-picker Enter-key fix)
- metadata/en-US/changelogs/14003.txt: F-Droid changelog for 14003

Covers user-facing changes since v0.14.2 (#206-#212).