### PR TITLE
chore/fix-and-0.14.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.4] - 2026-06-29
+
+### Fixed
+
+- Sign-in now succeeds against Readeck nightly server builds that no longer return `reader_settings` in the user profile response
+
 ## [0.14.3] - 2026-06-27
 
 ### Added

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,8 +30,8 @@ android {
         applicationId = "com.mydeck.app"
         minSdk = 24
         targetSdk = 35
-        versionCode = 14003
-        versionName = "0.14.3"
+        versionCode = 14004
+        versionName = "0.14.4"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/mydeck/app/io/rest/model/UserProfileDto.kt
+++ b/app/src/main/java/com/mydeck/app/io/rest/model/UserProfileDto.kt
@@ -34,7 +34,7 @@ data class SettingsDto(
     val debugInfo: Boolean,
     val lang: String,
     @SerialName("reader_settings")
-    val readerSettings: ReaderSettingsDto
+    val readerSettings: ReaderSettingsDto? = null
 )
 
 @Serializable

--- a/metadata/en-US/changelogs/14004.txt
+++ b/metadata/en-US/changelogs/14004.txt
@@ -1,0 +1,2 @@
+<b>fixed</b>
+- Emergency fix: sign-in now works against recent Readeck nightly server builds. 


### PR DESCRIPTION
Emergency fix: set reader_settings in DTO to null to avoid issue duri…ng sign-in caused by the element no longer being provided in /api/profile in latest nightly builds of Readeck