### PR TITLE
feat/collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ It began as a fork of [ReadeckApp](https://github.com/jensomato/ReadeckApp) and 
 - Sort and filter bookmark list views on things like title, author, site, labels, etc.
 - Reading progress tracking with per-card visual indicators
 - Readeck highlight and annotation support — view, create, edit, and delete highlights in the reader, and access to all highlights from the navigation drawer
+- Collections — save any filter as a reusable, server-synced view accessible from the navigation drawer
 - Reading typography customization (font family, size, line spacing, content width)
 - In-article text search with highlighted match navigation
 - Bookmark metadata editor for title, description, site name, authors, and more

--- a/app/schemas/com.mydeck.app.io.db.MyDeckDatabase/18.json
+++ b/app/schemas/com.mydeck.app.io.db.MyDeckDatabase/18.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 18,
-    "identityHash": "e7253f849f5193ea30ff1b9bc091d813",
+    "identityHash": "f5b4f527b305222dffe6b7c1bfb520ec",
     "entities": [
       {
         "tableName": "bookmarks",
@@ -727,7 +727,7 @@
       },
       {
         "tableName": "collections",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `isPinned` INTEGER NOT NULL, `search` TEXT, `title` TEXT, `author` TEXT, `site` TEXT, `labels` TEXT, `type` TEXT NOT NULL, `readStatus` TEXT NOT NULL, `isMarked` INTEGER, `isArchived` INTEGER, `rangeStart` TEXT, `rangeEnd` TEXT, `created` INTEGER NOT NULL, `updated` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `isPinned` INTEGER NOT NULL, `search` TEXT, `title` TEXT, `author` TEXT, `site` TEXT, `labels` TEXT, `type` TEXT NOT NULL, `readStatus` TEXT NOT NULL, `isMarked` INTEGER, `isArchived` INTEGER, `hasErrors` INTEGER, `hasLabels` INTEGER, `rangeStart` TEXT, `rangeEnd` TEXT, `created` INTEGER NOT NULL, `updated` INTEGER NOT NULL, PRIMARY KEY(`id`))",
         "fields": [
           {
             "fieldPath": "id",
@@ -795,6 +795,16 @@
             "affinity": "INTEGER"
           },
           {
+            "fieldPath": "hasErrors",
+            "columnName": "hasErrors",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hasLabels",
+            "columnName": "hasLabels",
+            "affinity": "INTEGER"
+          },
+          {
             "fieldPath": "rangeStart",
             "columnName": "rangeStart",
             "affinity": "TEXT"
@@ -827,7 +837,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'e7253f849f5193ea30ff1b9bc091d813')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'f5b4f527b305222dffe6b7c1bfb520ec')"
     ]
   }
 }

--- a/app/schemas/com.mydeck.app.io.db.MyDeckDatabase/18.json
+++ b/app/schemas/com.mydeck.app.io.db.MyDeckDatabase/18.json
@@ -1,0 +1,833 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 18,
+    "identityHash": "e7253f849f5193ea30ff1b9bc091d813",
+    "entities": [
+      {
+        "tableName": "bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `href` TEXT NOT NULL, `created` INTEGER NOT NULL, `updated` INTEGER NOT NULL, `state` INTEGER NOT NULL, `loaded` INTEGER NOT NULL, `url` TEXT NOT NULL, `title` TEXT NOT NULL, `siteName` TEXT NOT NULL, `site` TEXT NOT NULL, `authors` TEXT NOT NULL, `lang` TEXT NOT NULL, `textDirection` TEXT NOT NULL, `documentTpe` TEXT NOT NULL, `type` TEXT NOT NULL, `hasArticle` INTEGER NOT NULL, `description` TEXT NOT NULL, `isDeleted` INTEGER NOT NULL, `isMarked` INTEGER NOT NULL, `isArchived` INTEGER NOT NULL, `labels` TEXT NOT NULL, `readProgress` INTEGER NOT NULL, `wordCount` INTEGER, `readingTime` INTEGER, `published` INTEGER, `embed` TEXT, `embedHostname` TEXT, `contentState` INTEGER NOT NULL, `contentFailureReason` TEXT, `isLocalDeleted` INTEGER NOT NULL, `hasServerErrors` INTEGER NOT NULL, `omitDescription` INTEGER, `errors` TEXT NOT NULL, `article_src` TEXT NOT NULL, `icon_src` TEXT NOT NULL, `icon_width` INTEGER NOT NULL, `icon_height` INTEGER NOT NULL, `image_src` TEXT NOT NULL, `image_width` INTEGER NOT NULL, `image_height` INTEGER NOT NULL, `log_src` TEXT NOT NULL, `props_src` TEXT NOT NULL, `thumbnail_src` TEXT NOT NULL, `thumbnail_width` INTEGER NOT NULL, `thumbnail_height` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "href",
+            "columnName": "href",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updated",
+            "columnName": "updated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "loaded",
+            "columnName": "loaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "siteName",
+            "columnName": "siteName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "site",
+            "columnName": "site",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authors",
+            "columnName": "authors",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lang",
+            "columnName": "lang",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textDirection",
+            "columnName": "textDirection",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "documentTpe",
+            "columnName": "documentTpe",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasArticle",
+            "columnName": "hasArticle",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "isDeleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isMarked",
+            "columnName": "isMarked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isArchived",
+            "columnName": "isArchived",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "labels",
+            "columnName": "labels",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "readProgress",
+            "columnName": "readProgress",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wordCount",
+            "columnName": "wordCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "readingTime",
+            "columnName": "readingTime",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "published",
+            "columnName": "published",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "embed",
+            "columnName": "embed",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "embedHostname",
+            "columnName": "embedHostname",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "contentState",
+            "columnName": "contentState",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentFailureReason",
+            "columnName": "contentFailureReason",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isLocalDeleted",
+            "columnName": "isLocalDeleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasServerErrors",
+            "columnName": "hasServerErrors",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "omitDescription",
+            "columnName": "omitDescription",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "errors",
+            "columnName": "errors",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "article.src",
+            "columnName": "article_src",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon.src",
+            "columnName": "icon_src",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon.width",
+            "columnName": "icon_width",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon.height",
+            "columnName": "icon_height",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "image.src",
+            "columnName": "image_src",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "image.width",
+            "columnName": "image_width",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "image.height",
+            "columnName": "image_height",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "log.src",
+            "columnName": "log_src",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "props.src",
+            "columnName": "props_src",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnail.src",
+            "columnName": "thumbnail_src",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnail.width",
+            "columnName": "thumbnail_width",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnail.height",
+            "columnName": "thumbnail_height",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_bookmarks_readProgress",
+            "unique": false,
+            "columnNames": [
+              "readProgress"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_bookmarks_readProgress` ON `${TABLE_NAME}` (`readProgress`)"
+          },
+          {
+            "name": "index_bookmarks_type",
+            "unique": false,
+            "columnNames": [
+              "type"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_bookmarks_type` ON `${TABLE_NAME}` (`type`)"
+          },
+          {
+            "name": "index_bookmarks_isArchived",
+            "unique": false,
+            "columnNames": [
+              "isArchived"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_bookmarks_isArchived` ON `${TABLE_NAME}` (`isArchived`)"
+          },
+          {
+            "name": "index_bookmarks_isMarked",
+            "unique": false,
+            "columnNames": [
+              "isMarked"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_bookmarks_isMarked` ON `${TABLE_NAME}` (`isMarked`)"
+          }
+        ]
+      },
+      {
+        "tableName": "article_content",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookmarkId` TEXT NOT NULL, `content` TEXT NOT NULL, PRIMARY KEY(`bookmarkId`), FOREIGN KEY(`bookmarkId`) REFERENCES `bookmarks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bookmarkId",
+            "columnName": "bookmarkId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookmarkId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "bookmarks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bookmarkId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "content_package",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookmarkId` TEXT NOT NULL, `packageKind` TEXT NOT NULL, `hasHtml` INTEGER NOT NULL, `hasResources` INTEGER NOT NULL, `sourceUpdated` TEXT NOT NULL, `lastRefreshed` INTEGER NOT NULL, `localBasePath` TEXT NOT NULL, `source` TEXT NOT NULL DEFAULT 'AUTOMATIC', PRIMARY KEY(`bookmarkId`), FOREIGN KEY(`bookmarkId`) REFERENCES `bookmarks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bookmarkId",
+            "columnName": "bookmarkId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageKind",
+            "columnName": "packageKind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasHtml",
+            "columnName": "hasHtml",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasResources",
+            "columnName": "hasResources",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceUpdated",
+            "columnName": "sourceUpdated",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastRefreshed",
+            "columnName": "lastRefreshed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localBasePath",
+            "columnName": "localBasePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'AUTOMATIC'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookmarkId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "bookmarks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bookmarkId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "content_resource",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `bookmarkId` TEXT NOT NULL, `path` TEXT NOT NULL, `mimeType` TEXT NOT NULL, `group` TEXT, `localRelativePath` TEXT NOT NULL, `byteSize` INTEGER NOT NULL, FOREIGN KEY(`bookmarkId`) REFERENCES `bookmarks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarkId",
+            "columnName": "bookmarkId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mimeType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "group",
+            "columnName": "group",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localRelativePath",
+            "columnName": "localRelativePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "byteSize",
+            "columnName": "byteSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_content_resource_bookmarkId",
+            "unique": false,
+            "columnNames": [
+              "bookmarkId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_content_resource_bookmarkId` ON `${TABLE_NAME}` (`bookmarkId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "bookmarks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bookmarkId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "remote_bookmark_ids",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`syncRunId` TEXT NOT NULL, `id` TEXT NOT NULL, PRIMARY KEY(`syncRunId`, `id`))",
+        "fields": [
+          {
+            "fieldPath": "syncRunId",
+            "columnName": "syncRunId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "syncRunId",
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "remote_annotation_ids",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "pending_actions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `bookmarkId` TEXT NOT NULL, `actionType` TEXT NOT NULL, `payload` TEXT, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarkId",
+            "columnName": "bookmarkId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "actionType",
+            "columnName": "actionType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payload",
+            "columnName": "payload",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_pending_actions_bookmarkId_actionType",
+            "unique": false,
+            "columnNames": [
+              "bookmarkId",
+              "actionType"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_pending_actions_bookmarkId_actionType` ON `${TABLE_NAME}` (`bookmarkId`, `actionType`)"
+          }
+        ]
+      },
+      {
+        "tableName": "cached_annotation",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `bookmarkId` TEXT NOT NULL, `text` TEXT NOT NULL, `color` TEXT NOT NULL, `note` TEXT, `created` TEXT NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`bookmarkId`) REFERENCES `bookmarks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarkId",
+            "columnName": "bookmarkId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_annotation_bookmarkId",
+            "unique": false,
+            "columnNames": [
+              "bookmarkId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_annotation_bookmarkId` ON `${TABLE_NAME}` (`bookmarkId`)"
+          },
+          {
+            "name": "index_cached_annotation_created",
+            "unique": false,
+            "columnNames": [
+              "created"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_annotation_created` ON `${TABLE_NAME}` (`created`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "bookmarks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bookmarkId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "bookmark_annotation_sync_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookmarkId` TEXT NOT NULL, `lastAttemptAt` INTEGER, `lastSuccessAt` INTEGER, `lastFailureAt` INTEGER, `failureCount` INTEGER NOT NULL, `backoffUntil` INTEGER, PRIMARY KEY(`bookmarkId`))",
+        "fields": [
+          {
+            "fieldPath": "bookmarkId",
+            "columnName": "bookmarkId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAttemptAt",
+            "columnName": "lastAttemptAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastSuccessAt",
+            "columnName": "lastSuccessAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastFailureAt",
+            "columnName": "lastFailureAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "failureCount",
+            "columnName": "failureCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "backoffUntil",
+            "columnName": "backoffUntil",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookmarkId"
+          ]
+        }
+      },
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `isPinned` INTEGER NOT NULL, `search` TEXT, `title` TEXT, `author` TEXT, `site` TEXT, `labels` TEXT, `type` TEXT NOT NULL, `readStatus` TEXT NOT NULL, `isMarked` INTEGER, `isArchived` INTEGER, `rangeStart` TEXT, `rangeEnd` TEXT, `created` INTEGER NOT NULL, `updated` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPinned",
+            "columnName": "isPinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "search",
+            "columnName": "search",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "site",
+            "columnName": "site",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "labels",
+            "columnName": "labels",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "readStatus",
+            "columnName": "readStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isMarked",
+            "columnName": "isMarked",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isArchived",
+            "columnName": "isArchived",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "rangeStart",
+            "columnName": "rangeStart",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "rangeEnd",
+            "columnName": "rangeEnd",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updated",
+            "columnName": "updated",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'e7253f849f5193ea30ff1b9bc091d813')"
+    ]
+  }
+}

--- a/app/src/main/assets/guide/en/highlights.md
+++ b/app/src/main/assets/guide/en/highlights.md
@@ -42,7 +42,9 @@ Tap the **sort icon** (↕) in the top bar to toggle between newest-first and ol
 
 ## Sync and Refresh
 
-MyDeck keeps your highlights in sync with your Readeck server. 
+MyDeck keeps your highlights in sync with your Readeck server.
+- Pull down on the list to refresh highlights immediately.
 - A **progress bar** at the top shows when a refresh is in progress.
 - If a refresh fails, saved highlights remain visible and a **Retry** button appears.
+- If a background sync fails partway through, a banner indicates highlights may be incomplete — pull to refresh to retry.
 - When you reopen downloaded content while online, MyDeck checks whether the server-side highlights have changed and refreshes the content if needed.

--- a/app/src/main/assets/guide/en/your-bookmarks.md
+++ b/app/src/main/assets/guide/en/your-bookmarks.md
@@ -205,6 +205,14 @@ To create one, tap the **New Collection** button. A sheet opens with the same fi
 
 Tap any collection card to open it. The list then shows that collection as its own view: the top bar displays the collection's name with a leading icon, and the collection's own criteria are not shown as filter chips — it reads like an ordinary list. To leave a collection, pick any other view (My List, Archive, a label, etc.) from the navigation drawer.
 
+**Saving the current filter as a collection.** When you've applied a filter to an ordinary list (so chips are showing), open the **⋮ overflow menu** and tap **Save as Collection**. The editor opens pre-filled with your current filter; name it and tap Save to keep it.
+
+**Layering filters on a collection.** While viewing a collection you can still apply additional filters (⋮ → Filter). Those extra criteria appear as chips on top of the collection; the app-bar title stays the collection's name, and the saved collection is unchanged until you explicitly save. Dismiss a chip (or tap **Reset** in the filter sheet) to return to just the collection's own criteria.
+
+**Editing, renaming, and deleting.** While a collection is active, the **⋮ overflow menu** offers **Edit collection** and **Delete collection**. Edit opens the editor pre-filled with the collection's criteria (plus any filter you've layered on) and its current name — change the name to rename it, adjust the criteria, and Save. Delete (from the overflow or the editor's Delete button) asks for confirmation before removing the collection.
+
+Note: the **Downloaded** filter and the **Length** (reading time / word count) filters are specific to this device and aren't stored in collections, so they don't appear in the collection editor. They remain available in the normal list filter.
+
 ## Selecting Multiple Bookmarks
 
 Open the **⋮ overflow menu** and tap **Select bookmarks** to enter selection mode. The top bar switches to an **✕** (exit), the number of selected bookmarks as the title, an **📦 Archive** and a **❤️ Favorite** action, and a **⋮ overflow**. Tap any card to select or deselect it — each card's action buttons become dimmed icons showing its current favorite and archive state, with a selection indicator on the right. Tap **✕** to exit and clear the selection.

--- a/app/src/main/assets/guide/en/your-bookmarks.md
+++ b/app/src/main/assets/guide/en/your-bookmarks.md
@@ -197,6 +197,14 @@ To return to a standard view you can:
 
 Tap **Search** to apply, or **Reset** to clear all filters.
 
+## Collections
+
+A **collection** is a saved set of filter criteria you can return to with a single tap. Open **Collections** from the navigation drawer (or the navigation rail in wide layouts) to see all your collections, each shown as a card with its name and the date it was created.
+
+To create one, tap the **New Collection** button. A sheet opens with the same filter controls as the filter sheet, plus a **name** field at the top. Set the criteria you want, give the collection a name, and tap **Save** (Save stays disabled until you enter a name). MyDeck opens the new collection right away.
+
+Tap any collection card to open it. The list then shows that collection as its own view: the top bar displays the collection's name with a leading icon, and the collection's own criteria are not shown as filter chips — it reads like an ordinary list. To leave a collection, pick any other view (My List, Archive, a label, etc.) from the navigation drawer.
+
 ## Selecting Multiple Bookmarks
 
 Open the **⋮ overflow menu** and tap **Select bookmarks** to enter selection mode. The top bar switches to an **✕** (exit), the number of selected bookmarks as the title, an **📦 Archive** and a **❤️ Favorite** action, and a **⋮ overflow**. Tap any card to select or deselect it — each card's action buttons become dimmed icons showing its current favorite and archive state, with a selection indicator on the right. Tap **✕** to exit and clear the selection.

--- a/app/src/main/assets/guide/en/your-bookmarks.md
+++ b/app/src/main/assets/guide/en/your-bookmarks.md
@@ -13,9 +13,10 @@ Tap the **menu icon** (☰) in the top-left corner to open the navigation drawer
 - **Videos** — video-type bookmarks only
 - **Pictures** — picture-type bookmarks only
 - **Labels** — open the label sheet; tap a label to see all bookmarks with that label
-- **Highlights** — a global index of all highlights saved across all your bookmarks. Pull down on the list to refresh highlights immediately. If a sync fails partway through, MyDeck shows a banner indicating highlights may be incomplete — pull to refresh to retry.
+- **Highlights** — a global index of all highlights saved across all your bookmarks
+- **Collections** — your saved filter views; tap one to open it as the active list
 
-Each item shows a count of how many bookmarks it contains.
+Most items show a count of how many bookmarks they contain; Collections shows how many collections you've saved.
 Tap outside the drawer or swipe it closed to dismiss it without changing sections.
 
 The top bar shows the **☰ menu**, the current section title, a **layout icon**, a **sort icon**, and a **⋮ overflow menu**. The overflow holds **Filter** and **Select bookmarks**. (When you're viewing a single label, the overflow instead offers **Rename label**, **Delete label**, and **Select bookmarks**.)

--- a/app/src/main/assets/guide/en/your-bookmarks.md
+++ b/app/src/main/assets/guide/en/your-bookmarks.md
@@ -209,7 +209,7 @@ Tap any collection card to open it. The list then shows that collection as its o
 
 **Layering filters on a collection.** While viewing a collection you can still apply additional filters (⋮ → Filter). Those extra criteria appear as chips on top of the collection; the app-bar title stays the collection's name, and the saved collection is unchanged until you explicitly save. Dismiss a chip (or tap **Reset** in the filter sheet) to return to just the collection's own criteria.
 
-**Editing, renaming, and deleting.** While a collection is active, the **⋮ overflow menu** offers **Edit collection** and **Delete collection**. Edit opens the editor pre-filled with the collection's criteria (plus any filter you've layered on) and its current name — change the name to rename it, adjust the criteria, and Save. Delete (from the overflow or the editor's Delete button) asks for confirmation before removing the collection.
+**Editing, renaming, and deleting.** While a collection is active, the **⋮ overflow menu** offers **Edit collection** and **Delete collection**. Edit opens the editor pre-filled with the collection's criteria (plus any filter you've layered on) and its current name — change the name to rename it, adjust the criteria, and Save. Delete (from the overflow or the editor's **Delete** button) removes the collection and shows a **"Collection deleted"** snackbar with **Undo** — the same as deleting a bookmark, the removal is held until the snackbar goes away, so tap Undo to keep it.
 
 Note: the **Downloaded** filter and the **Length** (reading time / word count) filters are specific to this device and aren't stored in collections, so they don't appear in the collection editor. They remain available in the normal list filter.
 

--- a/app/src/main/java/com/mydeck/app/AppModule.kt
+++ b/app/src/main/java/com/mydeck/app/AppModule.kt
@@ -12,6 +12,8 @@ import com.mydeck.app.coroutine.ApplicationScope
 import com.mydeck.app.coroutine.IoDispatcher
 import com.mydeck.app.domain.BookmarkRepository
 import com.mydeck.app.domain.BookmarkRepositoryImpl
+import com.mydeck.app.domain.CollectionRepository
+import com.mydeck.app.domain.CollectionRepositoryImpl
 import com.mydeck.app.domain.UserRepository
 import com.mydeck.app.domain.UserRepositoryImpl
 import com.mydeck.app.domain.sync.ConnectivityMonitor
@@ -34,6 +36,10 @@ abstract class AppModule {
     @Binds
     @Singleton
     abstract fun bindBookmarkRepository(bookmarkRepositoryImpl: BookmarkRepositoryImpl): BookmarkRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindCollectionRepository(impl: CollectionRepositoryImpl): CollectionRepository
 
     @Binds
     abstract fun bindUserRepository(userRepositoryImpl: UserRepositoryImpl): UserRepository

--- a/app/src/main/java/com/mydeck/app/domain/CollectionRepository.kt
+++ b/app/src/main/java/com/mydeck/app/domain/CollectionRepository.kt
@@ -1,0 +1,22 @@
+package com.mydeck.app.domain
+
+import com.mydeck.app.domain.model.Collection
+import com.mydeck.app.domain.model.FilterFormState
+import kotlinx.coroutines.flow.Flow
+
+interface CollectionRepository {
+    /** Emits the local cached list of non-deleted collections. */
+    fun observeCollections(): Flow<List<Collection>>
+
+    /** Fetches all collections from the server and replaces the local cache atomically. */
+    suspend fun refreshCollections(): Result<Unit>
+
+    /** Creates a new collection server-side and caches it locally. */
+    suspend fun createCollection(name: String, filter: FilterFormState): Result<Collection>
+
+    /** Updates an existing collection's name and/or filter server-side, then updates the cache. */
+    suspend fun updateCollection(id: String, name: String, filter: FilterFormState): Result<Collection>
+
+    /** Soft-deletes a collection via PATCH is_deleted=true, then removes it from the local cache. */
+    suspend fun deleteCollection(id: String): Result<Unit>
+}

--- a/app/src/main/java/com/mydeck/app/domain/CollectionRepositoryImpl.kt
+++ b/app/src/main/java/com/mydeck/app/domain/CollectionRepositoryImpl.kt
@@ -4,13 +4,13 @@ import com.mydeck.app.coroutine.IoDispatcher
 import com.mydeck.app.domain.model.Collection
 import com.mydeck.app.domain.model.FilterFormState
 import com.mydeck.app.domain.model.toCreateCollectionDto
+import com.mydeck.app.domain.model.toUpdateCollectionJson
 import com.mydeck.app.domain.model.toDomain
 import com.mydeck.app.domain.model.toEntity
 import com.mydeck.app.io.db.MyDeckDatabase
 import com.mydeck.app.io.db.dao.CollectionDao
 import com.mydeck.app.io.db.model.CollectionEntity
 import com.mydeck.app.io.rest.ReadeckApi
-import com.mydeck.app.io.rest.model.UpdateCollectionDto
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -114,11 +114,20 @@ class CollectionRepositoryImpl @Inject constructor(
         filter: FilterFormState,
     ): Result<Collection> = withContext(dispatcher) {
         try {
-            val response = readeckApi.updateCollection(id, filter.toCreateCollectionDto(name))
-            val dto = response.body()
-            if (!response.isSuccessful || dto == null) {
+            // PATCH returns only a partial "updated fields" summary (no id/href/created), so we don't
+            // read its body; on success re-fetch the full object to cache (mirrors createCollection).
+            // The body sends explicit nulls (toUpdateCollectionJson) so cleared criteria are cleared.
+            val response = readeckApi.updateCollection(id, filter.toUpdateCollectionJson(name))
+            if (!response.isSuccessful) {
                 return@withContext Result.failure(
                     Exception("Failed to update collection $id: HTTP ${response.code()}")
+                )
+            }
+            val fetched = readeckApi.getCollectionById(id)
+            val dto = fetched.body()
+            if (!fetched.isSuccessful || dto == null) {
+                return@withContext Result.failure(
+                    Exception("Failed to load updated collection $id: HTTP ${fetched.code()}")
                 )
             }
             val entity = dto.toEntity()
@@ -134,17 +143,7 @@ class CollectionRepositoryImpl @Inject constructor(
 
     override suspend fun deleteCollection(id: String): Result<Unit> = withContext(dispatcher) {
         try {
-            // Soft delete: PATCH is_deleted=true. The PATCH body requires a name, so reuse the
-            // cached name (unchanged); the server has no DELETE endpoint for collections.
-            val name = collectionDao.getById(id)?.name
-                ?: readeckApi.getCollectionById(id).let { if (it.isSuccessful) it.body()?.name else null }
-                ?: return@withContext Result.failure(
-                    Exception("Cannot delete unknown collection $id")
-                )
-            val response = readeckApi.updateCollection(
-                id,
-                UpdateCollectionDto(name = name, isDeleted = true)
-            )
+            val response = readeckApi.deleteCollection(id)
             if (!response.isSuccessful) {
                 return@withContext Result.failure(
                     Exception("Failed to delete collection $id: HTTP ${response.code()}")

--- a/app/src/main/java/com/mydeck/app/domain/CollectionRepositoryImpl.kt
+++ b/app/src/main/java/com/mydeck/app/domain/CollectionRepositoryImpl.kt
@@ -1,0 +1,167 @@
+package com.mydeck.app.domain
+
+import com.mydeck.app.coroutine.IoDispatcher
+import com.mydeck.app.domain.model.Collection
+import com.mydeck.app.domain.model.FilterFormState
+import com.mydeck.app.domain.model.toCreateCollectionDto
+import com.mydeck.app.domain.model.toDomain
+import com.mydeck.app.domain.model.toEntity
+import com.mydeck.app.io.db.MyDeckDatabase
+import com.mydeck.app.io.db.dao.CollectionDao
+import com.mydeck.app.io.db.model.CollectionEntity
+import com.mydeck.app.io.rest.ReadeckApi
+import com.mydeck.app.io.rest.model.UpdateCollectionDto
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+import javax.inject.Inject
+
+class CollectionRepositoryImpl @Inject constructor(
+    private val database: MyDeckDatabase,
+    private val collectionDao: CollectionDao,
+    private val readeckApi: ReadeckApi,
+    @IoDispatcher
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : CollectionRepository {
+
+    override fun observeCollections(): Flow<List<Collection>> =
+        collectionDao.observeCollections().map { entities -> entities.map { it.toDomain() } }
+
+    override suspend fun refreshCollections(): Result<Unit> = withContext(dispatcher) {
+        try {
+            val all = mutableListOf<CollectionEntity>()
+            var offset = 0
+            // Guard against an unbounded loop if the server keeps returning full pages.
+            var page = 0
+            while (page < MAX_PAGES) {
+                val response = readeckApi.getCollections(limit = PAGE_SIZE, offset = offset)
+                if (!response.isSuccessful) {
+                    return@withContext Result.failure(
+                        Exception("Failed to fetch collections: HTTP ${response.code()}")
+                    )
+                }
+                val body = response.body().orEmpty()
+                // Drop soft-deleted collections; only non-deleted ones are cached.
+                all += body.filterNot { it.isDeleted == true }.map { it.toEntity() }
+                if (body.size < PAGE_SIZE) break
+                offset += PAGE_SIZE
+                page++
+            }
+            if (page >= MAX_PAGES) {
+                Timber.w("refreshCollections hit MAX_PAGES ($MAX_PAGES); some collections may be missing")
+            }
+            // Atomic cache replace.
+            database.performTransaction {
+                collectionDao.deleteAll()
+                collectionDao.upsertCollections(all)
+            }
+            Result.success(Unit)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.e(e, "refreshCollections failed")
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun createCollection(
+        name: String,
+        filter: FilterFormState,
+    ): Result<Collection> = withContext(dispatcher) {
+        try {
+            val response = readeckApi.createCollection(filter.toCreateCollectionDto(name))
+            if (!response.isSuccessful) {
+                return@withContext Result.failure(
+                    Exception("Failed to create collection: HTTP ${response.code()}")
+                )
+            }
+            // POST returns no id in the body; the new collection's id is the trailing path segment
+            // of the Location header. Fetch the full object by id to cache it.
+            val id = response.headers()[ReadeckApi.Header.LOCATION]
+                ?.substringBefore('?')
+                ?.trimEnd('/')
+                ?.substringAfterLast('/')
+                ?.takeIf { it.isNotBlank() }
+                ?: return@withContext Result.failure(
+                    Exception("Create collection response missing Location header")
+                )
+
+            val fetched = readeckApi.getCollectionById(id)
+            val dto = fetched.body()
+            if (!fetched.isSuccessful || dto == null) {
+                return@withContext Result.failure(
+                    Exception("Failed to load created collection $id: HTTP ${fetched.code()}")
+                )
+            }
+            val entity = dto.toEntity()
+            collectionDao.upsertCollections(listOf(entity))
+            Result.success(entity.toDomain())
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.e(e, "createCollection failed")
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun updateCollection(
+        id: String,
+        name: String,
+        filter: FilterFormState,
+    ): Result<Collection> = withContext(dispatcher) {
+        try {
+            val response = readeckApi.updateCollection(id, filter.toCreateCollectionDto(name))
+            val dto = response.body()
+            if (!response.isSuccessful || dto == null) {
+                return@withContext Result.failure(
+                    Exception("Failed to update collection $id: HTTP ${response.code()}")
+                )
+            }
+            val entity = dto.toEntity()
+            collectionDao.upsertCollections(listOf(entity))
+            Result.success(entity.toDomain())
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.e(e, "updateCollection failed")
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun deleteCollection(id: String): Result<Unit> = withContext(dispatcher) {
+        try {
+            // Soft delete: PATCH is_deleted=true. The PATCH body requires a name, so reuse the
+            // cached name (unchanged); the server has no DELETE endpoint for collections.
+            val name = collectionDao.getById(id)?.name
+                ?: readeckApi.getCollectionById(id).let { if (it.isSuccessful) it.body()?.name else null }
+                ?: return@withContext Result.failure(
+                    Exception("Cannot delete unknown collection $id")
+                )
+            val response = readeckApi.updateCollection(
+                id,
+                UpdateCollectionDto(name = name, isDeleted = true)
+            )
+            if (!response.isSuccessful) {
+                return@withContext Result.failure(
+                    Exception("Failed to delete collection $id: HTTP ${response.code()}")
+                )
+            }
+            collectionDao.deleteById(id)
+            Result.success(Unit)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.e(e, "deleteCollection failed")
+            Result.failure(e)
+        }
+    }
+
+    private companion object {
+        const val PAGE_SIZE = 100
+        const val MAX_PAGES = 100
+    }
+}

--- a/app/src/main/java/com/mydeck/app/domain/model/Collection.kt
+++ b/app/src/main/java/com/mydeck/app/domain/model/Collection.kt
@@ -1,0 +1,16 @@
+package com.mydeck.app.domain.model
+
+import kotlinx.datetime.Instant
+
+/**
+ * A named, persisted set of filter criteria. Selecting a collection applies its [filter] to the
+ * bookmark list. Collections are managed server-side via the Readeck API and cached locally in Room.
+ */
+data class Collection(
+    val id: String,
+    val name: String,
+    val isPinned: Boolean,
+    val filter: FilterFormState,
+    val created: Instant,
+    val updated: Instant,
+)

--- a/app/src/main/java/com/mydeck/app/domain/model/CollectionFilterAdapter.kt
+++ b/app/src/main/java/com/mydeck/app/domain/model/CollectionFilterAdapter.kt
@@ -1,0 +1,177 @@
+package com.mydeck.app.domain.model
+
+import com.mydeck.app.io.db.model.CollectionEntity
+import com.mydeck.app.io.rest.model.CollectionDto
+import com.mydeck.app.io.rest.model.CreateCollectionDto
+import kotlinx.datetime.Instant
+import timber.log.Timber
+
+/**
+ * Bi-directional conversion between [FilterFormState] and the Readeck collection DTO/entity shapes.
+ *
+ * Field mapping (see collections-feature-design.md):
+ * - `search` / `title` / `author` / `site` — passthrough.
+ * - `label` ↔ `labels` — single string. The API field accepts comma-separated values; we persist the
+ *   single active label and load the first segment.
+ * - `fromDate` ↔ `range_start`, `toDate` ↔ `range_end` — ISO-8601 [Instant] string.
+ * - `types` ↔ `type` — [Bookmark.Type] ↔ "article" / "photo" / "video".
+ * - `progress` ↔ `read_status` — [ProgressFilter] ↔ "unread" / "reading" / "read".
+ * - `isFavorite` ↔ `is_marked`, `isArchived` ↔ `is_archived` — nullable Boolean passthrough.
+ *
+ * Local-only fields with no API equivalent are **dropped on persist and default on load**:
+ * `isLoaded`, `withLabels`, `withErrors`, and the reading-time / word-count range fields
+ * (`minReadingTime`, `maxReadingTime`, `includeNullReadingTime`, `minWordCount`, `maxWordCount`,
+ * `includeNullWordCount`).
+ */
+
+// --- enum <-> wire string helpers (shared by DTO and entity conversions) ---
+
+private const val TYPE_ARTICLE = "article"
+private const val TYPE_PHOTO = "photo"
+private const val TYPE_VIDEO = "video"
+
+private const val READ_UNREAD = "unread"
+private const val READ_READING = "reading"
+private const val READ_READ = "read"
+
+private fun Bookmark.Type.toWire(): String = when (this) {
+    Bookmark.Type.Article -> TYPE_ARTICLE
+    Bookmark.Type.Picture -> TYPE_PHOTO
+    Bookmark.Type.Video -> TYPE_VIDEO
+}
+
+private fun String.toBookmarkTypeOrNull(): Bookmark.Type? = when (this) {
+    TYPE_ARTICLE -> Bookmark.Type.Article
+    TYPE_PHOTO -> Bookmark.Type.Picture
+    TYPE_VIDEO -> Bookmark.Type.Video
+    else -> null
+}
+
+private fun ProgressFilter.toWire(): String = when (this) {
+    ProgressFilter.UNVIEWED -> READ_UNREAD
+    ProgressFilter.IN_PROGRESS -> READ_READING
+    ProgressFilter.COMPLETED -> READ_READ
+}
+
+private fun String.toProgressFilterOrNull(): ProgressFilter? = when (this) {
+    READ_UNREAD -> ProgressFilter.UNVIEWED
+    READ_READING -> ProgressFilter.IN_PROGRESS
+    READ_READ -> ProgressFilter.COMPLETED
+    else -> null
+}
+
+private fun parseInstantOrNull(value: String?): Instant? {
+    if (value.isNullOrBlank()) return null
+    return try {
+        Instant.parse(value)
+    } catch (e: Exception) {
+        Timber.w(e, "Failed to parse collection date: $value")
+        null
+    }
+}
+
+/** First label of a (possibly comma-separated) API `labels` field, or null. */
+private fun firstLabelOrNull(labels: String?): String? =
+    labels?.split(",")?.firstOrNull()?.trim()?.takeIf { it.isNotEmpty() }
+
+private fun List<Bookmark.Type>.typesOrNull(): List<String>? =
+    map { it.toWire() }.takeIf { it.isNotEmpty() }
+
+private fun Set<ProgressFilter>.progressOrNull(): List<String>? =
+    map { it.toWire() }.takeIf { it.isNotEmpty() }
+
+// --- FilterFormState <-> create/update request ---
+
+/**
+ * Builds the create/update request body from this filter state. Local-only fields are omitted.
+ * [name] and [isPinned] are not part of [FilterFormState] and are supplied by the caller.
+ */
+fun FilterFormState.toCreateCollectionDto(
+    name: String,
+    isPinned: Boolean? = null,
+): CreateCollectionDto = CreateCollectionDto(
+    name = name,
+    isPinned = isPinned,
+    search = search,
+    title = title,
+    author = author,
+    site = site,
+    labels = label,
+    type = types.map { it.toWire() }.takeIf { it.isNotEmpty() },
+    readStatus = progress.progressOrNull(),
+    isMarked = isFavorite,
+    isArchived = isArchived,
+    rangeStart = fromDate?.toString(),
+    rangeEnd = toDate?.toString(),
+)
+
+// --- DTO -> FilterFormState ---
+
+fun CollectionDto.toFilterFormState(): FilterFormState = FilterFormState(
+    search = search,
+    title = title,
+    author = author,
+    site = site,
+    label = firstLabelOrNull(labels),
+    fromDate = parseInstantOrNull(rangeStart),
+    toDate = parseInstantOrNull(rangeEnd),
+    types = type?.mapNotNull { it.toBookmarkTypeOrNull() }?.toSet() ?: emptySet(),
+    progress = readStatus?.mapNotNull { it.toProgressFilterOrNull() }?.toSet() ?: emptySet(),
+    isFavorite = isMarked,
+    isArchived = isArchived,
+    // Local-only fields (no API equivalent): isLoaded/withLabels/withErrors default null; the
+    // reading-time/word-count fields default (null / false) by omission from this constructor call.
+    isLoaded = null,
+    withLabels = null,
+    withErrors = null,
+)
+
+// --- DTO -> Entity (for caching) ---
+
+fun CollectionDto.toEntity(): CollectionEntity = CollectionEntity(
+    id = id,
+    name = name,
+    isPinned = isPinned ?: false,
+    search = search,
+    title = title,
+    author = author,
+    site = site,
+    labels = labels,
+    type = type ?: emptyList(),
+    readStatus = readStatus ?: emptyList(),
+    isMarked = isMarked,
+    isArchived = isArchived,
+    rangeStart = rangeStart,
+    rangeEnd = rangeEnd,
+    created = (parseInstantOrNull(created) ?: Instant.fromEpochMilliseconds(0)).toEpochMilliseconds(),
+    updated = (parseInstantOrNull(updated) ?: Instant.fromEpochMilliseconds(0)).toEpochMilliseconds(),
+)
+
+// --- Entity -> Domain ---
+
+fun CollectionEntity.toFilterFormState(): FilterFormState = FilterFormState(
+    search = search,
+    title = title,
+    author = author,
+    site = site,
+    label = firstLabelOrNull(labels),
+    fromDate = parseInstantOrNull(rangeStart),
+    toDate = parseInstantOrNull(rangeEnd),
+    types = type.mapNotNull { it.toBookmarkTypeOrNull() }.toSet(),
+    progress = readStatus.mapNotNull { it.toProgressFilterOrNull() }.toSet(),
+    isFavorite = isMarked,
+    isArchived = isArchived,
+    // Local-only fields default as in CollectionDto.toFilterFormState (no persisted equivalent).
+    isLoaded = null,
+    withLabels = null,
+    withErrors = null,
+)
+
+fun CollectionEntity.toDomain(): Collection = Collection(
+    id = id,
+    name = name,
+    isPinned = isPinned,
+    filter = toFilterFormState(),
+    created = Instant.fromEpochMilliseconds(created),
+    updated = Instant.fromEpochMilliseconds(updated),
+)

--- a/app/src/main/java/com/mydeck/app/domain/model/CollectionFilterAdapter.kt
+++ b/app/src/main/java/com/mydeck/app/domain/model/CollectionFilterAdapter.kt
@@ -17,11 +17,14 @@ import timber.log.Timber
  * - `types` ↔ `type` — [Bookmark.Type] ↔ "article" / "photo" / "video".
  * - `progress` ↔ `read_status` — [ProgressFilter] ↔ "unread" / "reading" / "read".
  * - `isFavorite` ↔ `is_marked`, `isArchived` ↔ `is_archived` — nullable Boolean passthrough.
+ * - `withErrors` ↔ `has_errors`, `withLabels` ↔ `has_labels` — nullable Boolean passthrough
+ *   (server-supported on collections, verified against the live API).
  *
- * Local-only fields with no API equivalent are **dropped on persist and default on load**:
- * `isLoaded`, `withLabels`, `withErrors`, and the reading-time / word-count range fields
- * (`minReadingTime`, `maxReadingTime`, `includeNullReadingTime`, `minWordCount`, `maxWordCount`,
- * `includeNullWordCount`).
+ * Local-only fields with no collection-API equivalent are **dropped on persist and default on load**:
+ * `isLoaded` (the device-local "Downloaded" state; the server's `is_loaded` is a different,
+ * server-side fetch concept not stored on collections) and the reading-time / word-count range
+ * fields (`minReadingTime`, `maxReadingTime`, `includeNullReadingTime`, `minWordCount`,
+ * `maxWordCount`, `includeNullWordCount`).
  */
 
 // --- enum <-> wire string helpers (shared by DTO and entity conversions) ---
@@ -101,6 +104,8 @@ fun FilterFormState.toCreateCollectionDto(
     readStatus = progress.progressOrNull(),
     isMarked = isFavorite,
     isArchived = isArchived,
+    hasErrors = withErrors,
+    hasLabels = withLabels,
     rangeStart = fromDate?.toString(),
     rangeEnd = toDate?.toString(),
 )
@@ -119,11 +124,11 @@ fun CollectionDto.toFilterFormState(): FilterFormState = FilterFormState(
     progress = readStatus?.mapNotNull { it.toProgressFilterOrNull() }?.toSet() ?: emptySet(),
     isFavorite = isMarked,
     isArchived = isArchived,
-    // Local-only fields (no API equivalent): isLoaded/withLabels/withErrors default null; the
-    // reading-time/word-count fields default (null / false) by omission from this constructor call.
+    withErrors = hasErrors,
+    withLabels = hasLabels,
+    // Local-only: isLoaded ("Downloaded") has no collection equivalent → null; the reading-time /
+    // word-count fields default (null / false) by omission from this constructor call.
     isLoaded = null,
-    withLabels = null,
-    withErrors = null,
 )
 
 // --- DTO -> Entity (for caching) ---
@@ -141,6 +146,8 @@ fun CollectionDto.toEntity(): CollectionEntity = CollectionEntity(
     readStatus = readStatus ?: emptyList(),
     isMarked = isMarked,
     isArchived = isArchived,
+    hasErrors = hasErrors,
+    hasLabels = hasLabels,
     rangeStart = rangeStart,
     rangeEnd = rangeEnd,
     created = (parseInstantOrNull(created) ?: Instant.fromEpochMilliseconds(0)).toEpochMilliseconds(),
@@ -161,10 +168,10 @@ fun CollectionEntity.toFilterFormState(): FilterFormState = FilterFormState(
     progress = readStatus.mapNotNull { it.toProgressFilterOrNull() }.toSet(),
     isFavorite = isMarked,
     isArchived = isArchived,
-    // Local-only fields default as in CollectionDto.toFilterFormState (no persisted equivalent).
+    withErrors = hasErrors,
+    withLabels = hasLabels,
+    // Local-only: isLoaded ("Downloaded") has no persisted equivalent (see CollectionDto.toFilterFormState).
     isLoaded = null,
-    withLabels = null,
-    withErrors = null,
 )
 
 fun CollectionEntity.toDomain(): Collection = Collection(

--- a/app/src/main/java/com/mydeck/app/domain/model/CollectionFilterAdapter.kt
+++ b/app/src/main/java/com/mydeck/app/domain/model/CollectionFilterAdapter.kt
@@ -4,6 +4,12 @@ import com.mydeck.app.io.db.model.CollectionEntity
 import com.mydeck.app.io.rest.model.CollectionDto
 import com.mydeck.app.io.rest.model.CreateCollectionDto
 import kotlinx.datetime.Instant
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import timber.log.Timber
 
 /**
@@ -109,6 +115,30 @@ fun FilterFormState.toCreateCollectionDto(
     rangeStart = fromDate?.toString(),
     rangeEnd = toDate?.toString(),
 )
+
+/**
+ * Builds the PATCH (update) body for a collection. Unlike create, this serialises every managed
+ * filter field **explicitly, including nulls**, so clearing a criterion is sent as `null` and the
+ * server actually clears it. (The shared Json uses `explicitNulls = false`, which would otherwise
+ * omit cleared fields and PATCH would leave them unchanged.) `is_pinned` / `is_deleted` are
+ * deliberately omitted so editing a collection never disturbs its pin/deletion state.
+ */
+fun FilterFormState.toUpdateCollectionJson(name: String): JsonObject = buildJsonObject {
+    put("name", name)
+    put("search", search)
+    put("title", title)
+    put("author", author)
+    put("site", site)
+    put("labels", label)
+    put("is_marked", isFavorite)
+    put("is_archived", isArchived)
+    put("has_errors", withErrors)
+    put("has_labels", withLabels)
+    put("range_start", fromDate?.toString())
+    put("range_end", toDate?.toString())
+    put("type", if (types.isEmpty()) JsonNull else JsonArray(types.map { JsonPrimitive(it.toWire()) }))
+    put("read_status", if (progress.isEmpty()) JsonNull else JsonArray(progress.map { JsonPrimitive(it.toWire()) }))
+}
 
 // --- DTO -> FilterFormState ---
 

--- a/app/src/main/java/com/mydeck/app/domain/model/CollectionSortOption.kt
+++ b/app/src/main/java/com/mydeck/app/domain/model/CollectionSortOption.kt
@@ -1,0 +1,14 @@
+package com.mydeck.app.domain.model
+
+enum class CollectionSortOption {
+    DATE_NEWEST, DATE_OLDEST, NAME_A_TO_Z, NAME_Z_TO_A;
+
+    val comparator: Comparator<Collection> get() = when (this) {
+        DATE_NEWEST -> compareByDescending { it.created }
+        DATE_OLDEST -> compareBy { it.created }
+        NAME_A_TO_Z -> compareBy(String.CASE_INSENSITIVE_ORDER) { it.name }
+        NAME_Z_TO_A -> Comparator { a, b -> String.CASE_INSENSITIVE_ORDER.compare(b.name, a.name) }
+    }
+
+    val isDescending: Boolean get() = this == DATE_NEWEST || this == NAME_Z_TO_A
+}

--- a/app/src/main/java/com/mydeck/app/io/db/DatabaseModule.kt
+++ b/app/src/main/java/com/mydeck/app/io/db/DatabaseModule.kt
@@ -9,6 +9,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import com.mydeck.app.io.db.dao.BookmarkDao
 import com.mydeck.app.io.db.dao.CachedAnnotationDao
+import com.mydeck.app.io.db.dao.CollectionDao
 import com.mydeck.app.io.db.dao.ContentPackageDao
 import com.mydeck.app.io.db.dao.PendingActionDao
 import com.mydeck.app.domain.content.ContentPackageManager
@@ -39,7 +40,8 @@ object DatabaseModule {
                 MyDeckDatabase.MIGRATION_13_14,
                 MyDeckDatabase.MIGRATION_14_15,
                 MyDeckDatabase.MIGRATION_15_16,
-                MyDeckDatabase.MIGRATION_16_17
+                MyDeckDatabase.MIGRATION_16_17,
+                MyDeckDatabase.MIGRATION_17_18
             )
             .build()
     }
@@ -63,6 +65,11 @@ object DatabaseModule {
     @Singleton
     fun provideCachedAnnotationDao(readeckDatabase: MyDeckDatabase): CachedAnnotationDao =
         readeckDatabase.getCachedAnnotationDao()
+
+    @Provides
+    @Singleton
+    fun provideCollectionDao(readeckDatabase: MyDeckDatabase): CollectionDao =
+        readeckDatabase.getCollectionDao()
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/mydeck/app/io/db/MyDeckDatabase.kt
+++ b/app/src/main/java/com/mydeck/app/io/db/MyDeckDatabase.kt
@@ -7,8 +7,10 @@ import androidx.room.withTransaction
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import com.mydeck.app.io.db.dao.BookmarkDao
+import com.mydeck.app.io.db.dao.CollectionDao
 import com.mydeck.app.io.db.dao.ContentPackageDao
 import com.mydeck.app.io.db.model.ArticleContentEntity
+import com.mydeck.app.io.db.model.CollectionEntity
 import com.mydeck.app.io.db.model.BookmarkEntity
 import com.mydeck.app.io.db.model.ContentPackageEntity
 import com.mydeck.app.io.db.model.ContentResourceEntity
@@ -21,8 +23,10 @@ import com.mydeck.app.io.db.model.BookmarkAnnotationSyncMetadataEntity
 import com.mydeck.app.io.db.model.CachedAnnotationEntity
 
 @Database(
-    entities = [BookmarkEntity::class, ArticleContentEntity::class, ContentPackageEntity::class, ContentResourceEntity::class, RemoteBookmarkIdEntity::class, RemoteAnnotationIdEntity::class, PendingActionEntity::class, CachedAnnotationEntity::class, BookmarkAnnotationSyncMetadataEntity::class],
-    version = 17,
+    entities = [BookmarkEntity::class, ArticleContentEntity::class, ContentPackageEntity::class, ContentResourceEntity::class, RemoteBookmarkIdEntity::class, RemoteAnnotationIdEntity::class, PendingActionEntity::class, CachedAnnotationEntity::class, BookmarkAnnotationSyncMetadataEntity::class, CollectionEntity::class],
+    // PORT: DB version. MyDeck is at v18 (Collections added v17→v18). The Readeck port may be at a
+    // different base version; renumber the migration and exported schema to the target's vN→vN+1.
+    version = 18,
     exportSchema = true
 )
 @TypeConverters(Converters::class)
@@ -31,6 +35,7 @@ abstract class MyDeckDatabase : RoomDatabase() {
     abstract fun getPendingActionDao(): PendingActionDao
     abstract fun getContentPackageDao(): ContentPackageDao
     abstract fun getCachedAnnotationDao(): CachedAnnotationDao
+    abstract fun getCollectionDao(): CollectionDao
 
     open suspend fun <R> performTransaction(block: suspend () -> R): R = withTransaction(block)
 
@@ -310,6 +315,39 @@ abstract class MyDeckDatabase : RoomDatabase() {
             override fun migrate(database: SupportSQLiteDatabase) {
                 database.execSQL(
                     "ALTER TABLE content_package ADD COLUMN source TEXT NOT NULL DEFAULT 'AUTOMATIC'"
+                )
+            }
+        }
+
+        // PORT: migration version. Collections table added here as MyDeck v17→v18; renumber to the
+        // port target's next version (vN→vN+1) and regenerate the exported schema there.
+        val MIGRATION_17_18 = object : Migration(17, 18) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                // No DEFAULT clauses on the NOT NULL columns: the entity declares no @ColumnInfo
+                // defaults, and Room's schema validation compares defaults — adding them here would
+                // mismatch the generated schema. The table is created empty, so NOT NULL is safe.
+                database.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `collections` (
+                        `id` TEXT NOT NULL,
+                        `name` TEXT NOT NULL,
+                        `isPinned` INTEGER NOT NULL,
+                        `search` TEXT,
+                        `title` TEXT,
+                        `author` TEXT,
+                        `site` TEXT,
+                        `labels` TEXT,
+                        `type` TEXT NOT NULL,
+                        `readStatus` TEXT NOT NULL,
+                        `isMarked` INTEGER,
+                        `isArchived` INTEGER,
+                        `rangeStart` TEXT,
+                        `rangeEnd` TEXT,
+                        `created` INTEGER NOT NULL,
+                        `updated` INTEGER NOT NULL,
+                        PRIMARY KEY(`id`)
+                    )
+                    """.trimIndent()
                 )
             }
         }

--- a/app/src/main/java/com/mydeck/app/io/db/MyDeckDatabase.kt
+++ b/app/src/main/java/com/mydeck/app/io/db/MyDeckDatabase.kt
@@ -341,6 +341,8 @@ abstract class MyDeckDatabase : RoomDatabase() {
                         `readStatus` TEXT NOT NULL,
                         `isMarked` INTEGER,
                         `isArchived` INTEGER,
+                        `hasErrors` INTEGER,
+                        `hasLabels` INTEGER,
                         `rangeStart` TEXT,
                         `rangeEnd` TEXT,
                         `created` INTEGER NOT NULL,

--- a/app/src/main/java/com/mydeck/app/io/db/dao/CollectionDao.kt
+++ b/app/src/main/java/com/mydeck/app/io/db/dao/CollectionDao.kt
@@ -1,0 +1,26 @@
+package com.mydeck.app.io.db.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.mydeck.app.io.db.model.CollectionEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface CollectionDao {
+    @Query("SELECT * FROM collections ORDER BY isPinned DESC, name ASC")
+    fun observeCollections(): Flow<List<CollectionEntity>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertCollections(collections: List<CollectionEntity>)
+
+    @Query("DELETE FROM collections WHERE id = :id")
+    suspend fun deleteById(id: String)
+
+    @Query("DELETE FROM collections")
+    suspend fun deleteAll()
+
+    @Query("SELECT * FROM collections WHERE id = :id")
+    suspend fun getById(id: String): CollectionEntity?
+}

--- a/app/src/main/java/com/mydeck/app/io/db/dao/CollectionDao.kt
+++ b/app/src/main/java/com/mydeck/app/io/db/dao/CollectionDao.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface CollectionDao {
-    @Query("SELECT * FROM collections ORDER BY isPinned DESC, name ASC")
+    @Query("SELECT * FROM collections ORDER BY isPinned DESC, created DESC")
     fun observeCollections(): Flow<List<CollectionEntity>>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)

--- a/app/src/main/java/com/mydeck/app/io/db/model/CollectionEntity.kt
+++ b/app/src/main/java/com/mydeck/app/io/db/model/CollectionEntity.kt
@@ -1,0 +1,28 @@
+package com.mydeck.app.io.db.model
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * Local cache row for a Readeck collection. The flat filter columns mirror the API fields; [type]
+ * and [readStatus] are stored as JSON arrays via the existing [com.mydeck.app.io.db.Converters].
+ */
+@Entity(tableName = "collections")
+data class CollectionEntity(
+    @PrimaryKey val id: String,
+    val name: String,
+    val isPinned: Boolean,
+    val search: String?,
+    val title: String?,
+    val author: String?,
+    val site: String?,
+    val labels: String?,
+    val type: List<String>,
+    val readStatus: List<String>,
+    val isMarked: Boolean?,
+    val isArchived: Boolean?,
+    val rangeStart: String?,
+    val rangeEnd: String?,
+    val created: Long,
+    val updated: Long,
+)

--- a/app/src/main/java/com/mydeck/app/io/db/model/CollectionEntity.kt
+++ b/app/src/main/java/com/mydeck/app/io/db/model/CollectionEntity.kt
@@ -21,6 +21,8 @@ data class CollectionEntity(
     val readStatus: List<String>,
     val isMarked: Boolean?,
     val isArchived: Boolean?,
+    val hasErrors: Boolean?,
+    val hasLabels: Boolean?,
     val rangeStart: String?,
     val rangeEnd: String?,
     val created: Long,

--- a/app/src/main/java/com/mydeck/app/io/rest/ReadeckApi.kt
+++ b/app/src/main/java/com/mydeck/app/io/rest/ReadeckApi.kt
@@ -6,7 +6,6 @@ import com.mydeck.app.io.rest.model.CollectionDto
 import com.mydeck.app.io.rest.model.CreateAnnotationDto
 import com.mydeck.app.io.rest.model.CreateBookmarkDto
 import com.mydeck.app.io.rest.model.CreateCollectionDto
-import com.mydeck.app.io.rest.model.UpdateCollectionDto
 import com.mydeck.app.io.rest.model.EditBookmarkDto
 import com.mydeck.app.io.rest.model.EditBookmarkErrorDto
 import com.mydeck.app.io.rest.model.EditBookmarkResponseDto
@@ -23,6 +22,7 @@ import com.mydeck.app.io.rest.model.StatusMessageDto
 import com.mydeck.app.io.rest.model.SyncStatusDto
 import com.mydeck.app.io.rest.model.UpdateAnnotationDto
 import com.mydeck.app.io.rest.model.UserProfileDto
+import kotlinx.serialization.json.JsonObject
 import kotlinx.datetime.Instant
 import okhttp3.ResponseBody
 import retrofit2.Response
@@ -159,12 +159,22 @@ interface ReadeckApi {
         @Body body: CreateCollectionDto
     ): Response<StatusMessageDto>
 
+    // Body is a JsonObject (not UpdateCollectionDto) so cleared filter fields can be sent as explicit
+    // nulls — the shared Json uses explicitNulls=false, which would drop them and leave PATCH a no-op
+    // for that field. See FilterFormState.toUpdateCollectionJson. PATCH returns 200 with a partial
+    // `collectionSummary` (no id/href/created), so the body is ignored (Response<Unit>) and the repo
+    // re-fetches the full object via getCollectionById to cache it.
     @Headers("Accept: application/json")
     @PATCH("bookmarks/collections/{id}")
     suspend fun updateCollection(
         @Path("id") id: String,
-        @Body body: UpdateCollectionDto
-    ): Response<CollectionDto>
+        @Body body: JsonObject
+    ): Response<Unit>
+
+    @DELETE("bookmarks/collections/{id}")
+    suspend fun deleteCollection(
+        @Path("id") id: String
+    ): Response<Unit>
 
     data class SortOrder(val sort: Sort, val order: Order = Order.Ascending) {
         override fun toString(): String {

--- a/app/src/main/java/com/mydeck/app/io/rest/ReadeckApi.kt
+++ b/app/src/main/java/com/mydeck/app/io/rest/ReadeckApi.kt
@@ -2,8 +2,11 @@ package com.mydeck.app.io.rest
 
 import com.mydeck.app.io.rest.model.AnnotationDto
 import com.mydeck.app.io.rest.model.BookmarkDto
+import com.mydeck.app.io.rest.model.CollectionDto
 import com.mydeck.app.io.rest.model.CreateAnnotationDto
 import com.mydeck.app.io.rest.model.CreateBookmarkDto
+import com.mydeck.app.io.rest.model.CreateCollectionDto
+import com.mydeck.app.io.rest.model.UpdateCollectionDto
 import com.mydeck.app.io.rest.model.EditBookmarkDto
 import com.mydeck.app.io.rest.model.EditBookmarkErrorDto
 import com.mydeck.app.io.rest.model.EditBookmarkResponseDto
@@ -136,6 +139,33 @@ interface ReadeckApi {
     @DELETE("bookmarks/{id}")
     suspend fun deleteBookmark(@Path("id") id: String): Response<Unit>
 
+    // --- Collections ---
+
+    @GET("bookmarks/collections")
+    suspend fun getCollections(
+        @Query("limit") limit: Int = 100,
+        @Query("offset") offset: Int = 0
+    ): Response<List<CollectionDto>>
+
+    @GET("bookmarks/collections/{id}")
+    suspend fun getCollectionById(
+        @Path("id") id: String
+    ): Response<CollectionDto>
+
+    // POST returns 201 with a Location header pointing at the new collection; the body is only the
+    // generic status/message schema (no id). Callers read the Location header to resolve the id.
+    @POST("bookmarks/collections")
+    suspend fun createCollection(
+        @Body body: CreateCollectionDto
+    ): Response<StatusMessageDto>
+
+    @Headers("Accept: application/json")
+    @PATCH("bookmarks/collections/{id}")
+    suspend fun updateCollection(
+        @Path("id") id: String,
+        @Body body: UpdateCollectionDto
+    ): Response<CollectionDto>
+
     data class SortOrder(val sort: Sort, val order: Order = Order.Ascending) {
         override fun toString(): String {
             return "${order.value}${sort.value}"
@@ -162,6 +192,7 @@ interface ReadeckApi {
             const val TOTAL_COUNT = "total-count"
             const val CURRENT_PAGE = "current-page"
             const val BOOKMARK_ID = "bookmark-id"
+            const val LOCATION = "location"
         }
     }
 }

--- a/app/src/main/java/com/mydeck/app/io/rest/model/CollectionDto.kt
+++ b/app/src/main/java/com/mydeck/app/io/rest/model/CollectionDto.kt
@@ -1,0 +1,40 @@
+package com.mydeck.app.io.rest.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Server representation of a Readeck collection (a saved set of filter criteria).
+ *
+ * Returned by `GET /bookmarks/collections`, `GET /bookmarks/collections/{id}`, and
+ * `PATCH /bookmarks/collections/{id}`. The flat filter fields map to [com.mydeck.app.domain.model.FilterFormState]
+ * via the extension functions in `domain/model/CollectionFilterAdapter.kt`.
+ */
+@Serializable
+data class CollectionDto(
+    val id: String,
+    val href: String,
+    val created: String,
+    val updated: String,
+    val name: String,
+    @SerialName("is_pinned")
+    val isPinned: Boolean? = null,
+    @SerialName("is_deleted")
+    val isDeleted: Boolean? = null,
+    val search: String? = null,
+    val title: String? = null,
+    val author: String? = null,
+    val site: String? = null,
+    val type: List<String>? = null,
+    val labels: String? = null,
+    @SerialName("read_status")
+    val readStatus: List<String>? = null,
+    @SerialName("is_marked")
+    val isMarked: Boolean? = null,
+    @SerialName("is_archived")
+    val isArchived: Boolean? = null,
+    @SerialName("range_start")
+    val rangeStart: String? = null,
+    @SerialName("range_end")
+    val rangeEnd: String? = null,
+)

--- a/app/src/main/java/com/mydeck/app/io/rest/model/CollectionDto.kt
+++ b/app/src/main/java/com/mydeck/app/io/rest/model/CollectionDto.kt
@@ -33,6 +33,10 @@ data class CollectionDto(
     val isMarked: Boolean? = null,
     @SerialName("is_archived")
     val isArchived: Boolean? = null,
+    @SerialName("has_errors")
+    val hasErrors: Boolean? = null,
+    @SerialName("has_labels")
+    val hasLabels: Boolean? = null,
     @SerialName("range_start")
     val rangeStart: String? = null,
     @SerialName("range_end")

--- a/app/src/main/java/com/mydeck/app/io/rest/model/CreateCollectionDto.kt
+++ b/app/src/main/java/com/mydeck/app/io/rest/model/CreateCollectionDto.kt
@@ -1,0 +1,40 @@
+package com.mydeck.app.io.rest.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Request body for `POST /bookmarks/collections` (create).
+ *
+ * All fields except [name] are optional. Because the app's [kotlinx.serialization.json.Json] is
+ * configured with `explicitNulls = false` and without `encodeDefaults`, fields left at their default
+ * `null` are omitted from the wire body, so a sparse collection sends only the filter keys the user
+ * actually populated.
+ */
+@Serializable
+data class CreateCollectionDto(
+    val name: String,
+    @SerialName("is_pinned")
+    val isPinned: Boolean? = null,
+    @SerialName("is_deleted")
+    val isDeleted: Boolean? = null,
+    val search: String? = null,
+    val title: String? = null,
+    val author: String? = null,
+    val site: String? = null,
+    val type: List<String>? = null,
+    val labels: String? = null,
+    @SerialName("read_status")
+    val readStatus: List<String>? = null,
+    @SerialName("is_marked")
+    val isMarked: Boolean? = null,
+    @SerialName("is_archived")
+    val isArchived: Boolean? = null,
+    @SerialName("range_start")
+    val rangeStart: String? = null,
+    @SerialName("range_end")
+    val rangeEnd: String? = null,
+)
+
+/** PATCH body reuses the same shape (all fields optional). */
+typealias UpdateCollectionDto = CreateCollectionDto

--- a/app/src/main/java/com/mydeck/app/io/rest/model/CreateCollectionDto.kt
+++ b/app/src/main/java/com/mydeck/app/io/rest/model/CreateCollectionDto.kt
@@ -39,6 +39,3 @@ data class CreateCollectionDto(
     @SerialName("range_end")
     val rangeEnd: String? = null,
 )
-
-/** PATCH body reuses the same shape (all fields optional). */
-typealias UpdateCollectionDto = CreateCollectionDto

--- a/app/src/main/java/com/mydeck/app/io/rest/model/CreateCollectionDto.kt
+++ b/app/src/main/java/com/mydeck/app/io/rest/model/CreateCollectionDto.kt
@@ -30,6 +30,10 @@ data class CreateCollectionDto(
     val isMarked: Boolean? = null,
     @SerialName("is_archived")
     val isArchived: Boolean? = null,
+    @SerialName("has_errors")
+    val hasErrors: Boolean? = null,
+    @SerialName("has_labels")
+    val hasLabels: Boolean? = null,
     @SerialName("range_start")
     val rangeStart: String? = null,
     @SerialName("range_end")

--- a/app/src/main/java/com/mydeck/app/ui/collections/CollectionEditorSheet.kt
+++ b/app/src/main/java/com/mydeck/app/ui/collections/CollectionEditorSheet.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
@@ -24,6 +25,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -33,11 +35,12 @@ import com.mydeck.app.ui.components.FilterControls
 import com.mydeck.app.ui.components.rememberFilterEditorState
 
 /**
- * Unified collection editor: a name field on top of the shared [FilterControls]. In C2 this is used
- * only for creating a collection (FAB on the Collections screen). C3 extends it with edit/delete
- * modes and the main-list "Save as Collection" entry point.
+ * Unified collection editor: a name field on top of the shared [FilterControls]. Used for creating
+ * (FAB on the Collections screen, or main-list "Save as Collection") and editing a collection.
  *
- * Save is disabled until [title] (the name) is non-blank and the filter has no validation error.
+ * Entry points pass the appropriate [heading]/[initialName]/[initialFilter]. When [onDelete] is
+ * non-null (edit mode) a Delete action is shown alongside Save. Save is disabled until the name is
+ * non-blank and the filter has no validation error. Rename is supported via the name field.
  */
 // PORT: "MyDeck" brand never appears here; the editor reuses generic filter controls.
 @OptIn(ExperimentalMaterial3Api::class)
@@ -49,6 +52,7 @@ fun CollectionEditorSheet(
     labels: Map<String, Int>,
     onSave: (name: String, filter: FilterFormState) -> Unit,
     onDismiss: () -> Unit,
+    onDelete: (() -> Unit)? = null,
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     var name by remember(initialName) { mutableStateOf(initialName) }
@@ -92,7 +96,19 @@ fun CollectionEditorSheet(
 
             Spacer(Modifier.height(20.dp))
 
-            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                if (onDelete != null) {
+                    TextButton(
+                        onClick = onDelete,
+                        colors = ButtonDefaults.textButtonColors(
+                            contentColor = MaterialTheme.colorScheme.error
+                        ),
+                    ) { Text(stringResource(R.string.collection_delete_action)) }
+                }
+                Spacer(Modifier.weight(1f))
                 TextButton(onClick = onDismiss) { Text(stringResource(R.string.cancel)) }
                 Spacer(Modifier.width(8.dp))
                 Button(

--- a/app/src/main/java/com/mydeck/app/ui/collections/CollectionEditorSheet.kt
+++ b/app/src/main/java/com/mydeck/app/ui/collections/CollectionEditorSheet.kt
@@ -1,0 +1,107 @@
+package com.mydeck.app.ui.collections
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.mydeck.app.R
+import com.mydeck.app.domain.model.FilterFormState
+import com.mydeck.app.ui.components.FilterControls
+import com.mydeck.app.ui.components.rememberFilterEditorState
+
+/**
+ * Unified collection editor: a name field on top of the shared [FilterControls]. In C2 this is used
+ * only for creating a collection (FAB on the Collections screen). C3 extends it with edit/delete
+ * modes and the main-list "Save as Collection" entry point.
+ *
+ * Save is disabled until [title] (the name) is non-blank and the filter has no validation error.
+ */
+// PORT: "MyDeck" brand never appears here; the editor reuses generic filter controls.
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CollectionEditorSheet(
+    heading: String,
+    initialName: String,
+    initialFilter: FilterFormState,
+    labels: Map<String, Int>,
+    onSave: (name: String, filter: FilterFormState) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    var name by remember(initialName) { mutableStateOf(initialName) }
+    val filterState = rememberFilterEditorState(initialFilter)
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 24.dp)
+                .navigationBarsPadding()
+        ) {
+            Text(
+                text = heading,
+                style = MaterialTheme.typography.titleLarge,
+            )
+
+            Spacer(Modifier.height(16.dp))
+
+            OutlinedTextField(
+                value = name,
+                onValueChange = { name = it },
+                label = { Text(stringResource(R.string.collection_name_hint)) },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Spacer(Modifier.height(16.dp))
+
+            FilterControls(
+                state = filterState,
+                labels = labels,
+                // Collections can't persist the device-local "Downloaded" state or the reading-time /
+                // word-count filters, so those controls are hidden here to avoid silent data loss.
+                includeLocalOnlyFilters = false,
+            )
+
+            Spacer(Modifier.height(20.dp))
+
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                TextButton(onClick = onDismiss) { Text(stringResource(R.string.cancel)) }
+                Spacer(Modifier.width(8.dp))
+                Button(
+                    onClick = { onSave(name.trim(), filterState.toFilterFormState()) },
+                    enabled = name.isNotBlank() && !filterState.hasValidationError,
+                ) { Text(stringResource(R.string.collection_editor_save)) }
+            }
+
+            Spacer(Modifier.height(16.dp))
+        }
+    }
+}

--- a/app/src/main/java/com/mydeck/app/ui/collections/CollectionEditorSheet.kt
+++ b/app/src/main/java/com/mydeck/app/ui/collections/CollectionEditorSheet.kt
@@ -90,8 +90,9 @@ fun CollectionEditorSheet(
                 state = filterState,
                 labels = labels,
                 // Collections can't persist the device-local "Downloaded" state or the reading-time /
-                // word-count filters, so those controls are hidden here to avoid silent data loss.
-                includeLocalOnlyFilters = false,
+                // word-count filters. Rather than hide them (which silently drops any such criteria the
+                // user had applied), show them disabled as "Unavailable" with an explanatory tooltip.
+                localOnlyFiltersEditable = false,
             )
 
             Spacer(Modifier.height(20.dp))

--- a/app/src/main/java/com/mydeck/app/ui/collections/CollectionsScreen.kt
+++ b/app/src/main/java/com/mydeck/app/ui/collections/CollectionsScreen.kt
@@ -170,7 +170,7 @@ private fun CollectionCard(
         onClick = onClick,
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 4.dp),
+            .padding(horizontal = 16.dp, vertical = 8.dp),
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
             Text(
@@ -199,14 +199,14 @@ private fun CollectionsEmptyState(modifier: Modifier = Modifier) {
             imageVector = CollectionIcon,
             contentDescription = null,
             modifier = Modifier.size(48.dp),
-            tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
         )
         Spacer(Modifier.height(16.dp))
         Text(
             text = stringResource(R.string.collections_empty_title),
             style = MaterialTheme.typography.titleMedium,
             textAlign = TextAlign.Center,
-            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
         Spacer(Modifier.height(8.dp))
         Text(

--- a/app/src/main/java/com/mydeck/app/ui/collections/CollectionsScreen.kt
+++ b/app/src/main/java/com/mydeck/app/ui/collections/CollectionsScreen.kt
@@ -22,6 +22,8 @@ import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.IconButton
@@ -35,6 +37,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -67,13 +70,24 @@ fun CollectionsScreen(
     viewModel: BookmarkListViewModel,
     showBackButton: Boolean = true,
 ) {
-    val collections by viewModel.collections.collectAsState()
+    val collections by viewModel.visibleCollections.collectAsState()
     val labels by viewModel.labelsWithCounts.collectAsState()
     var showEditor by remember { mutableStateOf(false) }
+    val snackbarHostState = remember { SnackbarHostState() }
+    val context = LocalContext.current
 
     LaunchedEffect(Unit) { viewModel.refreshCollections() }
 
+    // Collection failures (e.g. a create from the FAB that doesn't reach the server) surface here
+    // while the Collections screen is foreground; the ViewModel is shared with the bookmark list.
+    LaunchedEffect(Unit) {
+        viewModel.collectionMessageEvent.collect { messageRes ->
+            snackbarHostState.showSnackbar(context.getString(messageRes))
+        }
+    }
+
     Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(R.string.collections_screen_title)) },

--- a/app/src/main/java/com/mydeck/app/ui/collections/CollectionsScreen.kt
+++ b/app/src/main/java/com/mydeck/app/ui/collections/CollectionsScreen.kt
@@ -15,8 +15,13 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.ArrowDownward
+import androidx.compose.material.icons.filled.ArrowUpward
+import androidx.compose.material.icons.filled.SwapVert
 import androidx.compose.material.icons.outlined.Bookmarks
 import androidx.compose.material3.Card
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.Icon
@@ -39,8 +44,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.mydeck.app.domain.model.CollectionSortOption
 import androidx.navigation.NavHostController
 import com.mydeck.app.R
 import com.mydeck.app.domain.model.Collection
@@ -72,7 +79,9 @@ fun CollectionsScreen(
 ) {
     val collections by viewModel.visibleCollections.collectAsState()
     val labels by viewModel.labelsWithCounts.collectAsState()
+    val sortOption by viewModel.collectionSortOption.collectAsState()
     var showEditor by remember { mutableStateOf(false) }
+    var showSortMenu by remember { mutableStateOf(false) }
     val snackbarHostState = remember { SnackbarHostState() }
     val context = LocalContext.current
 
@@ -98,6 +107,56 @@ fun CollectionsScreen(
                                 imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                                 contentDescription = stringResource(R.string.back)
                             )
+                        }
+                    }
+                },
+                actions = {
+                    Box {
+                        IconButton(onClick = { showSortMenu = true }) {
+                            Icon(Icons.Filled.SwapVert, contentDescription = stringResource(R.string.sort))
+                        }
+                        DropdownMenu(
+                            expanded = showSortMenu,
+                            onDismissRequest = { showSortMenu = false }
+                        ) {
+                            val sortGroups = listOf(
+                                Triple("Added", CollectionSortOption.DATE_NEWEST, CollectionSortOption.DATE_OLDEST),
+                                Triple("Name", CollectionSortOption.NAME_A_TO_Z, CollectionSortOption.NAME_Z_TO_A),
+                            )
+                            sortGroups.forEach { (label, firstOption, secondOption) ->
+                                val isFirstSelected = sortOption == firstOption
+                                val isSecondSelected = sortOption == secondOption
+                                val isGroupSelected = isFirstSelected || isSecondSelected
+                                DropdownMenuItem(
+                                    leadingIcon = {
+                                        if (isGroupSelected) {
+                                            Icon(
+                                                imageVector = if (sortOption.isDescending) Icons.Filled.ArrowDownward else Icons.Filled.ArrowUpward,
+                                                contentDescription = null,
+                                                tint = MaterialTheme.colorScheme.primary,
+                                            )
+                                        } else {
+                                            Spacer(Modifier.size(24.dp))
+                                        }
+                                    },
+                                    text = {
+                                        Text(
+                                            text = label,
+                                            color = if (isGroupSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface,
+                                            fontWeight = if (isGroupSelected) FontWeight.Bold else FontWeight.Normal,
+                                        )
+                                    },
+                                    onClick = {
+                                        val newOption = when {
+                                            isFirstSelected -> secondOption
+                                            isSecondSelected -> firstOption
+                                            else -> firstOption
+                                        }
+                                        viewModel.onCollectionSortSelected(newOption)
+                                        showSortMenu = false
+                                    }
+                                )
+                            }
                         }
                     }
                 },

--- a/app/src/main/java/com/mydeck/app/ui/collections/CollectionsScreen.kt
+++ b/app/src/main/java/com/mydeck/app/ui/collections/CollectionsScreen.kt
@@ -1,0 +1,205 @@
+package com.mydeck.app.ui.collections
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.outlined.Bookmarks
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExtendedFloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import com.mydeck.app.R
+import com.mydeck.app.domain.model.Collection
+import com.mydeck.app.domain.model.FilterFormState
+import com.mydeck.app.ui.list.BookmarkListViewModel
+import com.mydeck.app.ui.navigation.BookmarkListRoute
+import kotlinx.datetime.toJavaInstant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+
+/**
+ * Shared leading icon for a collection (drawer/rail entry, active-collection app bar, cards). The
+ * Navigation Settings custom-view item reuses this same icon, so keep them consistent.
+ */
+val CollectionIcon: ImageVector = Icons.Outlined.Bookmarks
+
+/**
+ * Browse/manage collections. Modeled on the Highlights screen: a list of cards (name + created
+ * date), a FAB to create one via the editor sheet, and an M3 empty state. Reuses the shell's shared
+ * [BookmarkListViewModel] so selection state stays in one place.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CollectionsScreen(
+    navController: NavHostController,
+    viewModel: BookmarkListViewModel,
+    showBackButton: Boolean = true,
+) {
+    val collections by viewModel.collections.collectAsState()
+    val labels by viewModel.labelsWithCounts.collectAsState()
+    var showEditor by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) { viewModel.refreshCollections() }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.collections_screen_title)) },
+                navigationIcon = {
+                    if (showBackButton) {
+                        IconButton(onClick = { navController.popBackStack() }) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                contentDescription = stringResource(R.string.back)
+                            )
+                        }
+                    }
+                },
+            )
+        },
+        floatingActionButton = {
+            ExtendedFloatingActionButton(
+                onClick = { showEditor = true },
+                icon = { Icon(Icons.Filled.Add, contentDescription = null) },
+                text = { Text(stringResource(R.string.collection_create_fab)) },
+            )
+        },
+    ) { paddingValues ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+        ) {
+            if (collections.isEmpty()) {
+                CollectionsEmptyState(modifier = Modifier.align(Alignment.Center))
+            } else {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(vertical = 8.dp),
+                ) {
+                    items(collections, key = { it.id }) { collection ->
+                        CollectionCard(
+                            collection = collection,
+                            onClick = {
+                                viewModel.onSelectCollection(collection.id)
+                                navController.navigate(BookmarkListRoute()) {
+                                    popUpTo(BookmarkListRoute()) { inclusive = true }
+                                    launchSingleTop = true
+                                }
+                            },
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    if (showEditor) {
+        CollectionEditorSheet(
+            heading = stringResource(R.string.collection_create_fab),
+            initialName = "",
+            initialFilter = FilterFormState(),
+            labels = labels,
+            onSave = { name, filter ->
+                showEditor = false
+                viewModel.onCreateCollection(name, filter)
+            },
+            onDismiss = { showEditor = false },
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun CollectionCard(
+    collection: Collection,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val formatter = remember {
+        DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM, FormatStyle.SHORT)
+            .withZone(ZoneId.systemDefault())
+    }
+    Card(
+        onClick = onClick,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = collection.name,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = formatter.format(collection.created.toJavaInstant()),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun CollectionsEmptyState(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier.padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Icon(
+            imageVector = CollectionIcon,
+            contentDescription = null,
+            modifier = Modifier.size(48.dp),
+            tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+        )
+        Spacer(Modifier.height(16.dp))
+        Text(
+            text = stringResource(R.string.collections_empty_title),
+            style = MaterialTheme.typography.titleMedium,
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
+        )
+        Spacer(Modifier.height(8.dp))
+        Text(
+            text = stringResource(R.string.collections_empty_message),
+            style = MaterialTheme.typography.bodyMedium,
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}

--- a/app/src/main/java/com/mydeck/app/ui/components/FilterBar.kt
+++ b/app/src/main/java/com/mydeck/app/ui/components/FilterBar.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.mydeck.app.R
 import com.mydeck.app.domain.model.Bookmark
-import com.mydeck.app.domain.model.DrawerPreset
 import com.mydeck.app.domain.model.FilterFormState
 import com.mydeck.app.domain.model.ProgressFilter
 import kotlinx.datetime.TimeZone
@@ -26,73 +25,74 @@ import java.util.Date
 import java.util.Locale
 
 /**
- * A horizontal row of InputChip elements summarising the active filters that differ from
- * the current drawer preset defaults.  Each chip has a trailing ✕ to dismiss that specific
- * filter.  Tapping anywhere on the bar (not on a chip) opens the filter bottom sheet.
+ * A horizontal row of InputChip elements summarising the active filters that differ from a
+ * [baseline] filter.  Each chip has a trailing ✕ to dismiss that specific filter (reverting that
+ * field to the baseline value).  Tapping anywhere on the bar (not on a chip) opens the filter sheet.
  *
- * The bar is only rendered when at least one chip is visible (i.e. when the current
- * filter state differs from the preset default in a user-visible way).
+ * The [baseline] is the drawer preset's defaults for an ordinary list, or the active collection's
+ * own criteria when a collection is selected — so collection chips show only the filters layered on
+ * top of the collection, not the collection's own criteria.
+ *
+ * The bar is only rendered when at least one chip is visible (i.e. the current filter differs from
+ * the baseline in a user-visible way).
  */
 @Composable
 fun FilterBar(
     filterFormState: FilterFormState,
-    drawerPreset: DrawerPreset,
+    baseline: FilterFormState,
     onFilterChanged: (FilterFormState) -> Unit,
     onOpenFilterSheet: () -> Unit,
 ) {
-    // Compute which chips to show by comparing against the preset defaults.
-    val preset = remember(drawerPreset) { FilterFormState.fromPreset(drawerPreset) }
-
     data class Chip(val label: String, val onDismiss: () -> Unit)
 
     val dateFormatter = remember { SimpleDateFormat("MMM d, yyyy", Locale.getDefault()) }
 
     val chips = buildList<Chip> {
-        filterFormState.search?.let { v ->
-            add(Chip("${stringResource(R.string.filter_search)}: $v") {
-                onFilterChanged(filterFormState.copy(search = null))
+        if (filterFormState.search != null && filterFormState.search != baseline.search) {
+            add(Chip("${stringResource(R.string.filter_search)}: ${filterFormState.search}") {
+                onFilterChanged(filterFormState.copy(search = baseline.search))
             })
         }
-        filterFormState.title?.let { v ->
-            add(Chip("${stringResource(R.string.filter_title)}: $v") {
-                onFilterChanged(filterFormState.copy(title = null))
+        if (filterFormState.title != null && filterFormState.title != baseline.title) {
+            add(Chip("${stringResource(R.string.filter_title)}: ${filterFormState.title}") {
+                onFilterChanged(filterFormState.copy(title = baseline.title))
             })
         }
-        filterFormState.author?.let { v ->
-            add(Chip("${stringResource(R.string.filter_author)}: $v") {
-                onFilterChanged(filterFormState.copy(author = null))
+        if (filterFormState.author != null && filterFormState.author != baseline.author) {
+            add(Chip("${stringResource(R.string.filter_author)}: ${filterFormState.author}") {
+                onFilterChanged(filterFormState.copy(author = baseline.author))
             })
         }
-        filterFormState.site?.let { v ->
-            add(Chip("${stringResource(R.string.filter_site)}: $v") {
-                onFilterChanged(filterFormState.copy(site = null))
+        if (filterFormState.site != null && filterFormState.site != baseline.site) {
+            add(Chip("${stringResource(R.string.filter_site)}: ${filterFormState.site}") {
+                onFilterChanged(filterFormState.copy(site = baseline.site))
             })
         }
-        filterFormState.label?.let { v ->
-            add(Chip("${stringResource(R.string.filter_label)}: $v") {
-                onFilterChanged(filterFormState.copy(label = null))
+        if (filterFormState.label != null && filterFormState.label != baseline.label) {
+            add(Chip("${stringResource(R.string.filter_label)}: ${filterFormState.label}") {
+                onFilterChanged(filterFormState.copy(label = baseline.label))
             })
         }
-        filterFormState.fromDate?.let { v ->
-            val formatted = dateFormatter.format(Date(v.toEpochMilliseconds()))
+        if (filterFormState.fromDate != null && filterFormState.fromDate != baseline.fromDate) {
+            val formatted = dateFormatter.format(Date(filterFormState.fromDate.toEpochMilliseconds()))
             add(Chip("${stringResource(R.string.filter_from_date)}: $formatted") {
-                onFilterChanged(filterFormState.copy(fromDate = null))
+                onFilterChanged(filterFormState.copy(fromDate = baseline.fromDate))
             })
         }
-        filterFormState.toDate?.let { v ->
-            val formatted = dateFormatter.format(Date(v.toEpochMilliseconds()))
+        if (filterFormState.toDate != null && filterFormState.toDate != baseline.toDate) {
+            val formatted = dateFormatter.format(Date(filterFormState.toDate.toEpochMilliseconds()))
             add(Chip("${stringResource(R.string.filter_to_date)}: $formatted") {
-                onFilterChanged(filterFormState.copy(toDate = null))
+                onFilterChanged(filterFormState.copy(toDate = baseline.toDate))
             })
         }
-        // Type chips: show synthetic "Any" chip when preset types were cleared,
-        // otherwise show each type that was added beyond the preset.
-        if (filterFormState.types.isEmpty() && preset.types.isNotEmpty()) {
+        // Type chips: show synthetic "Any" chip when the baseline's types were cleared,
+        // otherwise show each type that was added beyond the baseline.
+        if (filterFormState.types.isEmpty() && baseline.types.isNotEmpty()) {
             add(Chip("${stringResource(R.string.filter_type)}: ${stringResource(R.string.filter_type_any)}") {
-                onFilterChanged(filterFormState.copy(types = preset.types))
+                onFilterChanged(filterFormState.copy(types = baseline.types))
             })
         } else {
-            val addedTypes = filterFormState.types - preset.types
+            val addedTypes = filterFormState.types - baseline.types
             addedTypes.forEach { type ->
                 val typeName = when (type) {
                     Bookmark.Type.Article -> stringResource(R.string.filter_type_article)
@@ -104,8 +104,8 @@ fun FilterBar(
                 })
             }
         }
-        // Progress chips
-        filterFormState.progress.forEach { pf ->
+        // Progress chips: each status added beyond the baseline.
+        (filterFormState.progress - baseline.progress).forEach { pf ->
             val pfName = when (pf) {
                 ProgressFilter.UNVIEWED -> stringResource(R.string.progress_unviewed)
                 ProgressFilter.IN_PROGRESS -> stringResource(R.string.progress_in_progress)
@@ -116,49 +116,49 @@ fun FilterBar(
             })
         }
         // isFavorite — show explicit chip when non-null and differs, or synthetic N/A chip
-        // when null and preset is non-null (broadened scope).
-        if (filterFormState.isFavorite != preset.isFavorite) {
+        // when null and the baseline is non-null (broadened scope).
+        if (filterFormState.isFavorite != baseline.isFavorite) {
             if (filterFormState.isFavorite != null) {
                 val yesNo = if (filterFormState.isFavorite) stringResource(R.string.tri_state_yes) else stringResource(R.string.tri_state_no)
                 add(Chip("${stringResource(R.string.filter_is_favorite)}: $yesNo") {
-                    onFilterChanged(filterFormState.copy(isFavorite = preset.isFavorite))
+                    onFilterChanged(filterFormState.copy(isFavorite = baseline.isFavorite))
                 })
-            } else if (preset.isFavorite != null) {
+            } else if (baseline.isFavorite != null) {
                 add(Chip("${stringResource(R.string.filter_is_favorite)}: ${stringResource(R.string.tri_state_any)}") {
-                    onFilterChanged(filterFormState.copy(isFavorite = preset.isFavorite))
+                    onFilterChanged(filterFormState.copy(isFavorite = baseline.isFavorite))
                 })
             }
         }
         // isArchived — show explicit chip when non-null and differs, or synthetic N/A chip
-        // when null and preset is non-null (broadened scope).
-        if (filterFormState.isArchived != preset.isArchived) {
+        // when null and the baseline is non-null (broadened scope).
+        if (filterFormState.isArchived != baseline.isArchived) {
             if (filterFormState.isArchived != null) {
                 val yesNo = if (filterFormState.isArchived) stringResource(R.string.tri_state_yes) else stringResource(R.string.tri_state_no)
                 add(Chip("${stringResource(R.string.filter_is_archived)}: $yesNo") {
-                    onFilterChanged(filterFormState.copy(isArchived = preset.isArchived))
+                    onFilterChanged(filterFormState.copy(isArchived = baseline.isArchived))
                 })
-            } else if (preset.isArchived != null) {
+            } else if (baseline.isArchived != null) {
                 add(Chip("${stringResource(R.string.filter_is_archived)}: ${stringResource(R.string.tri_state_any)}") {
-                    onFilterChanged(filterFormState.copy(isArchived = preset.isArchived))
+                    onFilterChanged(filterFormState.copy(isArchived = baseline.isArchived))
                 })
             }
         }
-        filterFormState.isLoaded?.let { v ->
-            val yesNo = if (v) stringResource(R.string.tri_state_yes) else stringResource(R.string.tri_state_no)
+        if (filterFormState.isLoaded != null && filterFormState.isLoaded != baseline.isLoaded) {
+            val yesNo = if (filterFormState.isLoaded) stringResource(R.string.tri_state_yes) else stringResource(R.string.tri_state_no)
             add(Chip("${stringResource(R.string.filter_is_loaded)}: $yesNo") {
-                onFilterChanged(filterFormState.copy(isLoaded = null))
+                onFilterChanged(filterFormState.copy(isLoaded = baseline.isLoaded))
             })
         }
-        filterFormState.withLabels?.let { v ->
-            val yesNo = if (v) stringResource(R.string.tri_state_yes) else stringResource(R.string.tri_state_no)
+        if (filterFormState.withLabels != null && filterFormState.withLabels != baseline.withLabels) {
+            val yesNo = if (filterFormState.withLabels) stringResource(R.string.tri_state_yes) else stringResource(R.string.tri_state_no)
             add(Chip("${stringResource(R.string.filter_with_labels)}: $yesNo") {
-                onFilterChanged(filterFormState.copy(withLabels = null))
+                onFilterChanged(filterFormState.copy(withLabels = baseline.withLabels))
             })
         }
-        filterFormState.withErrors?.let { v ->
-            val yesNo = if (v) stringResource(R.string.tri_state_yes) else stringResource(R.string.tri_state_no)
+        if (filterFormState.withErrors != null && filterFormState.withErrors != baseline.withErrors) {
+            val yesNo = if (filterFormState.withErrors) stringResource(R.string.tri_state_yes) else stringResource(R.string.tri_state_no)
             add(Chip("${stringResource(R.string.filter_with_errors)}: $yesNo") {
-                onFilterChanged(filterFormState.copy(withErrors = null))
+                onFilterChanged(filterFormState.copy(withErrors = baseline.withErrors))
             })
         }
         val unknownLabel = stringResource(R.string.filter_length_unknown)

--- a/app/src/main/java/com/mydeck/app/ui/components/FilterBottomSheet.kt
+++ b/app/src/main/java/com/mydeck/app/ui/components/FilterBottomSheet.kt
@@ -45,6 +45,7 @@ import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -71,82 +72,107 @@ import java.util.Locale
 
 private const val FOCUSED_FIELD_BRING_INTO_VIEW_DELAY_MS = 250L
 
+/**
+ * Mutable working copy of a [FilterFormState] for the filter editing UI. Holds every editable field
+ * as Compose state so the same control set can back both [FilterBottomSheet] and the collection
+ * editor sheet. Reset whenever [currentFilter] changes via [rememberFilterEditorState].
+ */
+@Stable
+class FilterEditorState(initial: FilterFormState) {
+    var search by mutableStateOf(initial.search ?: "")
+    var title by mutableStateOf(initial.title ?: "")
+    var author by mutableStateOf(initial.author ?: "")
+    var site by mutableStateOf(initial.site ?: "")
+    var label by mutableStateOf(initial.label)
+    var fromDate by mutableStateOf(initial.fromDate)
+    var toDate by mutableStateOf(initial.toDate)
+    var types by mutableStateOf(initial.types)
+    var progress by mutableStateOf(initial.progress)
+    var isFavorite by mutableStateOf(initial.isFavorite)
+    var isArchived by mutableStateOf(initial.isArchived)
+    var isLoaded by mutableStateOf(initial.isLoaded)
+    var withLabels by mutableStateOf(initial.withLabels)
+    var withErrors by mutableStateOf(initial.withErrors)
+    var minReadingTime by mutableStateOf(initial.minReadingTime?.toString() ?: "")
+    var maxReadingTime by mutableStateOf(initial.maxReadingTime?.toString() ?: "")
+    var includeNullReadingTime by mutableStateOf(initial.includeNullReadingTime)
+    var minWordCount by mutableStateOf(initial.minWordCount?.toString() ?: "")
+    var maxWordCount by mutableStateOf(initial.maxWordCount?.toString() ?: "")
+    var includeNullWordCount by mutableStateOf(initial.includeNullWordCount)
+
+    val readingTimeError: Boolean
+        get() = minReadingTime.isNotEmpty() && maxReadingTime.isNotEmpty() &&
+            (minReadingTime.toIntOrNull() ?: 0) > (maxReadingTime.toIntOrNull() ?: 0)
+
+    val wordCountError: Boolean
+        get() = minWordCount.isNotEmpty() && maxWordCount.isNotEmpty() &&
+            (minWordCount.toIntOrNull() ?: 0) > (maxWordCount.toIntOrNull() ?: 0)
+
+    val hasValidationError: Boolean get() = readingTimeError || wordCountError
+
+    val hasActiveFilters: Boolean
+        get() = search.isNotBlank() || title.isNotBlank() || author.isNotBlank() ||
+            site.isNotBlank() || label != null || fromDate != null || toDate != null ||
+            types.isNotEmpty() || progress.isNotEmpty() || isFavorite != null ||
+            isArchived != null || isLoaded != null || withLabels != null || withErrors != null ||
+            minReadingTime.isNotBlank() || maxReadingTime.isNotBlank() || includeNullReadingTime ||
+            minWordCount.isNotBlank() || maxWordCount.isNotBlank() || includeNullWordCount
+
+    fun toFilterFormState(): FilterFormState = FilterFormState(
+        search = search.ifBlank { null },
+        title = title.ifBlank { null },
+        author = author.ifBlank { null },
+        site = site.ifBlank { null },
+        label = label,
+        fromDate = fromDate,
+        toDate = toDate,
+        types = types,
+        progress = progress,
+        isFavorite = isFavorite,
+        isArchived = isArchived,
+        isLoaded = isLoaded,
+        withLabels = withLabels,
+        withErrors = withErrors,
+        minReadingTime = minReadingTime.toIntOrNull(),
+        maxReadingTime = maxReadingTime.toIntOrNull(),
+        includeNullReadingTime = includeNullReadingTime,
+        minWordCount = minWordCount.toIntOrNull(),
+        maxWordCount = maxWordCount.toIntOrNull(),
+        includeNullWordCount = includeNullWordCount,
+    )
+}
+
+@Composable
+fun rememberFilterEditorState(currentFilter: FilterFormState): FilterEditorState =
+    remember(currentFilter) { FilterEditorState(currentFilter) }
+
+/**
+ * The full set of filter-criteria controls (search, title/author, site/label, dates, length, type
+ * and progress chips, and the boolean tri-state rows), backed by [state]. Renders as a plain
+ * [Column] meant to be placed inside a scrolling parent; the caller supplies the surrounding sheet
+ * chrome and action buttons. Reused by [FilterBottomSheet] and the collection editor sheet.
+ *
+ * [onImeAction] runs when the keyboard "search/done" action fires on a text field (e.g. apply the
+ * filter); pass null to make the action a no-op.
+ *
+ * [includeLocalOnlyFilters] controls the device-local criteria that cannot be persisted to a Readeck
+ * collection: the **Length** (reading-time / word-count) filter and the **Downloaded** (`isLoaded`)
+ * tri-state. Pass false from the collection editor so those controls aren't offered (they would be
+ * silently dropped on save). `With labels` and `With errors` are server-supported and always shown.
+ */
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
-fun FilterBottomSheet(
-    currentFilter: FilterFormState,
-    labels: Map<String, Int> = emptyMap(),
-    onApply: (FilterFormState) -> Unit,
-    onReset: () -> Unit,
-    onDismiss: () -> Unit,
+fun FilterControls(
+    state: FilterEditorState,
+    labels: Map<String, Int>,
+    modifier: Modifier = Modifier,
+    onImeAction: (() -> Unit)? = null,
+    includeLocalOnlyFilters: Boolean = true,
 ) {
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false)
-
-    var search by remember(currentFilter) { mutableStateOf(currentFilter.search ?: "") }
-    var title by remember(currentFilter) { mutableStateOf(currentFilter.title ?: "") }
-    var author by remember(currentFilter) { mutableStateOf(currentFilter.author ?: "") }
-    var site by remember(currentFilter) { mutableStateOf(currentFilter.site ?: "") }
-    var label by remember(currentFilter) { mutableStateOf(currentFilter.label) }
-    var fromDate by remember(currentFilter) { mutableStateOf(currentFilter.fromDate) }
-    var toDate by remember(currentFilter) { mutableStateOf(currentFilter.toDate) }
-    var types by remember(currentFilter) { mutableStateOf(currentFilter.types) }
-    var progress by remember(currentFilter) { mutableStateOf(currentFilter.progress) }
-    var isFavorite by remember(currentFilter) { mutableStateOf(currentFilter.isFavorite) }
-    var isArchived by remember(currentFilter) { mutableStateOf(currentFilter.isArchived) }
-    var isLoaded by remember(currentFilter) { mutableStateOf(currentFilter.isLoaded) }
-    var withLabels by remember(currentFilter) { mutableStateOf(currentFilter.withLabels) }
-    var withErrors by remember(currentFilter) { mutableStateOf(currentFilter.withErrors) }
-    var minReadingTime by remember(currentFilter) { mutableStateOf(currentFilter.minReadingTime?.toString() ?: "") }
-    var maxReadingTime by remember(currentFilter) { mutableStateOf(currentFilter.maxReadingTime?.toString() ?: "") }
-    var includeNullReadingTime by remember(currentFilter) { mutableStateOf(currentFilter.includeNullReadingTime) }
-    var minWordCount by remember(currentFilter) { mutableStateOf(currentFilter.minWordCount?.toString() ?: "") }
-    var maxWordCount by remember(currentFilter) { mutableStateOf(currentFilter.maxWordCount?.toString() ?: "") }
-    var includeNullWordCount by remember(currentFilter) { mutableStateOf(currentFilter.includeNullWordCount) }
-
-    val readingTimeError = minReadingTime.isNotEmpty() && maxReadingTime.isNotEmpty() &&
-        (minReadingTime.toIntOrNull() ?: 0) > (maxReadingTime.toIntOrNull() ?: 0)
-    val wordCountError = minWordCount.isNotEmpty() && maxWordCount.isNotEmpty() &&
-        (minWordCount.toIntOrNull() ?: 0) > (maxWordCount.toIntOrNull() ?: 0)
-    val hasValidationError = readingTimeError || wordCountError
-
     var showLabelPicker by remember { mutableStateOf(false) }
     var showFromDatePicker by remember { mutableStateOf(false) }
     var showToDatePicker by remember { mutableStateOf(false) }
     var showLengthFilterDialog by remember { mutableStateOf(false) }
-
-    val hasActiveFilters = search.isNotBlank() || title.isNotBlank() || author.isNotBlank() ||
-        site.isNotBlank() || label != null || fromDate != null || toDate != null ||
-        types.isNotEmpty() || progress.isNotEmpty() || isFavorite != null ||
-        isArchived != null || isLoaded != null || withLabels != null || withErrors != null ||
-        minReadingTime.isNotBlank() || maxReadingTime.isNotBlank() || includeNullReadingTime ||
-        minWordCount.isNotBlank() || maxWordCount.isNotBlank() || includeNullWordCount
-
-    val applyFilter = {
-        if (!hasValidationError) {
-            onApply(FilterFormState(
-                search = search.ifBlank { null },
-                title = title.ifBlank { null },
-                author = author.ifBlank { null },
-                site = site.ifBlank { null },
-                label = label,
-                fromDate = fromDate,
-                toDate = toDate,
-                types = types,
-                progress = progress,
-                isFavorite = isFavorite,
-                isArchived = isArchived,
-                isLoaded = isLoaded,
-                withLabels = withLabels,
-                withErrors = withErrors,
-                minReadingTime = minReadingTime.toIntOrNull(),
-                maxReadingTime = maxReadingTime.toIntOrNull(),
-                includeNullReadingTime = includeNullReadingTime,
-                minWordCount = minWordCount.toIntOrNull(),
-                maxWordCount = maxWordCount.toIntOrNull(),
-                includeNullWordCount = includeNullWordCount,
-            ))
-        }
-    }
 
     // Colors that make a disabled OutlinedTextField look like an enabled one.
     // Required for read-only picker fields (label, dates) because enabled=false is needed
@@ -161,13 +187,341 @@ fun FilterBottomSheet(
 
     val dateFormatter = remember { SimpleDateFormat("MMM d, yyyy", Locale.getDefault()) }
     val lengthSummary = lengthFilterSummary(
-        minReadingTime = minReadingTime.toIntOrNull(),
-        maxReadingTime = maxReadingTime.toIntOrNull(),
-        includeNullReadingTime = includeNullReadingTime,
-        minWordCount = minWordCount.toIntOrNull(),
-        maxWordCount = maxWordCount.toIntOrNull(),
-        includeNullWordCount = includeNullWordCount,
+        minReadingTime = state.minReadingTime.toIntOrNull(),
+        maxReadingTime = state.maxReadingTime.toIntOrNull(),
+        includeNullReadingTime = state.includeNullReadingTime,
+        minWordCount = state.minWordCount.toIntOrNull(),
+        maxWordCount = state.maxWordCount.toIntOrNull(),
+        includeNullWordCount = state.includeNullWordCount,
     )
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        // -- Search (full width, keyboard entry)
+        OutlinedTextField(
+            value = state.search,
+            onValueChange = { state.search = it },
+            label = { Text(stringResource(R.string.filter_search)) },
+            placeholder = { Text(stringResource(R.string.search_bookmarks)) },
+            trailingIcon = {
+                if (state.search.isNotEmpty()) {
+                    IconButton(onClick = { state.search = "" }) {
+                        Icon(Icons.Filled.Clear, contentDescription = null, modifier = Modifier.size(20.dp))
+                    }
+                }
+            },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+            keyboardActions = KeyboardActions(onSearch = { onImeAction?.invoke() }),
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        Spacer(Modifier.height(12.dp))
+
+        // -- Title / Author (side-by-side)
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            OutlinedTextField(
+                value = state.title,
+                onValueChange = { state.title = it },
+                label = { Text(stringResource(R.string.filter_title)) },
+                trailingIcon = {
+                    if (state.title.isNotEmpty()) {
+                        IconButton(onClick = { state.title = "" }) {
+                            Icon(Icons.Filled.Clear, contentDescription = null, modifier = Modifier.size(16.dp))
+                        }
+                    }
+                },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                keyboardActions = KeyboardActions(onSearch = { onImeAction?.invoke() }),
+                modifier = Modifier.weight(1f)
+            )
+            OutlinedTextField(
+                value = state.author,
+                onValueChange = { state.author = it },
+                label = { Text(stringResource(R.string.filter_author)) },
+                trailingIcon = {
+                    if (state.author.isNotEmpty()) {
+                        IconButton(onClick = { state.author = "" }) {
+                            Icon(Icons.Filled.Clear, contentDescription = null, modifier = Modifier.size(16.dp))
+                        }
+                    }
+                },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                keyboardActions = KeyboardActions(onSearch = { onImeAction?.invoke() }),
+                modifier = Modifier.weight(1f)
+            )
+        }
+
+        Spacer(Modifier.height(12.dp))
+
+        // -- Site / Label (side-by-side)
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            OutlinedTextField(
+                value = state.site,
+                onValueChange = { state.site = it },
+                label = { Text(stringResource(R.string.filter_site)) },
+                trailingIcon = {
+                    if (state.site.isNotEmpty()) {
+                        IconButton(onClick = { state.site = "" }) {
+                            Icon(Icons.Filled.Clear, contentDescription = null, modifier = Modifier.size(16.dp))
+                        }
+                    }
+                },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                keyboardActions = KeyboardActions(onSearch = { onImeAction?.invoke() }),
+                modifier = Modifier.weight(1f)
+            )
+            OutlinedTextField(
+                value = state.label ?: "",
+                onValueChange = {},
+                readOnly = true,
+                enabled = false,
+                colors = pickerColors,
+                label = { Text(stringResource(R.string.filter_label)) },
+                placeholder = { Text(stringResource(R.string.filter_select_label)) },
+                trailingIcon = {
+                    if (state.label != null) {
+                        IconButton(onClick = { state.label = null }) {
+                            Icon(Icons.Filled.Clear, contentDescription = null, modifier = Modifier.size(16.dp))
+                        }
+                    }
+                },
+                modifier = Modifier
+                    .weight(1f)
+                    .clickable { showLabelPicker = true }
+            )
+        }
+
+        Spacer(Modifier.height(12.dp))
+
+        // -- From Date / To Date (side-by-side)
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            OutlinedTextField(
+                value = state.fromDate?.let { dateFormatter.format(Date(it.toEpochMilliseconds())) } ?: "",
+                onValueChange = {},
+                readOnly = true,
+                enabled = false,
+                colors = pickerColors,
+                label = { Text(stringResource(R.string.filter_from_date)) },
+                trailingIcon = {
+                    if (state.fromDate != null) {
+                        IconButton(onClick = { state.fromDate = null }) {
+                            Icon(Icons.Filled.Clear, contentDescription = null, modifier = Modifier.size(16.dp))
+                        }
+                    }
+                },
+                modifier = Modifier
+                    .weight(1f)
+                    .clickable { showFromDatePicker = true }
+            )
+            OutlinedTextField(
+                value = state.toDate?.let { dateFormatter.format(Date(it.toEpochMilliseconds())) } ?: "",
+                onValueChange = {},
+                readOnly = true,
+                enabled = false,
+                colors = pickerColors,
+                label = { Text(stringResource(R.string.filter_to_date)) },
+                trailingIcon = {
+                    if (state.toDate != null) {
+                        IconButton(onClick = { state.toDate = null }) {
+                            Icon(Icons.Filled.Clear, contentDescription = null, modifier = Modifier.size(16.dp))
+                        }
+                    }
+                },
+                modifier = Modifier
+                    .weight(1f)
+                    .clickable { showToDatePicker = true }
+            )
+        }
+
+        Spacer(Modifier.height(12.dp))
+
+        if (includeLocalOnlyFilters) {
+            OutlinedTextField(
+                value = lengthSummary ?: "",
+                onValueChange = {},
+                readOnly = true,
+                enabled = false,
+                colors = pickerColors,
+                label = { Text(stringResource(R.string.filter_length)) },
+                placeholder = { Text(stringResource(R.string.filter_length_summary_none)) },
+                trailingIcon = {
+                    if (lengthSummary != null) {
+                        IconButton(onClick = {
+                            state.minReadingTime = ""
+                            state.maxReadingTime = ""
+                            state.includeNullReadingTime = false
+                            state.minWordCount = ""
+                            state.maxWordCount = ""
+                            state.includeNullWordCount = false
+                        }) {
+                            Icon(Icons.Filled.Clear, contentDescription = null, modifier = Modifier.size(16.dp))
+                        }
+                    }
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { showLengthFilterDialog = true }
+            )
+
+            Spacer(Modifier.height(12.dp))
+        }
+
+        // -- Type chips
+        Text(stringResource(R.string.filter_type), style = MaterialTheme.typography.labelLarge)
+        Spacer(Modifier.height(8.dp))
+        FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            FilterChip(
+                selected = Bookmark.Type.Article in state.types,
+                onClick = { state.types = if (Bookmark.Type.Article in state.types) state.types - Bookmark.Type.Article else state.types + Bookmark.Type.Article },
+                label = { Text(stringResource(R.string.filter_type_article)) }
+            )
+            FilterChip(
+                selected = Bookmark.Type.Video in state.types,
+                onClick = { state.types = if (Bookmark.Type.Video in state.types) state.types - Bookmark.Type.Video else state.types + Bookmark.Type.Video },
+                label = { Text(stringResource(R.string.filter_type_video)) }
+            )
+            FilterChip(
+                selected = Bookmark.Type.Picture in state.types,
+                onClick = { state.types = if (Bookmark.Type.Picture in state.types) state.types - Bookmark.Type.Picture else state.types + Bookmark.Type.Picture },
+                label = { Text(stringResource(R.string.filter_type_picture)) }
+            )
+        }
+
+        Spacer(Modifier.height(16.dp))
+
+        // -- Progress chips
+        Text(stringResource(R.string.filter_progress), style = MaterialTheme.typography.labelLarge)
+        Spacer(Modifier.height(8.dp))
+        FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            FilterChip(
+                selected = ProgressFilter.UNVIEWED in state.progress,
+                onClick = { state.progress = if (ProgressFilter.UNVIEWED in state.progress) state.progress - ProgressFilter.UNVIEWED else state.progress + ProgressFilter.UNVIEWED },
+                label = { Text(stringResource(R.string.progress_unviewed)) }
+            )
+            FilterChip(
+                selected = ProgressFilter.IN_PROGRESS in state.progress,
+                onClick = { state.progress = if (ProgressFilter.IN_PROGRESS in state.progress) state.progress - ProgressFilter.IN_PROGRESS else state.progress + ProgressFilter.IN_PROGRESS },
+                label = { Text(stringResource(R.string.progress_in_progress)) }
+            )
+            FilterChip(
+                selected = ProgressFilter.COMPLETED in state.progress,
+                onClick = { state.progress = if (ProgressFilter.COMPLETED in state.progress) state.progress - ProgressFilter.COMPLETED else state.progress + ProgressFilter.COMPLETED },
+                label = { Text(stringResource(R.string.progress_completed)) }
+            )
+        }
+
+        Spacer(Modifier.height(16.dp))
+
+        // -- Boolean filters (compact label-beside-control rows)
+        CompactTriStateRow(stringResource(R.string.filter_is_favorite), state.isFavorite) { state.isFavorite = it }
+        Spacer(Modifier.height(8.dp))
+        CompactTriStateRow(stringResource(R.string.filter_is_archived), state.isArchived) { state.isArchived = it }
+        Spacer(Modifier.height(8.dp))
+        if (includeLocalOnlyFilters) {
+            CompactTriStateRow(stringResource(R.string.filter_is_loaded), state.isLoaded) { state.isLoaded = it }
+            Spacer(Modifier.height(8.dp))
+        }
+        CompactTriStateRow(stringResource(R.string.filter_with_labels), state.withLabels) { state.withLabels = it }
+        Spacer(Modifier.height(8.dp))
+        CompactTriStateRow(stringResource(R.string.filter_with_errors), state.withErrors) { state.withErrors = it }
+    }
+
+    if (showLengthFilterDialog) {
+        LengthFilterDialog(
+            initialMinReadingTime = state.minReadingTime,
+            initialMaxReadingTime = state.maxReadingTime,
+            initialIncludeNullReadingTime = state.includeNullReadingTime,
+            initialMinWordCount = state.minWordCount,
+            initialMaxWordCount = state.maxWordCount,
+            initialIncludeNullWordCount = state.includeNullWordCount,
+            onApply = { newMinReadingTime,
+                    newMaxReadingTime,
+                    newIncludeNullReadingTime,
+                    newMinWordCount,
+                    newMaxWordCount,
+                    newIncludeNullWordCount ->
+                state.minReadingTime = newMinReadingTime
+                state.maxReadingTime = newMaxReadingTime
+                state.includeNullReadingTime = newIncludeNullReadingTime
+                state.minWordCount = newMinWordCount
+                state.maxWordCount = newMaxWordCount
+                state.includeNullWordCount = newIncludeNullWordCount
+                showLengthFilterDialog = false
+            },
+            onDismiss = { showLengthFilterDialog = false }
+        )
+    }
+
+    // Label picker (selection-only — no rename/delete)
+    if (showLabelPicker) {
+        LabelPickerBottomSheet(
+            labels = labels,
+            mode = LabelPickerMode.SingleSelect(
+                selectedLabel = state.label,
+                onLabelSelected = { selected ->
+                    state.label = selected
+                    showLabelPicker = false
+                }
+            ),
+            onDismiss = { showLabelPicker = false }
+        )
+    }
+
+    // From Date picker
+    if (showFromDatePicker) {
+        val pickerState = rememberDatePickerState(initialSelectedDateMillis = state.fromDate?.toEpochMilliseconds())
+        DatePickerDialog(
+            onDismissRequest = { showFromDatePicker = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    pickerState.selectedDateMillis?.let { state.fromDate = Instant.fromEpochMilliseconds(it) }
+                    showFromDatePicker = false
+                }) { Text(stringResource(R.string.ok)) }
+            },
+            dismissButton = {
+                TextButton(onClick = { showFromDatePicker = false }) { Text(stringResource(R.string.cancel)) }
+            }
+        ) { DatePicker(state = pickerState) }
+    }
+
+    // To Date picker
+    if (showToDatePicker) {
+        val pickerState = rememberDatePickerState(initialSelectedDateMillis = state.toDate?.toEpochMilliseconds())
+        DatePickerDialog(
+            onDismissRequest = { showToDatePicker = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    pickerState.selectedDateMillis?.let { state.toDate = Instant.fromEpochMilliseconds(it) }
+                    showToDatePicker = false
+                }) { Text(stringResource(R.string.ok)) }
+            },
+            dismissButton = {
+                TextButton(onClick = { showToDatePicker = false }) { Text(stringResource(R.string.cancel)) }
+            }
+        ) { DatePicker(state = pickerState) }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun FilterBottomSheet(
+    currentFilter: FilterFormState,
+    labels: Map<String, Int> = emptyMap(),
+    onApply: (FilterFormState) -> Unit,
+    onReset: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false)
+    val state = rememberFilterEditorState(currentFilter)
+
+    val applyFilter = {
+        if (!state.hasValidationError) {
+            onApply(state.toFilterFormState())
+        }
+    }
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,
@@ -180,322 +534,25 @@ fun FilterBottomSheet(
                 .padding(horizontal = 24.dp)
                 .navigationBarsPadding()
         ) {
-            // -- Search (full width, keyboard entry)
-            OutlinedTextField(
-                value = search,
-                onValueChange = { search = it },
-                label = { Text(stringResource(R.string.filter_search)) },
-                placeholder = { Text(stringResource(R.string.search_bookmarks)) },
-                trailingIcon = {
-                    if (search.isNotEmpty()) {
-                        IconButton(onClick = { search = "" }) {
-                            Icon(Icons.Filled.Clear, contentDescription = null, modifier = Modifier.size(20.dp))
-                        }
-                    }
-                },
-                singleLine = true,
-                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
-                keyboardActions = KeyboardActions(onSearch = { applyFilter() }),
-                modifier = Modifier.fillMaxWidth()
+            FilterControls(
+                state = state,
+                labels = labels,
+                onImeAction = applyFilter,
             )
-
-            Spacer(Modifier.height(12.dp))
-
-            // -- Title / Author (side-by-side)
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                OutlinedTextField(
-                    value = title,
-                    onValueChange = { title = it },
-                    label = { Text(stringResource(R.string.filter_title)) },
-                    trailingIcon = {
-                        if (title.isNotEmpty()) {
-                            IconButton(onClick = { title = "" }) {
-                                Icon(Icons.Filled.Clear, contentDescription = null, modifier = Modifier.size(16.dp))
-                            }
-                        }
-                    },
-                    singleLine = true,
-                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
-                    keyboardActions = KeyboardActions(onSearch = { applyFilter() }),
-                    modifier = Modifier.weight(1f)
-                )
-                OutlinedTextField(
-                    value = author,
-                    onValueChange = { author = it },
-                    label = { Text(stringResource(R.string.filter_author)) },
-                    trailingIcon = {
-                        if (author.isNotEmpty()) {
-                            IconButton(onClick = { author = "" }) {
-                                Icon(Icons.Filled.Clear, contentDescription = null, modifier = Modifier.size(16.dp))
-                            }
-                        }
-                    },
-                    singleLine = true,
-                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
-                    keyboardActions = KeyboardActions(onSearch = { applyFilter() }),
-                    modifier = Modifier.weight(1f)
-                )
-            }
-
-            Spacer(Modifier.height(12.dp))
-
-            // -- Site / Label (side-by-side)
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                OutlinedTextField(
-                    value = site,
-                    onValueChange = { site = it },
-                    label = { Text(stringResource(R.string.filter_site)) },
-                    trailingIcon = {
-                        if (site.isNotEmpty()) {
-                            IconButton(onClick = { site = "" }) {
-                                Icon(Icons.Filled.Clear, contentDescription = null, modifier = Modifier.size(16.dp))
-                            }
-                        }
-                    },
-                    singleLine = true,
-                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
-                    keyboardActions = KeyboardActions(onSearch = { applyFilter() }),
-                    modifier = Modifier.weight(1f)
-                )
-                OutlinedTextField(
-                    value = label ?: "",
-                    onValueChange = {},
-                    readOnly = true,
-                    enabled = false,
-                    colors = pickerColors,
-                    label = { Text(stringResource(R.string.filter_label)) },
-                    placeholder = { Text(stringResource(R.string.filter_select_label)) },
-                    trailingIcon = {
-                        if (label != null) {
-                            IconButton(onClick = { label = null }) {
-                                Icon(Icons.Filled.Clear, contentDescription = null, modifier = Modifier.size(16.dp))
-                            }
-                        }
-                    },
-                    modifier = Modifier
-                        .weight(1f)
-                        .clickable { showLabelPicker = true }
-                )
-            }
-
-            Spacer(Modifier.height(12.dp))
-
-            // -- From Date / To Date (side-by-side)
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                OutlinedTextField(
-                    value = fromDate?.let { dateFormatter.format(Date(it.toEpochMilliseconds())) } ?: "",
-                    onValueChange = {},
-                    readOnly = true,
-                    enabled = false,
-                    colors = pickerColors,
-                    label = { Text(stringResource(R.string.filter_from_date)) },
-                    trailingIcon = {
-                        if (fromDate != null) {
-                            IconButton(onClick = { fromDate = null }) {
-                                Icon(Icons.Filled.Clear, contentDescription = null, modifier = Modifier.size(16.dp))
-                            }
-                        }
-                    },
-                    modifier = Modifier
-                        .weight(1f)
-                        .clickable { showFromDatePicker = true }
-                )
-                OutlinedTextField(
-                    value = toDate?.let { dateFormatter.format(Date(it.toEpochMilliseconds())) } ?: "",
-                    onValueChange = {},
-                    readOnly = true,
-                    enabled = false,
-                    colors = pickerColors,
-                    label = { Text(stringResource(R.string.filter_to_date)) },
-                    trailingIcon = {
-                        if (toDate != null) {
-                            IconButton(onClick = { toDate = null }) {
-                                Icon(Icons.Filled.Clear, contentDescription = null, modifier = Modifier.size(16.dp))
-                            }
-                        }
-                    },
-                    modifier = Modifier
-                        .weight(1f)
-                        .clickable { showToDatePicker = true }
-                )
-            }
-
-            Spacer(Modifier.height(12.dp))
-
-            OutlinedTextField(
-                value = lengthSummary ?: "",
-                onValueChange = {},
-                readOnly = true,
-                enabled = false,
-                colors = pickerColors,
-                label = { Text(stringResource(R.string.filter_length)) },
-                placeholder = { Text(stringResource(R.string.filter_length_summary_none)) },
-                trailingIcon = {
-                    if (lengthSummary != null) {
-                        IconButton(onClick = {
-                            minReadingTime = ""
-                            maxReadingTime = ""
-                            includeNullReadingTime = false
-                            minWordCount = ""
-                            maxWordCount = ""
-                            includeNullWordCount = false
-                        }) {
-                            Icon(Icons.Filled.Clear, contentDescription = null, modifier = Modifier.size(16.dp))
-                        }
-                    }
-                },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable { showLengthFilterDialog = true }
-            )
-
-            Spacer(Modifier.height(12.dp))
-
-            // -- Type chips
-            Text(stringResource(R.string.filter_type), style = MaterialTheme.typography.labelLarge)
-            Spacer(Modifier.height(8.dp))
-            FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                FilterChip(
-                    selected = Bookmark.Type.Article in types,
-                    onClick = { types = if (Bookmark.Type.Article in types) types - Bookmark.Type.Article else types + Bookmark.Type.Article },
-                    label = { Text(stringResource(R.string.filter_type_article)) }
-                )
-                FilterChip(
-                    selected = Bookmark.Type.Video in types,
-                    onClick = { types = if (Bookmark.Type.Video in types) types - Bookmark.Type.Video else types + Bookmark.Type.Video },
-                    label = { Text(stringResource(R.string.filter_type_video)) }
-                )
-                FilterChip(
-                    selected = Bookmark.Type.Picture in types,
-                    onClick = { types = if (Bookmark.Type.Picture in types) types - Bookmark.Type.Picture else types + Bookmark.Type.Picture },
-                    label = { Text(stringResource(R.string.filter_type_picture)) }
-                )
-            }
-
-            Spacer(Modifier.height(16.dp))
-
-            // -- Progress chips
-            Text(stringResource(R.string.filter_progress), style = MaterialTheme.typography.labelLarge)
-            Spacer(Modifier.height(8.dp))
-            FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                FilterChip(
-                    selected = ProgressFilter.UNVIEWED in progress,
-                    onClick = { progress = if (ProgressFilter.UNVIEWED in progress) progress - ProgressFilter.UNVIEWED else progress + ProgressFilter.UNVIEWED },
-                    label = { Text(stringResource(R.string.progress_unviewed)) }
-                )
-                FilterChip(
-                    selected = ProgressFilter.IN_PROGRESS in progress,
-                    onClick = { progress = if (ProgressFilter.IN_PROGRESS in progress) progress - ProgressFilter.IN_PROGRESS else progress + ProgressFilter.IN_PROGRESS },
-                    label = { Text(stringResource(R.string.progress_in_progress)) }
-                )
-                FilterChip(
-                    selected = ProgressFilter.COMPLETED in progress,
-                    onClick = { progress = if (ProgressFilter.COMPLETED in progress) progress - ProgressFilter.COMPLETED else progress + ProgressFilter.COMPLETED },
-                    label = { Text(stringResource(R.string.progress_completed)) }
-                )
-            }
-
-            Spacer(Modifier.height(16.dp))
-
-            // -- Boolean filters (compact label-beside-control rows)
-            CompactTriStateRow(stringResource(R.string.filter_is_favorite), isFavorite) { isFavorite = it }
-            Spacer(Modifier.height(8.dp))
-            CompactTriStateRow(stringResource(R.string.filter_is_archived), isArchived) { isArchived = it }
-            Spacer(Modifier.height(8.dp))
-            CompactTriStateRow(stringResource(R.string.filter_is_loaded), isLoaded) { isLoaded = it }
-            Spacer(Modifier.height(8.dp))
-            CompactTriStateRow(stringResource(R.string.filter_with_labels), withLabels) { withLabels = it }
-            Spacer(Modifier.height(8.dp))
-            CompactTriStateRow(stringResource(R.string.filter_with_errors), withErrors) { withErrors = it }
 
             Spacer(Modifier.height(20.dp))
 
             // -- Action buttons
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
-                if (hasActiveFilters) {
+                if (state.hasActiveFilters) {
                     TextButton(onClick = onReset) { Text(stringResource(R.string.filter_reset)) }
                     Spacer(Modifier.width(8.dp))
                 }
-                Button(onClick = { applyFilter() }, enabled = !hasValidationError) { Text(stringResource(R.string.search)) }
+                Button(onClick = { applyFilter() }, enabled = !state.hasValidationError) { Text(stringResource(R.string.search)) }
             }
 
             Spacer(Modifier.height(16.dp))
         }
-    }
-
-    if (showLengthFilterDialog) {
-        LengthFilterDialog(
-            initialMinReadingTime = minReadingTime,
-            initialMaxReadingTime = maxReadingTime,
-            initialIncludeNullReadingTime = includeNullReadingTime,
-            initialMinWordCount = minWordCount,
-            initialMaxWordCount = maxWordCount,
-            initialIncludeNullWordCount = includeNullWordCount,
-            onApply = { newMinReadingTime,
-                    newMaxReadingTime,
-                    newIncludeNullReadingTime,
-                    newMinWordCount,
-                    newMaxWordCount,
-                    newIncludeNullWordCount ->
-                minReadingTime = newMinReadingTime
-                maxReadingTime = newMaxReadingTime
-                includeNullReadingTime = newIncludeNullReadingTime
-                minWordCount = newMinWordCount
-                maxWordCount = newMaxWordCount
-                includeNullWordCount = newIncludeNullWordCount
-                showLengthFilterDialog = false
-            },
-            onDismiss = { showLengthFilterDialog = false }
-        )
-    }
-
-    // Label picker (selection-only — no rename/delete)
-    if (showLabelPicker) {
-        LabelPickerBottomSheet(
-            labels = labels,
-            mode = LabelPickerMode.SingleSelect(
-                selectedLabel = label,
-                onLabelSelected = { selected ->
-                    label = selected
-                    showLabelPicker = false
-                }
-            ),
-            onDismiss = { showLabelPicker = false }
-        )
-    }
-
-    // From Date picker
-    if (showFromDatePicker) {
-        val state = rememberDatePickerState(initialSelectedDateMillis = fromDate?.toEpochMilliseconds())
-        DatePickerDialog(
-            onDismissRequest = { showFromDatePicker = false },
-            confirmButton = {
-                TextButton(onClick = {
-                    state.selectedDateMillis?.let { fromDate = Instant.fromEpochMilliseconds(it) }
-                    showFromDatePicker = false
-                }) { Text(stringResource(R.string.ok)) }
-            },
-            dismissButton = {
-                TextButton(onClick = { showFromDatePicker = false }) { Text(stringResource(R.string.cancel)) }
-            }
-        ) { DatePicker(state = state) }
-    }
-
-    // To Date picker
-    if (showToDatePicker) {
-        val state = rememberDatePickerState(initialSelectedDateMillis = toDate?.toEpochMilliseconds())
-        DatePickerDialog(
-            onDismissRequest = { showToDatePicker = false },
-            confirmButton = {
-                TextButton(onClick = {
-                    state.selectedDateMillis?.let { toDate = Instant.fromEpochMilliseconds(it) }
-                    showToDatePicker = false
-                }) { Text(stringResource(R.string.ok)) }
-            },
-            dismissButton = {
-                TextButton(onClick = { showToDatePicker = false }) { Text(stringResource(R.string.cancel)) }
-            }
-        ) { DatePicker(state = state) }
     }
 }
 

--- a/app/src/main/java/com/mydeck/app/ui/components/FilterBottomSheet.kt
+++ b/app/src/main/java/com/mydeck/app/ui/components/FilterBottomSheet.kt
@@ -2,6 +2,7 @@ package com.mydeck.app.ui.components
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -36,13 +37,17 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.PlainTooltip
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.TooltipBox
+import androidx.compose.material3.TooltipDefaults
 import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
@@ -52,9 +57,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.focus.onFocusEvent
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
@@ -155,10 +162,13 @@ fun rememberFilterEditorState(currentFilter: FilterFormState): FilterEditorState
  * [onImeAction] runs when the keyboard "search/done" action fires on a text field (e.g. apply the
  * filter); pass null to make the action a no-op.
  *
- * [includeLocalOnlyFilters] controls the device-local criteria that cannot be persisted to a Readeck
+ * [localOnlyFiltersEditable] controls the device-local criteria that cannot be persisted to a Readeck
  * collection: the **Length** (reading-time / word-count) filter and the **Downloaded** (`isLoaded`)
- * tri-state. Pass false from the collection editor so those controls aren't offered (they would be
- * silently dropped on save). `With labels` and `With errors` are server-supported and always shown.
+ * tri-state. When true (the normal filter sheet) they are fully editable. When false (the collection
+ * editor) they are still shown in their usual positions but rendered disabled with an "Unavailable"
+ * value and a long-press tooltip explaining why — so the user sees the criteria exist and learns they
+ * can't be saved, rather than the fields silently vanishing. `With labels` and `With errors` are
+ * server-supported and always editable.
  */
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
@@ -167,7 +177,7 @@ fun FilterControls(
     labels: Map<String, Int>,
     modifier: Modifier = Modifier,
     onImeAction: (() -> Unit)? = null,
-    includeLocalOnlyFilters: Boolean = true,
+    localOnlyFiltersEditable: Boolean = true,
 ) {
     var showLabelPicker by remember { mutableStateOf(false) }
     var showFromDatePicker by remember { mutableStateOf(false) }
@@ -338,7 +348,7 @@ fun FilterControls(
 
         Spacer(Modifier.height(12.dp))
 
-        if (includeLocalOnlyFilters) {
+        if (localOnlyFiltersEditable) {
             OutlinedTextField(
                 value = lengthSummary ?: "",
                 onValueChange = {},
@@ -366,6 +376,9 @@ fun FilterControls(
                     .clickable { showLengthFilterDialog = true }
             )
 
+            Spacer(Modifier.height(12.dp))
+        } else {
+            UnavailableInCollectionField(label = stringResource(R.string.filter_length))
             Spacer(Modifier.height(12.dp))
         }
 
@@ -420,8 +433,11 @@ fun FilterControls(
         Spacer(Modifier.height(8.dp))
         CompactTriStateRow(stringResource(R.string.filter_is_archived), state.isArchived) { state.isArchived = it }
         Spacer(Modifier.height(8.dp))
-        if (includeLocalOnlyFilters) {
+        if (localOnlyFiltersEditable) {
             CompactTriStateRow(stringResource(R.string.filter_is_loaded), state.isLoaded) { state.isLoaded = it }
+            Spacer(Modifier.height(8.dp))
+        } else {
+            UnavailableInCollectionRow(label = stringResource(R.string.filter_is_loaded))
             Spacer(Modifier.height(8.dp))
         }
         CompactTriStateRow(stringResource(R.string.filter_with_labels), state.withLabels) { state.withLabels = it }
@@ -800,6 +816,102 @@ private fun Modifier.bringFocusedFieldIntoView(): Modifier {
     return this
         .bringIntoViewRequester(bringIntoViewRequester)
         .onFocusEvent { state -> isFocused = state.isFocused }
+}
+
+/**
+ * The **Length** picker field rendered non-editable for the collection editor: the label and outlined
+ * box look normal (matching the editable filter fields), only the value reads a greyed "Unavailable".
+ * A long-press tooltip explains that this device-local criterion can't be saved in a collection.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun UnavailableInCollectionField(label: String) {
+    TooltipBox(
+        positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
+        tooltip = { PlainTooltip { Text(stringResource(R.string.filter_unavailable_in_collection_tooltip)) } },
+        state = rememberTooltipState(),
+    ) {
+        OutlinedTextField(
+            value = stringResource(R.string.filter_unavailable),
+            onValueChange = {},
+            readOnly = true,
+            enabled = false,
+            label = { Text(label) },
+            // Normal label + border; only the value text is greyed to read as "not set here".
+            colors = OutlinedTextFieldDefaults.colors(
+                disabledTextColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
+                disabledBorderColor = MaterialTheme.colorScheme.outline,
+                disabledLabelColor = MaterialTheme.colorScheme.onSurfaceVariant,
+            ),
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}
+
+/**
+ * A boolean tri-state row (e.g. **Downloaded**) rendered non-editable for the collection editor: the
+ * label stays in place and the 3-value segmented control is replaced by a single segmented pill with
+ * a normal outline and a greyed, centered "Unavailable". A long-press tooltip explains why the
+ * criterion can't be saved in a collection.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun UnavailableInCollectionRow(label: String) {
+    val unavailableColors = SegmentedButtonDefaults.colors(
+        disabledInactiveBorderColor = MaterialTheme.colorScheme.outline,
+        disabledInactiveContentColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
+    )
+    TooltipBox(
+        positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
+        tooltip = { PlainTooltip { Text(stringResource(R.string.filter_unavailable_in_collection_tooltip)) } },
+        state = rememberTooltipState(),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.weight(1f)
+            )
+            // The pill must match the width of the editable 3-value tri-state controls above/below it.
+            // That width is content- and locale-dependent, so an invisible reference copy of the
+            // 3-value control sizes the Box, and the visible single pill fills it via matchParentSize.
+            Box {
+                val triLabels = listOf(
+                    stringResource(R.string.tri_state_any),
+                    stringResource(R.string.tri_state_yes),
+                    stringResource(R.string.tri_state_no),
+                )
+                SingleChoiceSegmentedButtonRow(
+                    modifier = Modifier
+                        .alpha(0f)
+                        .clearAndSetSemantics {}
+                ) {
+                    triLabels.forEachIndexed { index, text ->
+                        SegmentedButton(
+                            shape = SegmentedButtonDefaults.itemShape(index = index, count = triLabels.size),
+                            onClick = {},
+                            selected = false,
+                            enabled = false,
+                        ) { Text(text) }
+                    }
+                }
+                SingleChoiceSegmentedButtonRow(modifier = Modifier.matchParentSize()) {
+                    SegmentedButton(
+                        shape = SegmentedButtonDefaults.itemShape(index = 0, count = 1),
+                        onClick = {},
+                        selected = false,
+                        enabled = false,
+                        colors = unavailableColors,
+                    ) {
+                        Text(stringResource(R.string.filter_unavailable))
+                    }
+                }
+            }
+        }
+    }
 }
 
 /** Single-row tri-state control: label on the left, [N/A | Yes | No] on the right. */

--- a/app/src/main/java/com/mydeck/app/ui/list/BookmarkListScreen.kt
+++ b/app/src/main/java/com/mydeck/app/ui/list/BookmarkListScreen.kt
@@ -277,7 +277,9 @@ fun BookmarkListScreen(
 
     fun stageCollectionDeleteWithSnackbar(collection: Collection) {
         // Mirror bookmark delete: stage now (hide + leave the view), defer the actual delete until the
-        // Undo snackbar is dismissed by an interaction other than Undo.
+        // Undo snackbar is dismissed by an interaction other than Undo. Dismiss any in-flight
+        // pending-delete snackbar first so this one shows immediately rather than queueing behind it.
+        dismissPendingDeleteSnackbar()
         viewModel.onStageDeleteCollection(collection.id)
         scope.launch {
             val result = snackbarHostState.showSnackbar(
@@ -810,7 +812,8 @@ fun BookmarkListScreen(
                     BookmarkListBarActions(
                         isLabelMode = isLabelMode,
                         isCollectionMode = isCollectionMode,
-                        canSaveAsCollection = filterFormState.value.differsFromPreset(drawerPreset.value),
+                        canSaveAsCollection = !isCollectionMode &&
+                            filterFormState.value.differsFromPreset(drawerPreset.value),
                         layoutMode = layoutMode.value,
                         sortOption = sortOption.value,
                         onLayoutModeSelected = { viewModel.onLayoutModeSelected(it) },

--- a/app/src/main/java/com/mydeck/app/ui/list/BookmarkListScreen.kt
+++ b/app/src/main/java/com/mydeck/app/ui/list/BookmarkListScreen.kt
@@ -125,6 +125,7 @@ import com.mydeck.app.domain.model.LayoutMode
 import com.mydeck.app.domain.model.SortOption
 import com.mydeck.app.domain.model.SwipeAction
 import com.mydeck.app.domain.model.SwipeConfig
+import com.mydeck.app.ui.collections.CollectionIcon
 import com.mydeck.app.ui.components.FilterBar
 import com.mydeck.app.ui.components.FilterBottomSheet
 import com.mydeck.app.ui.components.ShareBookmarkChooser
@@ -167,6 +168,7 @@ fun BookmarkListScreen(
     val drawerPreset = viewModel.drawerPreset.collectAsState()
     val filterFormState = viewModel.filterFormState.collectAsState()
     val activeLabel = viewModel.activeLabel.collectAsState()
+    val selectedCollection = viewModel.selectedCollection.collectAsState()
     val isFilterSheetOpen = viewModel.isFilterSheetOpen.collectAsState()
     val layoutMode = viewModel.layoutMode.collectAsState()
     val sortOption = viewModel.sortOption.collectAsState()
@@ -202,6 +204,7 @@ fun BookmarkListScreen(
     val syncFraction by viewModel.syncFraction.collectAsState()
 
     val isLabelMode = activeLabel.value != null
+    val isCollectionMode = selectedCollection.value != null
     val isMultiSelectMode = multiSelectState.value.active
     val dismissPendingDeleteSnackbar: () -> Unit = {
         snackbarHostState.currentSnackbarData?.dismiss()
@@ -578,6 +581,23 @@ fun BookmarkListScreen(
                             Spacer(modifier = Modifier.width(8.dp))
                             Text(text = activeLabel.value!!)
                         }
+                    } else if (isCollectionMode) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier.clickable {
+                                dismissPendingDeleteSnackbar()
+                                scrollToTopTrigger++
+                            }
+                        ) {
+                            Icon(
+                                imageVector = CollectionIcon,
+                                contentDescription = null,
+                                modifier = Modifier.size(20.dp),
+                                tint = MaterialTheme.colorScheme.onSurface
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(text = selectedCollection.value!!.name)
+                        }
                     } else {
                         Text(
                             text = currentViewTitle,
@@ -817,8 +837,10 @@ fun BookmarkListScreen(
                     }
                 }
         ) {
-            // FilterBar: visible when filters are active beyond preset defaults, not in label mode
-            if (!isLabelMode && !isMultiSelectMode) {
+            // FilterBar: visible when filters are active beyond preset defaults, not in label mode.
+            // While a collection is active its own criteria are suppressed (the active-collection
+            // view reads as an ordinary list); C3 adds chips for filters layered on top.
+            if (!isLabelMode && !isCollectionMode && !isMultiSelectMode) {
                 FilterBar(
                     filterFormState = filterFormState.value,
                     drawerPreset = drawerPreset.value,

--- a/app/src/main/java/com/mydeck/app/ui/list/BookmarkListScreen.kt
+++ b/app/src/main/java/com/mydeck/app/ui/list/BookmarkListScreen.kt
@@ -125,6 +125,9 @@ import com.mydeck.app.domain.model.LayoutMode
 import com.mydeck.app.domain.model.SortOption
 import com.mydeck.app.domain.model.SwipeAction
 import com.mydeck.app.domain.model.SwipeConfig
+import com.mydeck.app.domain.model.Collection
+import com.mydeck.app.domain.model.FilterFormState
+import com.mydeck.app.ui.collections.CollectionEditorSheet
 import com.mydeck.app.ui.collections.CollectionIcon
 import com.mydeck.app.ui.components.FilterBar
 import com.mydeck.app.ui.components.FilterBottomSheet
@@ -189,6 +192,8 @@ fun BookmarkListScreen(
     var showSelectionOverflowMenu by remember { mutableStateOf(false) }
     var showRenameLabelDialog by remember { mutableStateOf(false) }
     var showDeleteLabelDialog by remember { mutableStateOf(false) }
+    var showCollectionEditor by remember { mutableStateOf(false) }
+    var collectionPendingDelete by remember { mutableStateOf<Collection?>(null) }
     var scrollToTopTrigger by remember { mutableStateOf(0) }
 
     val scope = rememberCoroutineScope()
@@ -777,6 +782,8 @@ fun BookmarkListScreen(
                     } else {
                     BookmarkListBarActions(
                         isLabelMode = isLabelMode,
+                        isCollectionMode = isCollectionMode,
+                        canSaveAsCollection = filterFormState.value.differsFromPreset(drawerPreset.value),
                         layoutMode = layoutMode.value,
                         sortOption = sortOption.value,
                         onLayoutModeSelected = { viewModel.onLayoutModeSelected(it) },
@@ -786,6 +793,9 @@ fun BookmarkListScreen(
                         onEnterMultiSelectMode = { viewModel.onEnterMultiSelectMode() },
                         onRequestRenameLabel = { showRenameLabelDialog = true },
                         onRequestDeleteLabel = { showDeleteLabelDialog = true },
+                        onSaveAsCollection = { showCollectionEditor = true },
+                        onEditCollection = { showCollectionEditor = true },
+                        onRequestDeleteCollection = { collectionPendingDelete = selectedCollection.value },
                     )
                     }
                 }
@@ -837,13 +847,15 @@ fun BookmarkListScreen(
                     }
                 }
         ) {
-            // FilterBar: visible when filters are active beyond preset defaults, not in label mode.
-            // While a collection is active its own criteria are suppressed (the active-collection
-            // view reads as an ordinary list); C3 adds chips for filters layered on top.
-            if (!isLabelMode && !isCollectionMode && !isMultiSelectMode) {
+            // FilterBar: chips for filters that deviate from the baseline (the drawer preset, or the
+            // active collection's own criteria). A collection's own criteria are part of the baseline
+            // so they aren't shown — only filters layered on top of the collection appear as chips.
+            if (!isLabelMode && !isMultiSelectMode) {
+                val filterBaseline = selectedCollection.value?.filter
+                    ?: FilterFormState.fromPreset(drawerPreset.value)
                 FilterBar(
                     filterFormState = filterFormState.value,
-                    drawerPreset = drawerPreset.value,
+                    baseline = filterBaseline,
                     onFilterChanged = { viewModel.onApplyFilter(it) },
                     onOpenFilterSheet = { viewModel.onOpenFilterSheet() }
                 )
@@ -1135,6 +1147,59 @@ fun BookmarkListScreen(
             }
         )
     }
+
+    // Collection editor sheet: edit mode when a collection is active, otherwise "Save as Collection"
+    // from the current list filter. Both pre-fill from the visible filter (the active collection's
+    // combined criteria, or the layered list filter when none is active).
+    if (showCollectionEditor) {
+        val editing = selectedCollection.value
+        CollectionEditorSheet(
+            heading = if (editing != null) {
+                stringResource(R.string.collection_edit_action)
+            } else {
+                stringResource(R.string.collection_save_as_action)
+            },
+            initialName = editing?.name ?: "",
+            initialFilter = filterFormState.value,
+            labels = labelsWithCounts.value,
+            onSave = { name, filter ->
+                showCollectionEditor = false
+                if (editing != null) {
+                    viewModel.onUpdateCollection(editing.id, name, filter)
+                } else {
+                    viewModel.onCreateCollection(name, filter)
+                }
+            },
+            onDelete = if (editing != null) {
+                {
+                    showCollectionEditor = false
+                    collectionPendingDelete = editing
+                }
+            } else null,
+            onDismiss = { showCollectionEditor = false },
+        )
+    }
+
+    collectionPendingDelete?.let { collection ->
+        AlertDialog(
+            onDismissRequest = { collectionPendingDelete = null },
+            title = { Text(stringResource(R.string.collection_delete_confirm_title)) },
+            text = { Text(stringResource(R.string.collection_delete_confirm_message, collection.name)) },
+            confirmButton = {
+                Button(onClick = {
+                    collectionPendingDelete = null
+                    viewModel.onDeleteCollection(collection.id)
+                }) {
+                    Text(stringResource(R.string.collection_delete_action))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { collectionPendingDelete = null }) {
+                    Text(stringResource(R.string.cancel))
+                }
+            }
+        )
+    }
 }
 
 /**
@@ -1145,6 +1210,8 @@ fun BookmarkListScreen(
 @Composable
 internal fun BookmarkListBarActions(
     isLabelMode: Boolean,
+    isCollectionMode: Boolean,
+    canSaveAsCollection: Boolean,
     layoutMode: LayoutMode,
     sortOption: SortOption,
     onLayoutModeSelected: (LayoutMode) -> Unit,
@@ -1154,6 +1221,9 @@ internal fun BookmarkListBarActions(
     onEnterMultiSelectMode: () -> Unit,
     onRequestRenameLabel: () -> Unit,
     onRequestDeleteLabel: () -> Unit,
+    onSaveAsCollection: () -> Unit,
+    onEditCollection: () -> Unit,
+    onRequestDeleteCollection: () -> Unit,
 ) {
     var showLayoutMenu by remember { mutableStateOf(false) }
     var showSortMenu by remember { mutableStateOf(false) }
@@ -1311,6 +1381,36 @@ internal fun BookmarkListBarActions(
                         onOpenFilterSheet()
                     }
                 )
+                if (isCollectionMode) {
+                    DropdownMenuItem(
+                        leadingIcon = { Icon(Icons.Outlined.Edit, contentDescription = null) },
+                        text = { Text(stringResource(R.string.collection_edit_action)) },
+                        onClick = {
+                            showOverflowMenu = false
+                            onDismissPendingDelete()
+                            onEditCollection()
+                        }
+                    )
+                    DropdownMenuItem(
+                        leadingIcon = { Icon(Icons.Outlined.Delete, contentDescription = null) },
+                        text = { Text(stringResource(R.string.collection_delete_action)) },
+                        onClick = {
+                            showOverflowMenu = false
+                            onDismissPendingDelete()
+                            onRequestDeleteCollection()
+                        }
+                    )
+                } else if (canSaveAsCollection) {
+                    DropdownMenuItem(
+                        leadingIcon = { Icon(CollectionIcon, contentDescription = null) },
+                        text = { Text(stringResource(R.string.collection_save_as_action)) },
+                        onClick = {
+                            showOverflowMenu = false
+                            onDismissPendingDelete()
+                            onSaveAsCollection()
+                        }
+                    )
+                }
             }
             DropdownMenuItem(
                 leadingIcon = {

--- a/app/src/main/java/com/mydeck/app/ui/list/BookmarkListScreen.kt
+++ b/app/src/main/java/com/mydeck/app/ui/list/BookmarkListScreen.kt
@@ -193,7 +193,6 @@ fun BookmarkListScreen(
     var showRenameLabelDialog by remember { mutableStateOf(false) }
     var showDeleteLabelDialog by remember { mutableStateOf(false) }
     var showCollectionEditor by remember { mutableStateOf(false) }
-    var collectionPendingDelete by remember { mutableStateOf<Collection?>(null) }
     var scrollToTopTrigger by remember { mutableStateOf(0) }
 
     val scope = rememberCoroutineScope()
@@ -272,6 +271,24 @@ fun BookmarkListScreen(
                 viewModel.onCancelDeleteBookmark(bookmarkId)
             } else {
                 viewModel.onConfirmDeleteBookmark(bookmarkId)
+            }
+        }
+    }
+
+    fun stageCollectionDeleteWithSnackbar(collection: Collection) {
+        // Mirror bookmark delete: stage now (hide + leave the view), defer the actual delete until the
+        // Undo snackbar is dismissed by an interaction other than Undo.
+        viewModel.onStageDeleteCollection(collection.id)
+        scope.launch {
+            val result = snackbarHostState.showSnackbar(
+                message = context.getString(R.string.collection_deleted),
+                actionLabel = undoActionLabel,
+                duration = SnackbarDuration.Indefinite
+            )
+            if (result == androidx.compose.material3.SnackbarResult.ActionPerformed) {
+                viewModel.onCancelDeleteCollection(collection.id)
+            } else {
+                viewModel.onConfirmDeleteCollection(collection.id)
             }
         }
     }
@@ -444,6 +461,16 @@ fun BookmarkListScreen(
     // Constraint feedback snackbar (fires once after app-open sync if content sync is blocked)
     LaunchedEffect(Unit) {
         viewModel.constraintSnackbarEvent.collect { messageRes ->
+            snackbarHostState.showSnackbar(
+                message = context.getString(messageRes),
+                duration = SnackbarDuration.Short
+            )
+        }
+    }
+
+    // Collection create/update/delete/load failures (shared ViewModel; only the foreground screen collects)
+    LaunchedEffect(Unit) {
+        viewModel.collectionMessageEvent.collect { messageRes ->
             snackbarHostState.showSnackbar(
                 message = context.getString(messageRes),
                 duration = SnackbarDuration.Short
@@ -795,7 +822,9 @@ fun BookmarkListScreen(
                         onRequestDeleteLabel = { showDeleteLabelDialog = true },
                         onSaveAsCollection = { showCollectionEditor = true },
                         onEditCollection = { showCollectionEditor = true },
-                        onRequestDeleteCollection = { collectionPendingDelete = selectedCollection.value },
+                        onRequestDeleteCollection = {
+                            selectedCollection.value?.let { stageCollectionDeleteWithSnackbar(it) }
+                        },
                     )
                     }
                 }
@@ -1173,31 +1202,10 @@ fun BookmarkListScreen(
             onDelete = if (editing != null) {
                 {
                     showCollectionEditor = false
-                    collectionPendingDelete = editing
+                    stageCollectionDeleteWithSnackbar(editing)
                 }
             } else null,
             onDismiss = { showCollectionEditor = false },
-        )
-    }
-
-    collectionPendingDelete?.let { collection ->
-        AlertDialog(
-            onDismissRequest = { collectionPendingDelete = null },
-            title = { Text(stringResource(R.string.collection_delete_confirm_title)) },
-            text = { Text(stringResource(R.string.collection_delete_confirm_message, collection.name)) },
-            confirmButton = {
-                Button(onClick = {
-                    collectionPendingDelete = null
-                    viewModel.onDeleteCollection(collection.id)
-                }) {
-                    Text(stringResource(R.string.collection_delete_action))
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = { collectionPendingDelete = null }) {
-                    Text(stringResource(R.string.cancel))
-                }
-            }
         )
     }
 }

--- a/app/src/main/java/com/mydeck/app/ui/list/BookmarkListViewModel.kt
+++ b/app/src/main/java/com/mydeck/app/ui/list/BookmarkListViewModel.kt
@@ -258,6 +258,11 @@ class BookmarkListViewModel @Inject constructor(
         .observeCollections()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
+    /** The currently-active collection (its full model), or null when none is selected. */
+    val selectedCollection: StateFlow<Collection?> = combine(collections, _selectedCollectionId) { list, id ->
+        id?.let { selectedId -> list.find { it.id == selectedId } }
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+
     private val _isFilterSheetOpen = MutableStateFlow(false)
     val isFilterSheetOpen = _isFilterSheetOpen.asStateFlow()
 
@@ -469,6 +474,9 @@ class BookmarkListViewModel @Inject constructor(
 
     fun onClearCollection() {
         _selectedCollectionId.value = null
+        // Drop the collection's criteria too so the list returns to its preset default rather than
+        // staying silently filtered by the (now inactive) collection.
+        _filterFormState.value = FilterFormState.fromPreset(_drawerPreset.value)
     }
 
     fun refreshCollections() {
@@ -480,6 +488,25 @@ class BookmarkListViewModel @Inject constructor(
             collectionRepository.createCollection(name, _filterFormState.value)
                 .onSuccess { collection -> _selectedCollectionId.value = collection.id }
                 .onFailure { Timber.e(it, "Failed to save collection") }
+        }
+    }
+
+    /**
+     * Creates a collection from an explicit [filter] (the editor sheet's working copy) and, on
+     * success, makes it the active view: selects it, applies its filter, and emits
+     * [NavigationEvent.NavigateToBookmarkList] so callers on other screens land on the active list.
+     */
+    fun onCreateCollection(name: String, filter: FilterFormState) {
+        viewModelScope.launch {
+            collectionRepository.createCollection(name, filter)
+                .onSuccess { collection ->
+                    clearMultiSelectState()
+                    _selectedCollectionId.value = collection.id
+                    _filterFormState.value = collection.filter
+                    _activeLabel.value = null
+                    _navigationEvent.trySend(NavigationEvent.NavigateToBookmarkList)
+                }
+                .onFailure { Timber.e(it, "Failed to create collection") }
         }
     }
 
@@ -503,6 +530,9 @@ class BookmarkListViewModel @Inject constructor(
 
     fun onClickLabel(label: String) {
         clearMultiSelectState()
+        // Label and collection views are mutually exclusive (a preset/collection select clears the
+        // label; selecting a label clears any active collection).
+        _selectedCollectionId.value = null
         if (_activeLabel.value == label) {
             // Toggle off label mode, return to previous drawer preset
             _activeLabel.value = null
@@ -1290,6 +1320,7 @@ class BookmarkListViewModel @Inject constructor(
         data object NavigateToSettings : NavigationEvent()
         data object NavigateToAbout : NavigationEvent()
         data object NavigateToUserGuide : NavigationEvent()
+        data object NavigateToBookmarkList : NavigationEvent()
         data class NavigateToBookmarkDetail(val bookmarkId: String, val showOriginal: Boolean = false) : NavigationEvent()
     }
 

--- a/app/src/main/java/com/mydeck/app/ui/list/BookmarkListViewModel.kt
+++ b/app/src/main/java/com/mydeck/app/ui/list/BookmarkListViewModel.kt
@@ -20,6 +20,8 @@ import com.mydeck.app.domain.model.BookmarkCounts
 import com.mydeck.app.domain.model.BookmarkListItem
 import com.mydeck.app.domain.model.DrawerPreset
 import com.mydeck.app.domain.model.OpenWebPagesIn
+import com.mydeck.app.domain.CollectionRepository
+import com.mydeck.app.domain.model.Collection
 import com.mydeck.app.domain.model.FilterFormState
 import com.mydeck.app.domain.model.LayoutMode
 import com.mydeck.app.domain.model.SortOption
@@ -131,6 +133,7 @@ class BookmarkListViewModel @Inject constructor(
     private val contentSyncPolicyEvaluator: OfflinePolicyEvaluator,
     private val contentPackageManager: ContentPackageManager,
     private val syncScheduler: com.mydeck.app.domain.sync.SyncScheduler,
+    private val collectionRepository: CollectionRepository,
     connectivityMonitor: ConnectivityMonitor
 ) : ViewModel() {
 
@@ -245,6 +248,15 @@ class BookmarkListViewModel @Inject constructor(
 
     private val _activeLabel = MutableStateFlow<String?>(null)
     val activeLabel = _activeLabel.asStateFlow()
+
+    // --- Collections ---
+
+    private val _selectedCollectionId = MutableStateFlow<String?>(null)
+    val selectedCollectionId: StateFlow<String?> = _selectedCollectionId.asStateFlow()
+
+    val collections: StateFlow<List<Collection>> = collectionRepository
+        .observeCollections()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     private val _isFilterSheetOpen = MutableStateFlow(false)
     val isFilterSheetOpen = _isFilterSheetOpen.asStateFlow()
@@ -435,6 +447,7 @@ class BookmarkListViewModel @Inject constructor(
         _drawerPreset.value = preset
         _filterFormState.value = FilterFormState.fromPreset(preset)
         _activeLabel.value = null
+        _selectedCollectionId.value = null
     }
 
     fun onClickMyList() = onSelectDrawerPreset(DrawerPreset.MY_LIST)
@@ -443,6 +456,48 @@ class BookmarkListViewModel @Inject constructor(
     fun onClickArticles() = onSelectDrawerPreset(DrawerPreset.ARTICLES)
     fun onClickVideos() = onSelectDrawerPreset(DrawerPreset.VIDEOS)
     fun onClickPictures() = onSelectDrawerPreset(DrawerPreset.PICTURES)
+
+    // --- Collections actions ---
+
+    fun onSelectCollection(collectionId: String) {
+        val collection = collections.value.find { it.id == collectionId } ?: return
+        clearMultiSelectState()
+        _selectedCollectionId.value = collectionId
+        _filterFormState.value = collection.filter
+        _activeLabel.value = null
+    }
+
+    fun onClearCollection() {
+        _selectedCollectionId.value = null
+    }
+
+    fun refreshCollections() {
+        viewModelScope.launch { collectionRepository.refreshCollections() }
+    }
+
+    fun onSaveCurrentFilterAsCollection(name: String) {
+        viewModelScope.launch {
+            collectionRepository.createCollection(name, _filterFormState.value)
+                .onSuccess { collection -> _selectedCollectionId.value = collection.id }
+                .onFailure { Timber.e(it, "Failed to save collection") }
+        }
+    }
+
+    fun onUpdateActiveCollection(newName: String) {
+        val id = _selectedCollectionId.value ?: return
+        viewModelScope.launch {
+            collectionRepository.updateCollection(id, newName, _filterFormState.value)
+                .onFailure { Timber.e(it, "Failed to update collection") }
+        }
+    }
+
+    fun onDeleteCollection(id: String) {
+        viewModelScope.launch {
+            collectionRepository.deleteCollection(id)
+                .onSuccess { if (_selectedCollectionId.value == id) onClearCollection() }
+                .onFailure { Timber.e(it, "Failed to delete collection") }
+        }
+    }
 
     // --- Label mode ---
 

--- a/app/src/main/java/com/mydeck/app/ui/list/BookmarkListViewModel.kt
+++ b/app/src/main/java/com/mydeck/app/ui/list/BookmarkListViewModel.kt
@@ -22,6 +22,7 @@ import com.mydeck.app.domain.model.DrawerPreset
 import com.mydeck.app.domain.model.OpenWebPagesIn
 import com.mydeck.app.domain.CollectionRepository
 import com.mydeck.app.domain.model.Collection
+import com.mydeck.app.domain.model.CollectionSortOption
 import com.mydeck.app.domain.model.FilterFormState
 import com.mydeck.app.domain.model.LayoutMode
 import com.mydeck.app.domain.model.SortOption
@@ -266,9 +267,17 @@ class BookmarkListViewModel @Inject constructor(
     /** A collection staged for deletion (snackbar shown, actual delete deferred); hidden from lists. */
     private val _pendingCollectionDeleteId = MutableStateFlow<String?>(null)
 
-    /** Collections to show in the Collections screen, excluding any staged-for-deletion entry. */
-    val visibleCollections: StateFlow<List<Collection>> = combine(collections, _pendingCollectionDeleteId) { list, pendingId ->
-        if (pendingId == null) list else list.filterNot { it.id == pendingId }
+    private val _collectionSortOption = MutableStateFlow(CollectionSortOption.DATE_NEWEST)
+    val collectionSortOption: StateFlow<CollectionSortOption> = _collectionSortOption.asStateFlow()
+
+    fun onCollectionSortSelected(option: CollectionSortOption) {
+        _collectionSortOption.value = option
+    }
+
+    /** Collections to show in the Collections screen, excluding any staged-for-deletion entry, sorted per user preference. */
+    val visibleCollections: StateFlow<List<Collection>> = combine(collections, _pendingCollectionDeleteId, _collectionSortOption) { list, pendingId, sortOption ->
+        val filtered = if (pendingId == null) list else list.filterNot { it.id == pendingId }
+        filtered.sortedWith(sortOption.comparator)
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     /** The currently-active collection (its full model), or null when none is selected. */

--- a/app/src/main/java/com/mydeck/app/ui/list/BookmarkListViewModel.kt
+++ b/app/src/main/java/com/mydeck/app/ui/list/BookmarkListViewModel.kt
@@ -483,14 +483,6 @@ class BookmarkListViewModel @Inject constructor(
         viewModelScope.launch { collectionRepository.refreshCollections() }
     }
 
-    fun onSaveCurrentFilterAsCollection(name: String) {
-        viewModelScope.launch {
-            collectionRepository.createCollection(name, _filterFormState.value)
-                .onSuccess { collection -> _selectedCollectionId.value = collection.id }
-                .onFailure { Timber.e(it, "Failed to save collection") }
-        }
-    }
-
     /**
      * Creates a collection from an explicit [filter] (the editor sheet's working copy) and, on
      * success, makes it the active view: selects it, applies its filter, and emits
@@ -510,10 +502,20 @@ class BookmarkListViewModel @Inject constructor(
         }
     }
 
-    fun onUpdateActiveCollection(newName: String) {
-        val id = _selectedCollectionId.value ?: return
+    /**
+     * Updates an existing collection's name and/or criteria from an explicit [filter] (the editor
+     * sheet's working copy — the collection's saved criteria plus any layered filter). Rename is
+     * supported via [name]. When the edited collection is the active view, its applied filter is
+     * refreshed to the saved (round-tripped) result so the list reflects what was persisted.
+     */
+    fun onUpdateCollection(id: String, name: String, filter: FilterFormState) {
         viewModelScope.launch {
-            collectionRepository.updateCollection(id, newName, _filterFormState.value)
+            collectionRepository.updateCollection(id, name, filter)
+                .onSuccess { collection ->
+                    if (_selectedCollectionId.value == id) {
+                        _filterFormState.value = collection.filter
+                    }
+                }
                 .onFailure { Timber.e(it, "Failed to update collection") }
         }
     }
@@ -596,7 +598,10 @@ class BookmarkListViewModel @Inject constructor(
 
     fun onResetFilter() {
         clearMultiSelectState()
-        _filterFormState.value = FilterFormState.fromPreset(_drawerPreset.value)
+        // While a collection is active, "reset" restores the collection's own criteria (clearing any
+        // layered filter); otherwise it restores the drawer preset's defaults.
+        _filterFormState.value = selectedCollection.value?.filter
+            ?: FilterFormState.fromPreset(_drawerPreset.value)
         _isFilterSheetOpen.value = false
     }
 

--- a/app/src/main/java/com/mydeck/app/ui/list/BookmarkListViewModel.kt
+++ b/app/src/main/java/com/mydeck/app/ui/list/BookmarkListViewModel.kt
@@ -153,6 +153,11 @@ class BookmarkListViewModel @Inject constructor(
 
     private val _openUrlEvent = Channel<String>(Channel.BUFFERED)
     val openUrlEvent = _openUrlEvent.receiveAsFlow()
+
+    // One-shot user-facing messages for collection create/update/delete/load failures (string res).
+    // Collected by whichever Collections-related screen is foreground (they share this ViewModel).
+    private val _collectionMessageEvent = Channel<Int>(Channel.BUFFERED)
+    val collectionMessageEvent: Flow<Int> = _collectionMessageEvent.receiveAsFlow()
     private val _createBookmarkUiState = MutableStateFlow<CreateBookmarkUiState>(CreateBookmarkUiState.Closed)
     val createBookmarkUiState = _createBookmarkUiState.asStateFlow()
 
@@ -257,6 +262,14 @@ class BookmarkListViewModel @Inject constructor(
     val collections: StateFlow<List<Collection>> = collectionRepository
         .observeCollections()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    /** A collection staged for deletion (snackbar shown, actual delete deferred); hidden from lists. */
+    private val _pendingCollectionDeleteId = MutableStateFlow<String?>(null)
+
+    /** Collections to show in the Collections screen, excluding any staged-for-deletion entry. */
+    val visibleCollections: StateFlow<List<Collection>> = combine(collections, _pendingCollectionDeleteId) { list, pendingId ->
+        if (pendingId == null) list else list.filterNot { it.id == pendingId }
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     /** The currently-active collection (its full model), or null when none is selected. */
     val selectedCollection: StateFlow<Collection?> = combine(collections, _selectedCollectionId) { list, id ->
@@ -480,7 +493,10 @@ class BookmarkListViewModel @Inject constructor(
     }
 
     fun refreshCollections() {
-        viewModelScope.launch { collectionRepository.refreshCollections() }
+        viewModelScope.launch {
+            collectionRepository.refreshCollections()
+                .onFailure { _collectionMessageEvent.trySend(R.string.collection_load_error) }
+        }
     }
 
     /**
@@ -498,7 +514,10 @@ class BookmarkListViewModel @Inject constructor(
                     _activeLabel.value = null
                     _navigationEvent.trySend(NavigationEvent.NavigateToBookmarkList)
                 }
-                .onFailure { Timber.e(it, "Failed to create collection") }
+                .onFailure {
+                    Timber.e(it, "Failed to create collection")
+                    _collectionMessageEvent.trySend(R.string.collection_save_error)
+                }
         }
     }
 
@@ -516,15 +535,42 @@ class BookmarkListViewModel @Inject constructor(
                         _filterFormState.value = collection.filter
                     }
                 }
-                .onFailure { Timber.e(it, "Failed to update collection") }
+                .onFailure {
+                    Timber.e(it, "Failed to update collection")
+                    _collectionMessageEvent.trySend(R.string.collection_update_error)
+                }
         }
     }
 
-    fun onDeleteCollection(id: String) {
+    /**
+     * Stages a collection for deletion: it's hidden from the lists and the active view leaves it, but
+     * the actual server delete is deferred until [onConfirmDeleteCollection] (mirrors bookmark delete,
+     * which holds until the Undo snackbar is dismissed). [onCancelDeleteCollection] restores it.
+     */
+    fun onStageDeleteCollection(id: String) {
+        _pendingCollectionDeleteId.value = id
+        if (_selectedCollectionId.value == id) onClearCollection()
+    }
+
+    /** Undo: un-stage the collection and restore it as the active view. */
+    fun onCancelDeleteCollection(id: String) {
+        if (_pendingCollectionDeleteId.value == id) {
+            _pendingCollectionDeleteId.value = null
+            onSelectCollection(id)
+        }
+    }
+
+    /** Commit the staged deletion (server DELETE + cache removal). On failure it reappears. */
+    fun onConfirmDeleteCollection(id: String) {
+        if (_pendingCollectionDeleteId.value != id) return
         viewModelScope.launch {
             collectionRepository.deleteCollection(id)
-                .onSuccess { if (_selectedCollectionId.value == id) onClearCollection() }
-                .onFailure { Timber.e(it, "Failed to delete collection") }
+                .onSuccess { _pendingCollectionDeleteId.value = null }
+                .onFailure {
+                    Timber.e(it, "Failed to delete collection")
+                    _pendingCollectionDeleteId.value = null
+                    _collectionMessageEvent.trySend(R.string.collection_delete_error)
+                }
         }
     }
 

--- a/app/src/main/java/com/mydeck/app/ui/navigation/Routes.kt
+++ b/app/src/main/java/com/mydeck/app/ui/navigation/Routes.kt
@@ -16,6 +16,9 @@ data class BookmarkDetailRoute(
 object HighlightsRoute
 
 @Serializable
+object CollectionsRoute
+
+@Serializable
 object WelcomeRoute
 
 @Serializable

--- a/app/src/main/java/com/mydeck/app/ui/shell/AppDrawerContent.kt
+++ b/app/src/main/java/com/mydeck/app/ui/shell/AppDrawerContent.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.unit.dp
 import com.mydeck.app.R
 import com.mydeck.app.domain.model.BookmarkCounts
 import com.mydeck.app.domain.model.DrawerPreset
+import com.mydeck.app.ui.collections.CollectionIcon
 
 @Composable
 fun AppDrawerContent(
@@ -57,9 +58,11 @@ fun AppDrawerContent(
     onClickPictures: () -> Unit,
     onClickLabels: () -> Unit,
     onClickHighlights: () -> Unit,
+    onClickCollections: () -> Unit,
     onClickSettings: () -> Unit,
     onClickUserGuide: () -> Unit,
     onClickAbout: () -> Unit,
+    isCollectionsScreen: Boolean = false,
     usePermanentSheet: Boolean = false,
 ) {
     val isLabelMode = activeLabel != null
@@ -81,6 +84,8 @@ fun AppDrawerContent(
                 onClickPictures = onClickPictures,
                 onClickLabels = onClickLabels,
                 onClickHighlights = onClickHighlights,
+                onClickCollections = onClickCollections,
+                isCollectionsScreen = isCollectionsScreen,
                 onClickSettings = onClickSettings,
                 onClickUserGuide = onClickUserGuide,
                 onClickAbout = onClickAbout,
@@ -105,6 +110,8 @@ fun AppDrawerContent(
                 onClickPictures = onClickPictures,
                 onClickLabels = onClickLabels,
                 onClickHighlights = onClickHighlights,
+                onClickCollections = onClickCollections,
+                isCollectionsScreen = isCollectionsScreen,
                 onClickSettings = onClickSettings,
                 onClickUserGuide = onClickUserGuide,
                 onClickAbout = onClickAbout,
@@ -129,6 +136,8 @@ private fun DrawerColumnContent(
     onClickPictures: () -> Unit,
     onClickLabels: () -> Unit,
     onClickHighlights: () -> Unit,
+    onClickCollections: () -> Unit,
+    isCollectionsScreen: Boolean,
     onClickSettings: () -> Unit,
     onClickUserGuide: () -> Unit,
     onClickAbout: () -> Unit,
@@ -355,6 +364,18 @@ private fun DrawerColumnContent(
             selected = drawerPreset == com.mydeck.app.domain.model.DrawerPreset.HIGHLIGHTS,
             colors = prominentItemColors,
             onClick = onClickHighlights,
+        )
+        NavigationDrawerItem(
+            label = {
+                Text(
+                    style = MaterialTheme.typography.titleMedium,
+                    text = stringResource(R.string.collections_drawer_item)
+                )
+            },
+            icon = { Icon(CollectionIcon, contentDescription = null) },
+            selected = isCollectionsScreen,
+            colors = prominentItemColors,
+            onClick = onClickCollections,
         )
         HorizontalDivider(
             modifier = Modifier.padding(vertical = 4.dp).fillMaxWidth(),

--- a/app/src/main/java/com/mydeck/app/ui/shell/AppDrawerContent.kt
+++ b/app/src/main/java/com/mydeck/app/ui/shell/AppDrawerContent.kt
@@ -63,6 +63,7 @@ fun AppDrawerContent(
     onClickUserGuide: () -> Unit,
     onClickAbout: () -> Unit,
     isCollectionsScreen: Boolean = false,
+    collectionCount: Int = 0,
     usePermanentSheet: Boolean = false,
 ) {
     val isLabelMode = activeLabel != null
@@ -86,6 +87,7 @@ fun AppDrawerContent(
                 onClickHighlights = onClickHighlights,
                 onClickCollections = onClickCollections,
                 isCollectionsScreen = isCollectionsScreen,
+                collectionCount = collectionCount,
                 onClickSettings = onClickSettings,
                 onClickUserGuide = onClickUserGuide,
                 onClickAbout = onClickAbout,
@@ -112,6 +114,7 @@ fun AppDrawerContent(
                 onClickHighlights = onClickHighlights,
                 onClickCollections = onClickCollections,
                 isCollectionsScreen = isCollectionsScreen,
+                collectionCount = collectionCount,
                 onClickSettings = onClickSettings,
                 onClickUserGuide = onClickUserGuide,
                 onClickAbout = onClickAbout,
@@ -138,6 +141,7 @@ private fun DrawerColumnContent(
     onClickHighlights: () -> Unit,
     onClickCollections: () -> Unit,
     isCollectionsScreen: Boolean,
+    collectionCount: Int = 0,
     onClickSettings: () -> Unit,
     onClickUserGuide: () -> Unit,
     onClickAbout: () -> Unit,
@@ -373,6 +377,13 @@ private fun DrawerColumnContent(
                 )
             },
             icon = { Icon(CollectionIcon, contentDescription = null) },
+            badge = {
+                if (collectionCount > 0) {
+                    Badge(containerColor = MaterialTheme.colorScheme.secondaryContainer) {
+                        Text(text = collectionCount.toString())
+                    }
+                }
+            },
             selected = isCollectionsScreen,
             colors = prominentItemColors,
             onClick = onClickCollections,

--- a/app/src/main/java/com/mydeck/app/ui/shell/AppNavigationRailContent.kt
+++ b/app/src/main/java/com/mydeck/app/ui/shell/AppNavigationRailContent.kt
@@ -37,6 +37,7 @@ fun AppNavigationRailContent(
     onClickHighlights: () -> Unit,
     onClickCollections: () -> Unit,
     isCollectionsScreen: Boolean = false,
+    collectionCount: Int = 0,
     onClickSettings: () -> Unit,
     onClickUserGuide: () -> Unit,
     onClickAbout: () -> Unit,

--- a/app/src/main/java/com/mydeck/app/ui/shell/AppNavigationRailContent.kt
+++ b/app/src/main/java/com/mydeck/app/ui/shell/AppNavigationRailContent.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.mydeck.app.domain.model.BookmarkCounts
 import com.mydeck.app.domain.model.DrawerPreset
+import com.mydeck.app.ui.collections.CollectionIcon
 
 @Composable
 fun AppNavigationRailContent(
@@ -34,6 +35,8 @@ fun AppNavigationRailContent(
     onClickPictures: () -> Unit,
     onClickLabels: () -> Unit,
     onClickHighlights: () -> Unit,
+    onClickCollections: () -> Unit,
+    isCollectionsScreen: Boolean = false,
     onClickSettings: () -> Unit,
     onClickUserGuide: () -> Unit,
     onClickAbout: () -> Unit,
@@ -80,6 +83,11 @@ fun AppNavigationRailContent(
             selected = !isLabelMode && drawerPreset == DrawerPreset.HIGHLIGHTS,
             onClick = onClickHighlights,
             icon = { Icon(imageVector = Icons.Outlined.EditNote, contentDescription = null) },
+        )
+        NavigationRailItem(
+            selected = isCollectionsScreen,
+            onClick = onClickCollections,
+            icon = { Icon(imageVector = CollectionIcon, contentDescription = null) },
         )
         Spacer(Modifier.weight(1f))
         NavigationRailItem(

--- a/app/src/main/java/com/mydeck/app/ui/shell/AppShell.kt
+++ b/app/src/main/java/com/mydeck/app/ui/shell/AppShell.kt
@@ -96,6 +96,7 @@ fun AppShell(
     val activeLabel = bookmarkListViewModel.activeLabel.collectAsState()
     val bookmarkCounts = bookmarkListViewModel.bookmarkCounts.collectAsState()
     val labelsWithCounts = bookmarkListViewModel.labelsWithCounts.collectAsState()
+    val collectionCount = bookmarkListViewModel.visibleCollections.collectAsState()
     val isOnline = bookmarkListViewModel.isOnline.collectAsState()
 
     val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
@@ -141,6 +142,7 @@ fun AppShell(
             labelsWithCounts = labelsWithCounts.value,
             isOnline = isOnline.value,
             isCollectionsScreen = isCollectionsScreen,
+            collectionCount = collectionCount.value.size,
         )
         } // end CompactAppShell CompositionLocalProvider
         "expanded" -> CompositionLocalProvider(LocalReaderMaxWidth provides Dimens.ReaderMaxWidthExpanded) {
@@ -155,6 +157,7 @@ fun AppShell(
             isOnline = isOnline.value,
             hideNavigation = hideNavigation,
             isCollectionsScreen = isCollectionsScreen,
+            collectionCount = collectionCount.value.size,
         )
         } // end ExpandedAppShell CompositionLocalProvider
         else -> CompositionLocalProvider(LocalReaderMaxWidth provides Dimens.ReaderMaxWidthMedium) {
@@ -167,6 +170,7 @@ fun AppShell(
             bookmarkCounts = bookmarkCounts.value,
             hideNavigation = hideNavigation,
             isCollectionsScreen = isCollectionsScreen,
+            collectionCount = collectionCount.value.size,
         )
         } // end MediumAppShell CompositionLocalProvider
     }
@@ -184,6 +188,7 @@ private fun CompactAppShell(
     labelsWithCounts: Map<String, Int>,
     isOnline: Boolean,
     isCollectionsScreen: Boolean,
+    collectionCount: Int,
 ) {
     val drawerState = rememberDrawerState(DrawerValue.Closed)
     val scope = rememberCoroutineScope()
@@ -292,6 +297,7 @@ private fun CompactAppShell(
                     scope.launch { drawerState.close() }
                 },
                 isCollectionsScreen = isCollectionsScreen,
+                collectionCount = collectionCount,
             )
         }
     ) {
@@ -408,6 +414,7 @@ private fun MediumAppShell(
     bookmarkCounts: com.mydeck.app.domain.model.BookmarkCounts,
     hideNavigation: Boolean,
     isCollectionsScreen: Boolean,
+    collectionCount: Int,
 ) {
     LaunchedEffect(Unit) {
         bookmarkListViewModel.navigationEvent.collectLatest { event ->
@@ -483,6 +490,7 @@ private fun MediumAppShell(
                     onClickHighlights = { navController.navigate(HighlightsRoute) { launchSingleTop = true } },
                     onClickCollections = { navController.navigate(CollectionsRoute) { launchSingleTop = true } },
                     isCollectionsScreen = isCollectionsScreen,
+                    collectionCount = collectionCount,
                     onClickSettings = { bookmarkListViewModel.onClickSettings() },
                     onClickUserGuide = { bookmarkListViewModel.onClickUserGuide() },
                     onClickAbout = { bookmarkListViewModel.onClickAbout() },
@@ -630,6 +638,7 @@ private fun ExpandedAppShell(
     isOnline: Boolean,
     hideNavigation: Boolean,
     isCollectionsScreen: Boolean,
+    collectionCount: Int,
 ) {
     LaunchedEffect(Unit) {
         bookmarkListViewModel.navigationEvent.collectLatest { event ->
@@ -705,6 +714,7 @@ private fun ExpandedAppShell(
                 onClickUserGuide = { bookmarkListViewModel.onClickUserGuide() },
                 onClickAbout = { bookmarkListViewModel.onClickAbout() },
                 isCollectionsScreen = isCollectionsScreen,
+                collectionCount = collectionCount,
             )
         }
 

--- a/app/src/main/java/com/mydeck/app/ui/shell/AppShell.kt
+++ b/app/src/main/java/com/mydeck/app/ui/shell/AppShell.kt
@@ -55,6 +55,7 @@ import com.mydeck.app.ui.navigation.AboutRoute
 import com.mydeck.app.ui.navigation.AccountSettingsRoute
 import com.mydeck.app.ui.navigation.BookmarkDetailRoute
 import com.mydeck.app.ui.navigation.BookmarkListRoute
+import com.mydeck.app.ui.navigation.CollectionsRoute
 import com.mydeck.app.ui.navigation.HighlightsRoute
 import com.mydeck.app.ui.navigation.LogViewRoute
 import com.mydeck.app.ui.navigation.OpenSourceLibrariesRoute
@@ -64,6 +65,7 @@ import com.mydeck.app.ui.navigation.UiSettingsRoute
 import com.mydeck.app.ui.navigation.UserGuideRoute
 import com.mydeck.app.ui.navigation.UserGuideSectionRoute
 import com.mydeck.app.ui.navigation.WelcomeRoute
+import com.mydeck.app.ui.collections.CollectionsScreen
 import com.mydeck.app.ui.highlights.HighlightsScreen
 import com.mydeck.app.ui.settings.AccountSettingsScreen
 import com.mydeck.app.ui.settings.LogViewScreen
@@ -122,6 +124,8 @@ fun AppShell(
         drawerPreset.value
     }
 
+    val isCollectionsScreen = currentDestination.matchesRoute<CollectionsRoute>()
+
     when (layoutTier) {
         "compact" -> CompositionLocalProvider(
             LocalReaderMaxWidth provides Dp.Unspecified,
@@ -136,6 +140,7 @@ fun AppShell(
             bookmarkCounts = bookmarkCounts.value,
             labelsWithCounts = labelsWithCounts.value,
             isOnline = isOnline.value,
+            isCollectionsScreen = isCollectionsScreen,
         )
         } // end CompactAppShell CompositionLocalProvider
         "expanded" -> CompositionLocalProvider(LocalReaderMaxWidth provides Dimens.ReaderMaxWidthExpanded) {
@@ -149,6 +154,7 @@ fun AppShell(
             labelsWithCounts = labelsWithCounts.value,
             isOnline = isOnline.value,
             hideNavigation = hideNavigation,
+            isCollectionsScreen = isCollectionsScreen,
         )
         } // end ExpandedAppShell CompositionLocalProvider
         else -> CompositionLocalProvider(LocalReaderMaxWidth provides Dimens.ReaderMaxWidthMedium) {
@@ -160,6 +166,7 @@ fun AppShell(
             activeLabel = activeLabel.value,
             bookmarkCounts = bookmarkCounts.value,
             hideNavigation = hideNavigation,
+            isCollectionsScreen = isCollectionsScreen,
         )
         } // end MediumAppShell CompositionLocalProvider
     }
@@ -176,6 +183,7 @@ private fun CompactAppShell(
     bookmarkCounts: com.mydeck.app.domain.model.BookmarkCounts,
     labelsWithCounts: Map<String, Int>,
     isOnline: Boolean,
+    isCollectionsScreen: Boolean,
 ) {
     val drawerState = rememberDrawerState(DrawerValue.Closed)
     val scope = rememberCoroutineScope()
@@ -198,6 +206,13 @@ private fun CompactAppShell(
                 is BookmarkListViewModel.NavigationEvent.NavigateToAbout -> {
                     navController.navigate(AboutRoute) { launchSingleTop = true }
                     scope.launch { drawerState.close() }
+                }
+
+                is BookmarkListViewModel.NavigationEvent.NavigateToBookmarkList -> {
+                    navController.navigate(BookmarkListRoute()) {
+                        popUpTo(BookmarkListRoute()) { inclusive = true }
+                        launchSingleTop = true
+                    }
                 }
 
                 is BookmarkListViewModel.NavigationEvent.NavigateToBookmarkDetail -> {
@@ -260,6 +275,10 @@ private fun CompactAppShell(
                     navController.navigate(HighlightsRoute) { launchSingleTop = true }
                     scope.launch { drawerState.close() }
                 },
+                onClickCollections = {
+                    navController.navigate(CollectionsRoute) { launchSingleTop = true }
+                    scope.launch { drawerState.close() }
+                },
                 onClickSettings = {
                     bookmarkListViewModel.onClickSettings()
                     scope.launch { drawerState.close() }
@@ -272,6 +291,7 @@ private fun CompactAppShell(
                     bookmarkListViewModel.onClickAbout()
                     scope.launch { drawerState.close() }
                 },
+                isCollectionsScreen = isCollectionsScreen,
             )
         }
     ) {
@@ -310,6 +330,9 @@ private fun CompactAppShell(
                 }
                 composable<HighlightsRoute> {
                     HighlightsScreen(navController)
+                }
+                composable<CollectionsRoute> {
+                    CollectionsScreen(navController, bookmarkListViewModel)
                 }
                 composable<SettingsRoute> { SettingsScreen(navController) }
                 composable<WelcomeRoute> { WelcomeScreen(navController) }
@@ -384,6 +407,7 @@ private fun MediumAppShell(
     activeLabel: String?,
     bookmarkCounts: com.mydeck.app.domain.model.BookmarkCounts,
     hideNavigation: Boolean,
+    isCollectionsScreen: Boolean,
 ) {
     LaunchedEffect(Unit) {
         bookmarkListViewModel.navigationEvent.collectLatest { event ->
@@ -398,6 +422,13 @@ private fun MediumAppShell(
 
                 is BookmarkListViewModel.NavigationEvent.NavigateToAbout -> {
                     navController.navigate(AboutRoute) { launchSingleTop = true }
+                }
+
+                is BookmarkListViewModel.NavigationEvent.NavigateToBookmarkList -> {
+                    navController.navigate(BookmarkListRoute()) {
+                        popUpTo(BookmarkListRoute()) { inclusive = true }
+                        launchSingleTop = true
+                    }
                 }
 
                 is BookmarkListViewModel.NavigationEvent.NavigateToBookmarkDetail -> {
@@ -450,6 +481,8 @@ private fun MediumAppShell(
                     onClickPictures = { navigateToListAndApply { bookmarkListViewModel.onClickPictures() } },
                     onClickLabels = { navigateToListAndApply { bookmarkListViewModel.onOpenLabelsSheet() } },
                     onClickHighlights = { navController.navigate(HighlightsRoute) { launchSingleTop = true } },
+                    onClickCollections = { navController.navigate(CollectionsRoute) { launchSingleTop = true } },
+                    isCollectionsScreen = isCollectionsScreen,
                     onClickSettings = { bookmarkListViewModel.onClickSettings() },
                     onClickUserGuide = { bookmarkListViewModel.onClickUserGuide() },
                     onClickAbout = { bookmarkListViewModel.onClickAbout() },
@@ -518,6 +551,9 @@ private fun AppShellNavHost(
             }
             composable<HighlightsRoute> {
                 HighlightsScreen(navController, showBackButton = false)
+            }
+            composable<CollectionsRoute> {
+                CollectionsScreen(navController, bookmarkListViewModel, showBackButton = false)
             }
             composable<SettingsRoute> { SettingsScreen(navController, showBackButton = false) }
             composable<WelcomeRoute> { WelcomeScreen(navController) }
@@ -593,6 +629,7 @@ private fun ExpandedAppShell(
     labelsWithCounts: Map<String, Int>,
     isOnline: Boolean,
     hideNavigation: Boolean,
+    isCollectionsScreen: Boolean,
 ) {
     LaunchedEffect(Unit) {
         bookmarkListViewModel.navigationEvent.collectLatest { event ->
@@ -607,6 +644,13 @@ private fun ExpandedAppShell(
 
                 is BookmarkListViewModel.NavigationEvent.NavigateToAbout -> {
                     navController.navigate(AboutRoute) { launchSingleTop = true }
+                }
+
+                is BookmarkListViewModel.NavigationEvent.NavigateToBookmarkList -> {
+                    navController.navigate(BookmarkListRoute()) {
+                        popUpTo(BookmarkListRoute()) { inclusive = true }
+                        launchSingleTop = true
+                    }
                 }
 
                 is BookmarkListViewModel.NavigationEvent.NavigateToBookmarkDetail -> {
@@ -656,9 +700,11 @@ private fun ExpandedAppShell(
                 onClickPictures = { navigateToListAndApply { bookmarkListViewModel.onClickPictures() } },
                 onClickLabels = { navigateToListAndApply { bookmarkListViewModel.onOpenLabelsSheet() } },
                 onClickHighlights = { navController.navigate(HighlightsRoute) { launchSingleTop = true } },
+                onClickCollections = { navController.navigate(CollectionsRoute) { launchSingleTop = true } },
                 onClickSettings = { bookmarkListViewModel.onClickSettings() },
                 onClickUserGuide = { bookmarkListViewModel.onClickUserGuide() },
                 onClickAbout = { bookmarkListViewModel.onClickAbout() },
+                isCollectionsScreen = isCollectionsScreen,
             )
         }
 

--- a/app/src/main/java/com/mydeck/app/worker/FullSyncWorker.kt
+++ b/app/src/main/java/com/mydeck/app/worker/FullSyncWorker.kt
@@ -16,6 +16,7 @@ import com.mydeck.app.MainActivity
 import com.mydeck.app.R
 import com.mydeck.app.domain.BookmarkAnnotationSyncReason
 import com.mydeck.app.domain.BookmarkRepository
+import com.mydeck.app.domain.CollectionRepository
 import com.mydeck.app.domain.HighlightsRefreshReason
 import com.mydeck.app.domain.HighlightsRepository
 import com.mydeck.app.domain.SyncPriority
@@ -40,6 +41,7 @@ class FullSyncWorker @AssistedInject constructor(
     val freshnessMarkerUseCase: FreshnessMarkerUseCase,
     val highlightsRepository: HighlightsRepository,
     val bookmarkMetadataSyncCoordinator: BookmarkMetadataSyncCoordinator,
+    val collectionRepository: CollectionRepository,
 ) : CoroutineWorker(appContext, workerParams) {
     override suspend fun doWork(): Result {
         try {
@@ -88,6 +90,7 @@ class FullSyncWorker @AssistedInject constructor(
             if (outcome.requestGlobalHighlightsBackstop) {
                 requestGlobalHighlightsBackstop(globalBackstopReason)
             }
+            refreshCollections()
 
             return outcome.result
         } catch (e: CancellationException) {
@@ -219,6 +222,16 @@ class FullSyncWorker @AssistedInject constructor(
                 }
             }
         }
+    }
+
+    /**
+     * Best-effort refresh of the cached collections list. Collections are server-side saved filters
+     * — the same data tier as bookmark metadata and highlights, so they ride along with every sync.
+     * A collections failure must never fail a bookmark sync, so this is logged and swallowed.
+     */
+    private suspend fun refreshCollections() {
+        collectionRepository.refreshCollections()
+            .onFailure { Timber.w(it, "Collections refresh failed during full sync") }
     }
 
     private suspend fun requestGlobalHighlightsBackstop(reason: HighlightsRefreshReason) {

--- a/app/src/main/java/com/mydeck/app/worker/LoadBookmarksWorker.kt
+++ b/app/src/main/java/com/mydeck/app/worker/LoadBookmarksWorker.kt
@@ -19,6 +19,7 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import com.mydeck.app.domain.BookmarkAnnotationSyncReason
 import com.mydeck.app.domain.BookmarkRepository
+import com.mydeck.app.domain.CollectionRepository
 import com.mydeck.app.domain.HighlightsRefreshReason
 import com.mydeck.app.domain.HighlightsRepository
 import com.mydeck.app.domain.SyncPriority
@@ -44,6 +45,7 @@ class LoadBookmarksWorker @AssistedInject constructor(
     private val settingsDataStore: SettingsDataStore,
     private val highlightsRepository: HighlightsRepository,
     private val bookmarkMetadataSyncCoordinator: BookmarkMetadataSyncCoordinator,
+    private val collectionRepository: CollectionRepository,
 ) : CoroutineWorker(appContext, workerParams) {
 
     enum class Trigger {
@@ -82,6 +84,7 @@ class LoadBookmarksWorker @AssistedInject constructor(
             requestBookmarkAnnotationChecksForDeltaHints(outcome.bookmarkAnnotationCheckIds)
         }
         outcome.globalHighlightsReason?.let { requestGlobalHighlightsBackstop(it) }
+        refreshCollections()
 
         return outcome.result
     }
@@ -210,6 +213,16 @@ class LoadBookmarksWorker @AssistedInject constructor(
                 }
             }
         }
+    }
+
+    /**
+     * Best-effort refresh of the cached collections list. Collections are server-side saved filters
+     * — the same data tier as bookmark metadata and highlights, so they ride along with every sync.
+     * A collections failure must never fail a bookmark sync, so this is logged and swallowed.
+     */
+    private suspend fun refreshCollections() {
+        collectionRepository.refreshCollections()
+            .onFailure { Timber.w(it, "Collections refresh failed during bookmark sync") }
     }
 
     private suspend fun requestGlobalHighlightsBackstop(reason: HighlightsRefreshReason) {

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -488,6 +488,8 @@ other{}
     <string name="filter_word_count_est">Word Count</string>
     <string name="filter_word_count">Words</string>
     <string name="filter_is_loaded">Is downloaded</string>
+    <string name="filter_unavailable">Unavailable</string>
+    <string name="filter_unavailable_in_collection_tooltip">This filter is specific to this device and can\'t be saved in a collection. It still works on the bookmark list.</string>
     <string name="filtered_list">Filtered List</string>
     <string name="filter_with_labels">With labels</string>
     <string name="filter_with_errors">With errors</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -281,8 +281,11 @@ other{}
     <string name="collection_save_as_action">Save as Collection</string>
     <string name="collection_edit_action">Edit collection</string>
     <string name="collection_delete_action">Delete collection</string>
-    <string name="collection_delete_confirm_title">Delete collection?</string>
-    <string name="collection_delete_confirm_message">\"%s\" will be permanently deleted.</string>
+    <string name="collection_deleted">Collection deleted</string>
+    <string name="collection_save_error">Failed to save collection</string>
+    <string name="collection_update_error">Failed to update collection</string>
+    <string name="collection_delete_error">Failed to delete collection</string>
+    <string name="collection_load_error">Failed to load collections</string>
     <string name="collections_empty_title">No collections yet</string>
     <string name="collections_empty_message">Save a filter as a collection to see it here.</string>
     <string name="highlights_title">Highlights</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -272,6 +272,14 @@ other{}
     <string name="action_is_read">Is read</string>
     <string name="action_search_in_article">Find in article</string>
     <string name="action_find_in_page">Find in page</string>
+    <!-- Collections -->
+    <string name="collections_drawer_item">Collections</string>
+    <string name="collections_screen_title">Collections</string>
+    <string name="collection_create_fab">New Collection</string>
+    <string name="collection_name_hint">Collection name</string>
+    <string name="collection_editor_save">Save</string>
+    <string name="collections_empty_title">No collections yet</string>
+    <string name="collections_empty_message">Save a filter as a collection to see it here.</string>
     <string name="highlights_title">Highlights</string>
     <string name="highlights_empty">No highlights yet</string>
     <string name="highlights_refreshing">Refreshing highlights...</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -278,6 +278,11 @@ other{}
     <string name="collection_create_fab">New Collection</string>
     <string name="collection_name_hint">Collection name</string>
     <string name="collection_editor_save">Save</string>
+    <string name="collection_save_as_action">Save as Collection</string>
+    <string name="collection_edit_action">Edit collection</string>
+    <string name="collection_delete_action">Delete collection</string>
+    <string name="collection_delete_confirm_title">Delete collection?</string>
+    <string name="collection_delete_confirm_message">\"%s\" will be permanently deleted.</string>
     <string name="collections_empty_title">No collections yet</string>
     <string name="collections_empty_message">Save a filter as a collection to see it here.</string>
     <string name="highlights_title">Highlights</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -470,6 +470,8 @@ other{}
     <string name="filter_word_count_est">Word Count</string>
     <string name="filter_word_count">Words</string>
     <string name="filter_is_loaded">Está descargado</string>
+    <string name="filter_unavailable">Unavailable</string>
+    <string name="filter_unavailable_in_collection_tooltip">This filter is specific to this device and can\'t be saved in a collection. It still works on the bookmark list.</string>
     <string name="filtered_list">Filtered List</string>
     <string name="filter_with_labels">Con etiquetas</string>
     <string name="filter_with_errors">Con errores</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -516,6 +516,11 @@ other{}
     <string name="collection_create_fab">New Collection</string>
     <string name="collection_name_hint">Collection name</string>
     <string name="collection_editor_save">Save</string>
+    <string name="collection_save_as_action">Save as Collection</string>
+    <string name="collection_edit_action">Edit collection</string>
+    <string name="collection_delete_action">Delete collection</string>
+    <string name="collection_delete_confirm_title">Delete collection?</string>
+    <string name="collection_delete_confirm_message">\"%s\" will be permanently deleted.</string>
     <string name="collections_empty_title">No collections yet</string>
     <string name="collections_empty_message">Save a filter as a collection to see it here.</string>
     <string name="highlights_title">Highlights</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -510,6 +510,14 @@ other{}
     <string name="gallery_image_counter">%1$d of %2$d</string>
     <string name="action_view_photograph">View Photograph</string>
     <string name="action_find_in_page">Find in Page</string>
+    <!-- Collections -->
+    <string name="collections_drawer_item">Collections</string>
+    <string name="collections_screen_title">Collections</string>
+    <string name="collection_create_fab">New Collection</string>
+    <string name="collection_name_hint">Collection name</string>
+    <string name="collection_editor_save">Save</string>
+    <string name="collections_empty_title">No collections yet</string>
+    <string name="collections_empty_message">Save a filter as a collection to see it here.</string>
     <string name="highlights_title">Highlights</string>
     <string name="highlights_empty">No highlights yet</string>
     <string name="highlights_refreshing">Refreshing highlights...</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -519,8 +519,11 @@ other{}
     <string name="collection_save_as_action">Save as Collection</string>
     <string name="collection_edit_action">Edit collection</string>
     <string name="collection_delete_action">Delete collection</string>
-    <string name="collection_delete_confirm_title">Delete collection?</string>
-    <string name="collection_delete_confirm_message">\"%s\" will be permanently deleted.</string>
+    <string name="collection_deleted">Collection deleted</string>
+    <string name="collection_save_error">Failed to save collection</string>
+    <string name="collection_update_error">Failed to update collection</string>
+    <string name="collection_delete_error">Failed to delete collection</string>
+    <string name="collection_load_error">Failed to load collections</string>
     <string name="collections_empty_title">No collections yet</string>
     <string name="collections_empty_message">Save a filter as a collection to see it here.</string>
     <string name="highlights_title">Highlights</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -416,6 +416,11 @@
     <string name="collection_create_fab">New Collection</string>
     <string name="collection_name_hint">Collection name</string>
     <string name="collection_editor_save">Save</string>
+    <string name="collection_save_as_action">Save as Collection</string>
+    <string name="collection_edit_action">Edit collection</string>
+    <string name="collection_delete_action">Delete collection</string>
+    <string name="collection_delete_confirm_title">Delete collection?</string>
+    <string name="collection_delete_confirm_message">\"%s\" will be permanently deleted.</string>
     <string name="collections_empty_title">No collections yet</string>
     <string name="collections_empty_message">Save a filter as a collection to see it here.</string>
     <string name="highlights_title">Highlights</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -419,8 +419,11 @@
     <string name="collection_save_as_action">Save as Collection</string>
     <string name="collection_edit_action">Edit collection</string>
     <string name="collection_delete_action">Delete collection</string>
-    <string name="collection_delete_confirm_title">Delete collection?</string>
-    <string name="collection_delete_confirm_message">\"%s\" will be permanently deleted.</string>
+    <string name="collection_deleted">Collection deleted</string>
+    <string name="collection_save_error">Failed to save collection</string>
+    <string name="collection_update_error">Failed to update collection</string>
+    <string name="collection_delete_error">Failed to delete collection</string>
+    <string name="collection_load_error">Failed to load collections</string>
     <string name="collections_empty_title">No collections yet</string>
     <string name="collections_empty_message">Save a filter as a collection to see it here.</string>
     <string name="highlights_title">Highlights</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -326,6 +326,8 @@
     <string name="filter_word_count_est">Word Count</string>
     <string name="filter_word_count">Words</string>
     <string name="filter_is_loaded">Is downloaded</string>
+    <string name="filter_unavailable">Unavailable</string>
+    <string name="filter_unavailable_in_collection_tooltip">This filter is specific to this device and can\'t be saved in a collection. It still works on the bookmark list.</string>
     <string name="filtered_list">Filtered List</string>
     <string name="filter_with_labels">With labels</string>
     <string name="filter_with_errors">With errors</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -410,6 +410,14 @@
     <string name="gallery_image_counter">%1$d of %2$d</string>
     <string name="action_view_photograph">View Photograph</string>
     <string name="action_find_in_page">Find in Page</string>
+    <!-- Collections -->
+    <string name="collections_drawer_item">Collections</string>
+    <string name="collections_screen_title">Collections</string>
+    <string name="collection_create_fab">New Collection</string>
+    <string name="collection_name_hint">Collection name</string>
+    <string name="collection_editor_save">Save</string>
+    <string name="collections_empty_title">No collections yet</string>
+    <string name="collections_empty_message">Save a filter as a collection to see it here.</string>
     <string name="highlights_title">Highlights</string>
     <string name="highlights_empty">No highlights yet</string>
     <string name="highlights_refreshing">Refreshing highlights...</string>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -482,6 +482,11 @@ other{}
     <string name="collection_create_fab">New Collection</string>
     <string name="collection_name_hint">Collection name</string>
     <string name="collection_editor_save">Save</string>
+    <string name="collection_save_as_action">Save as Collection</string>
+    <string name="collection_edit_action">Edit collection</string>
+    <string name="collection_delete_action">Delete collection</string>
+    <string name="collection_delete_confirm_title">Delete collection?</string>
+    <string name="collection_delete_confirm_message">\"%s\" will be permanently deleted.</string>
     <string name="collections_empty_title">No collections yet</string>
     <string name="collections_empty_message">Save a filter as a collection to see it here.</string>
     <string name="highlights_title">Highlights</string>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -476,6 +476,14 @@ other{}
     <string name="gallery_image_counter">%1$d of %2$d</string>
     <string name="action_view_photograph">View Photograph</string>
     <string name="action_find_in_page">Find in Page</string>
+    <!-- Collections -->
+    <string name="collections_drawer_item">Collections</string>
+    <string name="collections_screen_title">Collections</string>
+    <string name="collection_create_fab">New Collection</string>
+    <string name="collection_name_hint">Collection name</string>
+    <string name="collection_editor_save">Save</string>
+    <string name="collections_empty_title">No collections yet</string>
+    <string name="collections_empty_message">Save a filter as a collection to see it here.</string>
     <string name="highlights_title">Highlights</string>
     <string name="highlights_empty">No highlights yet</string>
     <string name="highlights_refreshing">Refreshing highlights...</string>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -394,6 +394,8 @@ other{}
     <string name="filter_word_count_est">Word Count</string>
     <string name="filter_word_count">Words</string>
     <string name="filter_is_loaded">Is downloaded</string>
+    <string name="filter_unavailable">Unavailable</string>
+    <string name="filter_unavailable_in_collection_tooltip">This filter is specific to this device and can\'t be saved in a collection. It still works on the bookmark list.</string>
     <string name="filtered_list">Filtered List</string>
     <string name="filter_with_labels">With labels</string>
     <string name="filter_with_errors">With errors</string>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -485,8 +485,11 @@ other{}
     <string name="collection_save_as_action">Save as Collection</string>
     <string name="collection_edit_action">Edit collection</string>
     <string name="collection_delete_action">Delete collection</string>
-    <string name="collection_delete_confirm_title">Delete collection?</string>
-    <string name="collection_delete_confirm_message">\"%s\" will be permanently deleted.</string>
+    <string name="collection_deleted">Collection deleted</string>
+    <string name="collection_save_error">Failed to save collection</string>
+    <string name="collection_update_error">Failed to update collection</string>
+    <string name="collection_delete_error">Failed to delete collection</string>
+    <string name="collection_load_error">Failed to load collections</string>
     <string name="collections_empty_title">No collections yet</string>
     <string name="collections_empty_message">Save a filter as a collection to see it here.</string>
     <string name="highlights_title">Highlights</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -416,6 +416,11 @@
     <string name="collection_create_fab">New Collection</string>
     <string name="collection_name_hint">Collection name</string>
     <string name="collection_editor_save">Save</string>
+    <string name="collection_save_as_action">Save as Collection</string>
+    <string name="collection_edit_action">Edit collection</string>
+    <string name="collection_delete_action">Delete collection</string>
+    <string name="collection_delete_confirm_title">Delete collection?</string>
+    <string name="collection_delete_confirm_message">\"%s\" will be permanently deleted.</string>
     <string name="collections_empty_title">No collections yet</string>
     <string name="collections_empty_message">Save a filter as a collection to see it here.</string>
     <string name="highlights_title">Highlights</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -419,8 +419,11 @@
     <string name="collection_save_as_action">Save as Collection</string>
     <string name="collection_edit_action">Edit collection</string>
     <string name="collection_delete_action">Delete collection</string>
-    <string name="collection_delete_confirm_title">Delete collection?</string>
-    <string name="collection_delete_confirm_message">\"%s\" will be permanently deleted.</string>
+    <string name="collection_deleted">Collection deleted</string>
+    <string name="collection_save_error">Failed to save collection</string>
+    <string name="collection_update_error">Failed to update collection</string>
+    <string name="collection_delete_error">Failed to delete collection</string>
+    <string name="collection_load_error">Failed to load collections</string>
     <string name="collections_empty_title">No collections yet</string>
     <string name="collections_empty_message">Save a filter as a collection to see it here.</string>
     <string name="highlights_title">Highlights</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -326,6 +326,8 @@
     <string name="filter_word_count_est">Word Count</string>
     <string name="filter_word_count">Words</string>
     <string name="filter_is_loaded">Is downloaded</string>
+    <string name="filter_unavailable">Unavailable</string>
+    <string name="filter_unavailable_in_collection_tooltip">This filter is specific to this device and can\'t be saved in a collection. It still works on the bookmark list.</string>
     <string name="filtered_list">Filtered List</string>
     <string name="filter_with_labels">With labels</string>
     <string name="filter_with_errors">With errors</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -410,6 +410,14 @@
     <string name="gallery_image_counter">%1$d of %2$d</string>
     <string name="action_view_photograph">View Photograph</string>
     <string name="action_find_in_page">Find in Page</string>
+    <!-- Collections -->
+    <string name="collections_drawer_item">Collections</string>
+    <string name="collections_screen_title">Collections</string>
+    <string name="collection_create_fab">New Collection</string>
+    <string name="collection_name_hint">Collection name</string>
+    <string name="collection_editor_save">Save</string>
+    <string name="collections_empty_title">No collections yet</string>
+    <string name="collections_empty_message">Save a filter as a collection to see it here.</string>
     <string name="highlights_title">Highlights</string>
     <string name="highlights_empty">No highlights yet</string>
     <string name="highlights_refreshing">Refreshing highlights...</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -416,6 +416,11 @@
     <string name="collection_create_fab">New Collection</string>
     <string name="collection_name_hint">Collection name</string>
     <string name="collection_editor_save">Save</string>
+    <string name="collection_save_as_action">Save as Collection</string>
+    <string name="collection_edit_action">Edit collection</string>
+    <string name="collection_delete_action">Delete collection</string>
+    <string name="collection_delete_confirm_title">Delete collection?</string>
+    <string name="collection_delete_confirm_message">\"%s\" will be permanently deleted.</string>
     <string name="collections_empty_title">No collections yet</string>
     <string name="collections_empty_message">Save a filter as a collection to see it here.</string>
     <string name="highlights_title">Highlights</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -419,8 +419,11 @@
     <string name="collection_save_as_action">Save as Collection</string>
     <string name="collection_edit_action">Edit collection</string>
     <string name="collection_delete_action">Delete collection</string>
-    <string name="collection_delete_confirm_title">Delete collection?</string>
-    <string name="collection_delete_confirm_message">\"%s\" will be permanently deleted.</string>
+    <string name="collection_deleted">Collection deleted</string>
+    <string name="collection_save_error">Failed to save collection</string>
+    <string name="collection_update_error">Failed to update collection</string>
+    <string name="collection_delete_error">Failed to delete collection</string>
+    <string name="collection_load_error">Failed to load collections</string>
     <string name="collections_empty_title">No collections yet</string>
     <string name="collections_empty_message">Save a filter as a collection to see it here.</string>
     <string name="highlights_title">Highlights</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -326,6 +326,8 @@
     <string name="filter_word_count_est">Word Count</string>
     <string name="filter_word_count">Words</string>
     <string name="filter_is_loaded">Is downloaded</string>
+    <string name="filter_unavailable">Unavailable</string>
+    <string name="filter_unavailable_in_collection_tooltip">This filter is specific to this device and can\'t be saved in a collection. It still works on the bookmark list.</string>
     <string name="filtered_list">Filtered List</string>
     <string name="filter_with_labels">With labels</string>
     <string name="filter_with_errors">With errors</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -410,6 +410,14 @@
     <string name="gallery_image_counter">%1$d of %2$d</string>
     <string name="action_view_photograph">View Photograph</string>
     <string name="action_find_in_page">Find in Page</string>
+    <!-- Collections -->
+    <string name="collections_drawer_item">Collections</string>
+    <string name="collections_screen_title">Collections</string>
+    <string name="collection_create_fab">New Collection</string>
+    <string name="collection_name_hint">Collection name</string>
+    <string name="collection_editor_save">Save</string>
+    <string name="collections_empty_title">No collections yet</string>
+    <string name="collections_empty_message">Save a filter as a collection to see it here.</string>
     <string name="highlights_title">Highlights</string>
     <string name="highlights_empty">No highlights yet</string>
     <string name="highlights_refreshing">Refreshing highlights...</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -416,6 +416,11 @@
     <string name="collection_create_fab">New Collection</string>
     <string name="collection_name_hint">Collection name</string>
     <string name="collection_editor_save">Save</string>
+    <string name="collection_save_as_action">Save as Collection</string>
+    <string name="collection_edit_action">Edit collection</string>
+    <string name="collection_delete_action">Delete collection</string>
+    <string name="collection_delete_confirm_title">Delete collection?</string>
+    <string name="collection_delete_confirm_message">\"%s\" will be permanently deleted.</string>
     <string name="collections_empty_title">No collections yet</string>
     <string name="collections_empty_message">Save a filter as a collection to see it here.</string>
     <string name="highlights_title">Highlights</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -419,8 +419,11 @@
     <string name="collection_save_as_action">Save as Collection</string>
     <string name="collection_edit_action">Edit collection</string>
     <string name="collection_delete_action">Delete collection</string>
-    <string name="collection_delete_confirm_title">Delete collection?</string>
-    <string name="collection_delete_confirm_message">\"%s\" will be permanently deleted.</string>
+    <string name="collection_deleted">Collection deleted</string>
+    <string name="collection_save_error">Failed to save collection</string>
+    <string name="collection_update_error">Failed to update collection</string>
+    <string name="collection_delete_error">Failed to delete collection</string>
+    <string name="collection_load_error">Failed to load collections</string>
     <string name="collections_empty_title">No collections yet</string>
     <string name="collections_empty_message">Save a filter as a collection to see it here.</string>
     <string name="highlights_title">Highlights</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -326,6 +326,8 @@
     <string name="filter_word_count_est">Word Count</string>
     <string name="filter_word_count">Words</string>
     <string name="filter_is_loaded">Is downloaded</string>
+    <string name="filter_unavailable">Unavailable</string>
+    <string name="filter_unavailable_in_collection_tooltip">This filter is specific to this device and can\'t be saved in a collection. It still works on the bookmark list.</string>
     <string name="filtered_list">Filtered List</string>
     <string name="filter_with_labels">With labels</string>
     <string name="filter_with_errors">With errors</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -410,6 +410,14 @@
     <string name="gallery_image_counter">%1$d of %2$d</string>
     <string name="action_view_photograph">View Photograph</string>
     <string name="action_find_in_page">Find in Page</string>
+    <!-- Collections -->
+    <string name="collections_drawer_item">Collections</string>
+    <string name="collections_screen_title">Collections</string>
+    <string name="collection_create_fab">New Collection</string>
+    <string name="collection_name_hint">Collection name</string>
+    <string name="collection_editor_save">Save</string>
+    <string name="collections_empty_title">No collections yet</string>
+    <string name="collections_empty_message">Save a filter as a collection to see it here.</string>
     <string name="highlights_title">Highlights</string>
     <string name="highlights_empty">No highlights yet</string>
     <string name="highlights_refreshing">Refreshing highlights...</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -416,6 +416,11 @@
     <string name="collection_create_fab">New Collection</string>
     <string name="collection_name_hint">Collection name</string>
     <string name="collection_editor_save">Save</string>
+    <string name="collection_save_as_action">Save as Collection</string>
+    <string name="collection_edit_action">Edit collection</string>
+    <string name="collection_delete_action">Delete collection</string>
+    <string name="collection_delete_confirm_title">Delete collection?</string>
+    <string name="collection_delete_confirm_message">\"%s\" will be permanently deleted.</string>
     <string name="collections_empty_title">No collections yet</string>
     <string name="collections_empty_message">Save a filter as a collection to see it here.</string>
     <string name="highlights_title">Highlights</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -419,8 +419,11 @@
     <string name="collection_save_as_action">Save as Collection</string>
     <string name="collection_edit_action">Edit collection</string>
     <string name="collection_delete_action">Delete collection</string>
-    <string name="collection_delete_confirm_title">Delete collection?</string>
-    <string name="collection_delete_confirm_message">\"%s\" will be permanently deleted.</string>
+    <string name="collection_deleted">Collection deleted</string>
+    <string name="collection_save_error">Failed to save collection</string>
+    <string name="collection_update_error">Failed to update collection</string>
+    <string name="collection_delete_error">Failed to delete collection</string>
+    <string name="collection_load_error">Failed to load collections</string>
     <string name="collections_empty_title">No collections yet</string>
     <string name="collections_empty_message">Save a filter as a collection to see it here.</string>
     <string name="highlights_title">Highlights</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -326,6 +326,8 @@
     <string name="filter_word_count_est">Word Count</string>
     <string name="filter_word_count">Words</string>
     <string name="filter_is_loaded">Is downloaded</string>
+    <string name="filter_unavailable">Unavailable</string>
+    <string name="filter_unavailable_in_collection_tooltip">This filter is specific to this device and can\'t be saved in a collection. It still works on the bookmark list.</string>
     <string name="filtered_list">Filtered List</string>
     <string name="filter_with_labels">With labels</string>
     <string name="filter_with_errors">With errors</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -410,6 +410,14 @@
     <string name="gallery_image_counter">%1$d of %2$d</string>
     <string name="action_view_photograph">View Photograph</string>
     <string name="action_find_in_page">Find in Page</string>
+    <!-- Collections -->
+    <string name="collections_drawer_item">Collections</string>
+    <string name="collections_screen_title">Collections</string>
+    <string name="collection_create_fab">New Collection</string>
+    <string name="collection_name_hint">Collection name</string>
+    <string name="collection_editor_save">Save</string>
+    <string name="collections_empty_title">No collections yet</string>
+    <string name="collections_empty_message">Save a filter as a collection to see it here.</string>
     <string name="highlights_title">Highlights</string>
     <string name="highlights_empty">No highlights yet</string>
     <string name="highlights_refreshing">Refreshing highlights...</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -510,6 +510,11 @@
     <string name="collection_create_fab">New Collection</string>
     <string name="collection_name_hint">Collection name</string>
     <string name="collection_editor_save">Save</string>
+    <string name="collection_save_as_action">Save as Collection</string>
+    <string name="collection_edit_action">Edit collection</string>
+    <string name="collection_delete_action">Delete collection</string>
+    <string name="collection_delete_confirm_title">Delete collection?</string>
+    <string name="collection_delete_confirm_message">\"%s\" will be permanently deleted.</string>
     <string name="collections_empty_title">No collections yet</string>
     <string name="collections_empty_message">Save a filter as a collection to see it here.</string>
     <string name="highlights_title">Highlights</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -504,6 +504,14 @@
     <string name="gallery_image_counter">%1$d of %2$d</string>
     <string name="action_view_photograph">View Photograph</string>
     <string name="action_find_in_page">Find in Page</string>
+    <!-- Collections -->
+    <string name="collections_drawer_item">Collections</string>
+    <string name="collections_screen_title">Collections</string>
+    <string name="collection_create_fab">New Collection</string>
+    <string name="collection_name_hint">Collection name</string>
+    <string name="collection_editor_save">Save</string>
+    <string name="collections_empty_title">No collections yet</string>
+    <string name="collections_empty_message">Save a filter as a collection to see it here.</string>
     <string name="highlights_title">Highlights</string>
     <string name="highlights_empty">No highlights yet</string>
     <string name="highlights_refreshing">Refreshing highlights...</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -463,6 +463,8 @@
     <string name="filter_word_count_est">Word Count</string>
     <string name="filter_word_count">Words</string>
     <string name="filter_is_loaded">Is downloaded</string>
+    <string name="filter_unavailable">Unavailable</string>
+    <string name="filter_unavailable_in_collection_tooltip">This filter is specific to this device and can\'t be saved in a collection. It still works on the bookmark list.</string>
     <string name="filtered_list">Filtered List</string>
     <string name="filter_with_labels">With labels</string>
     <string name="filter_with_errors">With errors</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -513,8 +513,11 @@
     <string name="collection_save_as_action">Save as Collection</string>
     <string name="collection_edit_action">Edit collection</string>
     <string name="collection_delete_action">Delete collection</string>
-    <string name="collection_delete_confirm_title">Delete collection?</string>
-    <string name="collection_delete_confirm_message">\"%s\" will be permanently deleted.</string>
+    <string name="collection_deleted">Collection deleted</string>
+    <string name="collection_save_error">Failed to save collection</string>
+    <string name="collection_update_error">Failed to update collection</string>
+    <string name="collection_delete_error">Failed to delete collection</string>
+    <string name="collection_load_error">Failed to load collections</string>
     <string name="collections_empty_title">No collections yet</string>
     <string name="collections_empty_message">Save a filter as a collection to see it here.</string>
     <string name="highlights_title">Highlights</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -208,6 +208,14 @@ other{}
     <string name="action_decrease_line_spacing">Decrease line spacing</string>
     <string name="action_search_in_article">Find in article</string>
     <string name="action_find_in_page">Find in page</string>
+    <!-- Collections -->
+    <string name="collections_drawer_item">Collections</string>
+    <string name="collections_screen_title">Collections</string>
+    <string name="collection_create_fab">New Collection</string>
+    <string name="collection_name_hint">Collection name</string>
+    <string name="collection_editor_save">Save</string>
+    <string name="collections_empty_title">No collections yet</string>
+    <string name="collections_empty_message">Save a filter as a collection to see it here.</string>
     <string name="highlights_title">Highlights</string>
     <string name="highlights_empty">No highlights yet</string>
     <string name="highlights_refreshing">Refreshing highlights...</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -214,6 +214,11 @@ other{}
     <string name="collection_create_fab">New Collection</string>
     <string name="collection_name_hint">Collection name</string>
     <string name="collection_editor_save">Save</string>
+    <string name="collection_save_as_action">Save as Collection</string>
+    <string name="collection_edit_action">Edit collection</string>
+    <string name="collection_delete_action">Delete collection</string>
+    <string name="collection_delete_confirm_title">Delete collection?</string>
+    <string name="collection_delete_confirm_message">\"%s\" will be permanently deleted.</string>
     <string name="collections_empty_title">No collections yet</string>
     <string name="collections_empty_message">Save a filter as a collection to see it here.</string>
     <string name="highlights_title">Highlights</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -696,6 +696,8 @@ other{}
     <string name="filter_word_count_est">Word Count</string>
     <string name="filter_word_count">Words</string>
     <string name="filter_is_loaded">Is downloaded</string>
+    <string name="filter_unavailable">Unavailable</string>
+    <string name="filter_unavailable_in_collection_tooltip">This filter is specific to this device and can\'t be saved in a collection. It still works on the bookmark list.</string>
     <string name="filtered_list">Filtered List</string>
     <string name="filter_with_labels">With labels</string>
     <string name="filter_with_errors">With errors</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -217,8 +217,11 @@ other{}
     <string name="collection_save_as_action">Save as Collection</string>
     <string name="collection_edit_action">Edit collection</string>
     <string name="collection_delete_action">Delete collection</string>
-    <string name="collection_delete_confirm_title">Delete collection?</string>
-    <string name="collection_delete_confirm_message">\"%s\" will be permanently deleted.</string>
+    <string name="collection_deleted">Collection deleted</string>
+    <string name="collection_save_error">Failed to save collection</string>
+    <string name="collection_update_error">Failed to update collection</string>
+    <string name="collection_delete_error">Failed to delete collection</string>
+    <string name="collection_load_error">Failed to load collections</string>
     <string name="collections_empty_title">No collections yet</string>
     <string name="collections_empty_message">Save a filter as a collection to see it here.</string>
     <string name="highlights_title">Highlights</string>

--- a/app/src/test/java/com/mydeck/app/domain/CollectionRepositoryImplTest.kt
+++ b/app/src/test/java/com/mydeck/app/domain/CollectionRepositoryImplTest.kt
@@ -94,6 +94,8 @@ class CollectionRepositoryImplTest {
         readStatus = emptyList(),
         isMarked = null,
         isArchived = null,
+        hasErrors = null,
+        hasLabels = null,
         rangeStart = null,
         rangeEnd = null,
         created = 0L,

--- a/app/src/test/java/com/mydeck/app/domain/CollectionRepositoryImplTest.kt
+++ b/app/src/test/java/com/mydeck/app/domain/CollectionRepositoryImplTest.kt
@@ -7,11 +7,9 @@ import com.mydeck.app.io.db.dao.CollectionDao
 import com.mydeck.app.io.db.model.CollectionEntity
 import com.mydeck.app.io.rest.ReadeckApi
 import com.mydeck.app.io.rest.model.CollectionDto
-import com.mydeck.app.io.rest.model.CreateCollectionDto
 import com.mydeck.app.io.rest.model.StatusMessageDto
 import io.mockk.coEvery
 import io.mockk.mockk
-import io.mockk.slot
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -185,8 +183,10 @@ class CollectionRepositoryImplTest {
     // --- updateCollection ---
 
     @Test
-    fun `updateCollection success caches updated entity`() = runTest {
-        coEvery { readeckApi.updateCollection("c1", any()) } returns
+    fun `updateCollection success refetches full object and caches it`() = runTest {
+        // PATCH returns only a partial summary (Response<Unit>); the impl re-fetches by id to cache.
+        coEvery { readeckApi.updateCollection("c1", any()) } returns Response.success(Unit)
+        coEvery { readeckApi.getCollectionById("c1") } returns
             Response.success(dto(id = "c1", name = "Updated"))
 
         val result = impl.updateCollection("c1", "Updated", com.mydeck.app.domain.model.FilterFormState())
@@ -209,27 +209,25 @@ class CollectionRepositoryImplTest {
     // --- deleteCollection ---
 
     @Test
-    fun `deleteCollection soft deletes with correct name and removes from local cache`() = runTest {
+    fun `deleteCollection removes from local cache on success`() = runTest {
         collectionDao.upsertCollections(listOf(entity("c1", "Keeper")))
-        val bodySlot = slot<CreateCollectionDto>()
-        coEvery { readeckApi.updateCollection("c1", capture(bodySlot)) } returns
-            Response.success(dto(id = "c1", name = "Keeper", isDeleted = true))
+        coEvery { readeckApi.deleteCollection("c1") } returns Response.success(Unit)
 
         val result = impl.deleteCollection("c1")
 
         assertTrue(result.isSuccess)
-        assertTrue(bodySlot.captured.isDeleted == true)
-        assertEquals("Keeper", bodySlot.captured.name)
         assertNull(collectionDao.getById("c1"))
     }
 
     @Test
-    fun `deleteCollection unknown id with api 404 returns failure`() = runTest {
-        coEvery { readeckApi.getCollectionById("x") } returns
-            Response.error(404, "".toResponseBody(null))
+    fun `deleteCollection HTTP error returns failure and keeps local cache`() = runTest {
+        collectionDao.upsertCollections(listOf(entity("c1", "Keeper")))
+        coEvery { readeckApi.deleteCollection("c1") } returns
+            Response.error(500, "".toResponseBody(null))
 
-        val result = impl.deleteCollection("x")
+        val result = impl.deleteCollection("c1")
 
         assertTrue(result.isFailure)
+        assertNotNull(collectionDao.getById("c1"))
     }
 }

--- a/app/src/test/java/com/mydeck/app/domain/CollectionRepositoryImplTest.kt
+++ b/app/src/test/java/com/mydeck/app/domain/CollectionRepositoryImplTest.kt
@@ -1,0 +1,233 @@
+package com.mydeck.app.domain
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.mydeck.app.io.db.MyDeckDatabase
+import com.mydeck.app.io.db.dao.CollectionDao
+import com.mydeck.app.io.db.model.CollectionEntity
+import com.mydeck.app.io.rest.ReadeckApi
+import com.mydeck.app.io.rest.model.CollectionDto
+import com.mydeck.app.io.rest.model.CreateCollectionDto
+import com.mydeck.app.io.rest.model.StatusMessageDto
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import okhttp3.Headers
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import retrofit2.Response
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class CollectionRepositoryImplTest {
+
+    private lateinit var database: MyDeckDatabase
+    private lateinit var collectionDao: CollectionDao
+    private lateinit var readeckApi: ReadeckApi
+    private lateinit var impl: CollectionRepositoryImpl
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @Before
+    fun setUp() {
+        database = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            MyDeckDatabase::class.java
+        ).allowMainThreadQueries().build()
+        collectionDao = database.getCollectionDao()
+        readeckApi = mockk()
+        impl = CollectionRepositoryImpl(
+            database = database,
+            collectionDao = collectionDao,
+            readeckApi = readeckApi,
+            dispatcher = testDispatcher,
+        )
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+
+    private fun dto(
+        id: String = "c1",
+        name: String = "Test",
+        isPinned: Boolean? = false,
+        isDeleted: Boolean? = null,
+        created: String = "2026-01-01T00:00:00Z",
+        updated: String = "2026-06-01T00:00:00Z",
+    ) = CollectionDto(
+        id = id,
+        href = "/api/bookmarks/collections/$id",
+        created = created,
+        updated = updated,
+        name = name,
+        isPinned = isPinned,
+        isDeleted = isDeleted,
+    )
+
+    private fun entity(
+        id: String,
+        name: String,
+        isPinned: Boolean = false,
+    ) = CollectionEntity(
+        id = id,
+        name = name,
+        isPinned = isPinned,
+        search = null,
+        title = null,
+        author = null,
+        site = null,
+        labels = null,
+        type = emptyList(),
+        readStatus = emptyList(),
+        isMarked = null,
+        isArchived = null,
+        rangeStart = null,
+        rangeEnd = null,
+        created = 0L,
+        updated = 0L,
+    )
+
+    // --- refreshCollections ---
+
+    @Test
+    fun `refreshCollections single page filters deleted and caches remaining`() = runTest {
+        val dtos = listOf(
+            dto(id = "active", name = "Active", isDeleted = null),
+            dto(id = "deleted", name = "Deleted", isDeleted = true),
+        )
+        coEvery { readeckApi.getCollections(100, 0) } returns Response.success(dtos)
+
+        val result = impl.refreshCollections()
+
+        assertTrue(result.isSuccess)
+        assertNotNull(collectionDao.getById("active"))
+        assertNull(collectionDao.getById("deleted"))
+    }
+
+    @Test
+    fun `refreshCollections paginates until page smaller than page size`() = runTest {
+        val page1 = (1..100).map { dto(id = "p1-$it", name = "P1 $it") }
+        val page2 = listOf(dto(id = "p2-1", name = "P2 1"))
+        coEvery { readeckApi.getCollections(100, 0) } returns Response.success(page1)
+        coEvery { readeckApi.getCollections(100, 100) } returns Response.success(page2)
+
+        val result = impl.refreshCollections()
+
+        assertTrue(result.isSuccess)
+        assertNotNull(collectionDao.getById("p1-1"))
+        assertNotNull(collectionDao.getById("p2-1"))
+        // Total 101 non-deleted entities cached
+        assertNotNull(collectionDao.getById("p1-100"))
+    }
+
+    @Test
+    fun `refreshCollections returns failure on HTTP error`() = runTest {
+        coEvery { readeckApi.getCollections(100, 0) } returns
+            Response.error(500, "".toResponseBody(null))
+
+        val result = impl.refreshCollections()
+
+        assertTrue(result.isFailure)
+    }
+
+    // --- createCollection ---
+
+    @Test
+    fun `createCollection success reads location header and caches entity`() = runTest {
+        val locationHeaders = Headers.headersOf("location", "/api/bookmarks/collections/new-id")
+        coEvery { readeckApi.createCollection(any()) } returns
+            Response.success(StatusMessageDto(0, "ok"), locationHeaders)
+        coEvery { readeckApi.getCollectionById("new-id") } returns
+            Response.success(dto(id = "new-id", name = "New"))
+
+        val result = impl.createCollection("New", com.mydeck.app.domain.model.FilterFormState())
+
+        assertTrue(result.isSuccess)
+        assertEquals("new-id", result.getOrNull()?.id)
+        assertNotNull(collectionDao.getById("new-id"))
+    }
+
+    @Test
+    fun `createCollection missing location header returns failure`() = runTest {
+        coEvery { readeckApi.createCollection(any()) } returns
+            Response.success(StatusMessageDto(0, "ok"))
+
+        val result = impl.createCollection("No Location", com.mydeck.app.domain.model.FilterFormState())
+
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun `createCollection HTTP error returns failure`() = runTest {
+        coEvery { readeckApi.createCollection(any()) } returns
+            Response.error(400, "".toResponseBody(null))
+
+        val result = impl.createCollection("Fail", com.mydeck.app.domain.model.FilterFormState())
+
+        assertTrue(result.isFailure)
+    }
+
+    // --- updateCollection ---
+
+    @Test
+    fun `updateCollection success caches updated entity`() = runTest {
+        coEvery { readeckApi.updateCollection("c1", any()) } returns
+            Response.success(dto(id = "c1", name = "Updated"))
+
+        val result = impl.updateCollection("c1", "Updated", com.mydeck.app.domain.model.FilterFormState())
+
+        assertTrue(result.isSuccess)
+        assertNotNull(collectionDao.getById("c1"))
+        assertEquals("Updated", collectionDao.getById("c1")?.name)
+    }
+
+    @Test
+    fun `updateCollection HTTP error returns failure`() = runTest {
+        coEvery { readeckApi.updateCollection("c1", any()) } returns
+            Response.error(500, "".toResponseBody(null))
+
+        val result = impl.updateCollection("c1", "Fail", com.mydeck.app.domain.model.FilterFormState())
+
+        assertTrue(result.isFailure)
+    }
+
+    // --- deleteCollection ---
+
+    @Test
+    fun `deleteCollection soft deletes with correct name and removes from local cache`() = runTest {
+        collectionDao.upsertCollections(listOf(entity("c1", "Keeper")))
+        val bodySlot = slot<CreateCollectionDto>()
+        coEvery { readeckApi.updateCollection("c1", capture(bodySlot)) } returns
+            Response.success(dto(id = "c1", name = "Keeper", isDeleted = true))
+
+        val result = impl.deleteCollection("c1")
+
+        assertTrue(result.isSuccess)
+        assertTrue(bodySlot.captured.isDeleted == true)
+        assertEquals("Keeper", bodySlot.captured.name)
+        assertNull(collectionDao.getById("c1"))
+    }
+
+    @Test
+    fun `deleteCollection unknown id with api 404 returns failure`() = runTest {
+        coEvery { readeckApi.getCollectionById("x") } returns
+            Response.error(404, "".toResponseBody(null))
+
+        val result = impl.deleteCollection("x")
+
+        assertTrue(result.isFailure)
+    }
+}

--- a/app/src/test/java/com/mydeck/app/domain/model/CollectionFilterAdapterTest.kt
+++ b/app/src/test/java/com/mydeck/app/domain/model/CollectionFilterAdapterTest.kt
@@ -1,0 +1,191 @@
+package com.mydeck.app.domain.model
+
+import com.mydeck.app.io.db.model.CollectionEntity
+import com.mydeck.app.io.rest.model.CollectionDto
+import kotlinx.datetime.Instant
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CollectionFilterAdapterTest {
+
+    private val isoCreated = "2026-01-01T00:00:00Z"
+    private val isoUpdated = "2026-06-01T12:00:00Z"
+
+    private fun makeDto(
+        id: String = "c1",
+        name: String = "Test",
+        isPinned: Boolean? = false,
+        isDeleted: Boolean? = null,
+        search: String? = null,
+        title: String? = null,
+        author: String? = null,
+        site: String? = null,
+        type: List<String>? = null,
+        labels: String? = null,
+        readStatus: List<String>? = null,
+        isMarked: Boolean? = null,
+        isArchived: Boolean? = null,
+        rangeStart: String? = null,
+        rangeEnd: String? = null,
+        created: String = isoCreated,
+        updated: String = isoUpdated,
+    ) = CollectionDto(
+        id = id,
+        href = "/api/bookmarks/collections/$id",
+        created = created,
+        updated = updated,
+        name = name,
+        isPinned = isPinned,
+        isDeleted = isDeleted,
+        search = search,
+        title = title,
+        author = author,
+        site = site,
+        type = type,
+        labels = labels,
+        readStatus = readStatus,
+        isMarked = isMarked,
+        isArchived = isArchived,
+        rangeStart = rangeStart,
+        rangeEnd = rangeEnd,
+    )
+
+    // --- toCreateCollectionDto ---
+
+    @Test
+    fun `toCreateCollectionDto maps all persistable fields correctly`() {
+        val from = Instant.parse("2026-01-01T00:00:00Z")
+        val to = Instant.parse("2026-12-31T23:59:59Z")
+        val filter = FilterFormState(
+            search = "query",
+            title = "My Title",
+            author = "Jane",
+            site = "example.com",
+            label = "tech",
+            types = linkedSetOf(Bookmark.Type.Article, Bookmark.Type.Picture, Bookmark.Type.Video),
+            progress = linkedSetOf(ProgressFilter.UNVIEWED, ProgressFilter.IN_PROGRESS, ProgressFilter.COMPLETED),
+            isFavorite = true,
+            isArchived = false,
+            fromDate = from,
+            toDate = to,
+        )
+
+        val dto = filter.toCreateCollectionDto("My Collection", isPinned = true)
+
+        assertEquals("My Collection", dto.name)
+        assertTrue(dto.isPinned == true)
+        assertEquals("query", dto.search)
+        assertEquals("My Title", dto.title)
+        assertEquals("Jane", dto.author)
+        assertEquals("example.com", dto.site)
+        assertEquals("tech", dto.labels)
+        assertEquals(setOf("article", "photo", "video"), dto.type?.toSet())
+        assertEquals(setOf("unread", "reading", "read"), dto.readStatus?.toSet())
+        assertTrue(dto.isMarked == true)
+        assertTrue(dto.isArchived == false)
+        assertEquals(from.toString(), dto.rangeStart)
+        assertEquals(to.toString(), dto.rangeEnd)
+    }
+
+    @Test
+    fun `toCreateCollectionDto with empty types and progress produces null lists`() {
+        val filter = FilterFormState()
+        val dto = filter.toCreateCollectionDto("Empty")
+        assertNull(dto.type)
+        assertNull(dto.readStatus)
+    }
+
+    @Test
+    fun `toCreateCollectionDto ignores local-only fields`() {
+        val filter = FilterFormState(
+            search = "hello",
+            isLoaded = true,
+            withLabels = true,
+            withErrors = true,
+            minReadingTime = 5,
+            minWordCount = 10,
+        )
+        val dto = filter.toCreateCollectionDto("Local Only Test")
+        // No crash; search should still round-trip
+        assertEquals("hello", dto.search)
+    }
+
+    // --- CollectionDto.toFilterFormState ---
+
+    @Test
+    fun `CollectionDto toFilterFormState maps types and progress and takes first label segment`() {
+        val rangeStart = "2026-01-01T00:00:00Z"
+        val rangeEnd = "2026-06-30T00:00:00Z"
+        val dto = makeDto(
+            type = listOf("article", "video"),
+            readStatus = listOf("unread", "read"),
+            labels = "x,y,z",
+            rangeStart = rangeStart,
+            rangeEnd = rangeEnd,
+            isMarked = true,
+            isArchived = false,
+        )
+
+        val state = dto.toFilterFormState()
+
+        assertEquals(setOf(Bookmark.Type.Article, Bookmark.Type.Video), state.types)
+        assertEquals(setOf(ProgressFilter.UNVIEWED, ProgressFilter.COMPLETED), state.progress)
+        assertEquals("x", state.label)
+        assertNull(state.isLoaded)
+        assertNull(state.withLabels)
+        assertNull(state.withErrors)
+        assertEquals(Instant.parse(rangeStart), state.fromDate)
+        assertEquals(Instant.parse(rangeEnd), state.toDate)
+        assertTrue(state.isFavorite == true)
+        assertTrue(state.isArchived == false)
+    }
+
+    @Test
+    fun `CollectionDto toFilterFormState ignores unknown type and readStatus strings`() {
+        val dto = makeDto(
+            type = listOf("article", "bogus"),
+            readStatus = listOf("unread", "unknown_status"),
+        )
+
+        val state = dto.toFilterFormState()
+
+        assertEquals(setOf(Bookmark.Type.Article), state.types)
+        assertEquals(setOf(ProgressFilter.UNVIEWED), state.progress)
+    }
+
+    // --- Entity round-trip: CollectionDto.toEntity().toDomain() ---
+
+    @Test
+    fun `CollectionDto toEntity toDomain round trip preserves fields`() {
+        val dto = makeDto(
+            id = "col-42",
+            name = "Round Trip",
+            isPinned = true,
+            type = listOf("article", "video"),
+            readStatus = listOf("reading"),
+            labels = "tech,science",
+            isMarked = true,
+            isArchived = false,
+            rangeStart = isoCreated,
+            rangeEnd = isoUpdated,
+            created = isoCreated,
+            updated = isoUpdated,
+        )
+
+        val domain = dto.toEntity().toDomain()
+
+        assertEquals("col-42", domain.id)
+        assertEquals("Round Trip", domain.name)
+        assertTrue(domain.isPinned)
+        assertEquals(Instant.parse(isoCreated), domain.created)
+        assertEquals(Instant.parse(isoUpdated), domain.updated)
+        assertEquals(setOf(Bookmark.Type.Article, Bookmark.Type.Video), domain.filter.types)
+        assertEquals(setOf(ProgressFilter.IN_PROGRESS), domain.filter.progress)
+        // first label segment
+        assertEquals("tech", domain.filter.label)
+        assertTrue(domain.filter.isFavorite == true)
+        assertTrue(domain.filter.isArchived == false)
+    }
+}

--- a/app/src/test/java/com/mydeck/app/domain/model/CollectionFilterAdapterTest.kt
+++ b/app/src/test/java/com/mydeck/app/domain/model/CollectionFilterAdapterTest.kt
@@ -3,6 +3,10 @@ package com.mydeck.app.domain.model
 import com.mydeck.app.io.db.model.CollectionEntity
 import com.mydeck.app.io.rest.model.CollectionDto
 import kotlinx.datetime.Instant
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -125,6 +129,45 @@ class CollectionFilterAdapterTest {
         val dto = filter.toCreateCollectionDto("Local Only Test")
         // No crash; search should still round-trip
         assertEquals("hello", dto.search)
+    }
+
+    // --- toUpdateCollectionJson (PATCH body) ---
+
+    @Test
+    fun `toUpdateCollectionJson sends explicit nulls for cleared fields so PATCH clears them`() {
+        // An all-unset filter must still send every managed field as JSON null (not omit them),
+        // otherwise PATCH leaves the previous values in place.
+        val json = FilterFormState().toUpdateCollectionJson("My Collection")
+
+        assertEquals("My Collection", json["name"]?.jsonPrimitive?.content)
+        listOf(
+            "search", "title", "author", "site", "labels",
+            "is_marked", "is_archived", "has_errors", "has_labels",
+            "range_start", "range_end", "type", "read_status",
+        ).forEach { key ->
+            assertTrue("expected key '$key' present", json.containsKey(key))
+            assertTrue("expected '$key' to be JSON null", json[key] is JsonNull)
+        }
+        // is_pinned / is_deleted are deliberately omitted so editing doesn't disturb them.
+        assertNull(json["is_pinned"])
+        assertNull(json["is_deleted"])
+    }
+
+    @Test
+    fun `toUpdateCollectionJson encodes set fields with their values`() {
+        val json = FilterFormState(
+            author = "Ada",
+            withErrors = true,
+            withLabels = false,
+            isFavorite = true,
+            types = linkedSetOf(Bookmark.Type.Article),
+        ).toUpdateCollectionJson("C")
+
+        assertEquals("Ada", json["author"]?.jsonPrimitive?.content)
+        assertEquals(true, json["has_errors"]?.jsonPrimitive?.boolean)
+        assertEquals(false, json["has_labels"]?.jsonPrimitive?.boolean)
+        assertEquals(true, json["is_marked"]?.jsonPrimitive?.boolean)
+        assertEquals("article", (json["type"] as JsonArray)[0].jsonPrimitive.content)
     }
 
     // --- CollectionDto.toFilterFormState ---

--- a/app/src/test/java/com/mydeck/app/domain/model/CollectionFilterAdapterTest.kt
+++ b/app/src/test/java/com/mydeck/app/domain/model/CollectionFilterAdapterTest.kt
@@ -27,6 +27,8 @@ class CollectionFilterAdapterTest {
         readStatus: List<String>? = null,
         isMarked: Boolean? = null,
         isArchived: Boolean? = null,
+        hasErrors: Boolean? = null,
+        hasLabels: Boolean? = null,
         rangeStart: String? = null,
         rangeEnd: String? = null,
         created: String = isoCreated,
@@ -48,6 +50,8 @@ class CollectionFilterAdapterTest {
         readStatus = readStatus,
         isMarked = isMarked,
         isArchived = isArchived,
+        hasErrors = hasErrors,
+        hasLabels = hasLabels,
         rangeStart = rangeStart,
         rangeEnd = rangeEnd,
     )
@@ -68,6 +72,8 @@ class CollectionFilterAdapterTest {
             progress = linkedSetOf(ProgressFilter.UNVIEWED, ProgressFilter.IN_PROGRESS, ProgressFilter.COMPLETED),
             isFavorite = true,
             isArchived = false,
+            withErrors = true,
+            withLabels = false,
             fromDate = from,
             toDate = to,
         )
@@ -85,6 +91,8 @@ class CollectionFilterAdapterTest {
         assertEquals(setOf("unread", "reading", "read"), dto.readStatus?.toSet())
         assertTrue(dto.isMarked == true)
         assertTrue(dto.isArchived == false)
+        assertTrue(dto.hasErrors == true)
+        assertTrue(dto.hasLabels == false)
         assertEquals(from.toString(), dto.rangeStart)
         assertEquals(to.toString(), dto.rangeEnd)
     }
@@ -98,12 +106,19 @@ class CollectionFilterAdapterTest {
     }
 
     @Test
+    fun `toCreateCollectionDto persists has_errors and has_labels`() {
+        val dto = FilterFormState(withErrors = true, withLabels = true).toCreateCollectionDto("WE")
+        assertTrue(dto.hasErrors == true)
+        assertTrue(dto.hasLabels == true)
+    }
+
+    @Test
     fun `toCreateCollectionDto ignores local-only fields`() {
+        // isLoaded ("Downloaded") and the reading-time/word-count fields have no collection-API
+        // equivalent and must not surface on the request body.
         val filter = FilterFormState(
             search = "hello",
             isLoaded = true,
-            withLabels = true,
-            withErrors = true,
             minReadingTime = 5,
             minWordCount = 10,
         )
@@ -126,6 +141,8 @@ class CollectionFilterAdapterTest {
             rangeEnd = rangeEnd,
             isMarked = true,
             isArchived = false,
+            hasErrors = true,
+            hasLabels = false,
         )
 
         val state = dto.toFilterFormState()
@@ -133,9 +150,10 @@ class CollectionFilterAdapterTest {
         assertEquals(setOf(Bookmark.Type.Article, Bookmark.Type.Video), state.types)
         assertEquals(setOf(ProgressFilter.UNVIEWED, ProgressFilter.COMPLETED), state.progress)
         assertEquals("x", state.label)
+        // has_errors / has_labels round-trip; isLoaded ("Downloaded") stays local-only (null).
+        assertTrue(state.withErrors == true)
+        assertTrue(state.withLabels == false)
         assertNull(state.isLoaded)
-        assertNull(state.withLabels)
-        assertNull(state.withErrors)
         assertEquals(Instant.parse(rangeStart), state.fromDate)
         assertEquals(Instant.parse(rangeEnd), state.toDate)
         assertTrue(state.isFavorite == true)
@@ -168,6 +186,8 @@ class CollectionFilterAdapterTest {
             labels = "tech,science",
             isMarked = true,
             isArchived = false,
+            hasErrors = true,
+            hasLabels = true,
             rangeStart = isoCreated,
             rangeEnd = isoUpdated,
             created = isoCreated,
@@ -187,5 +207,7 @@ class CollectionFilterAdapterTest {
         assertEquals("tech", domain.filter.label)
         assertTrue(domain.filter.isFavorite == true)
         assertTrue(domain.filter.isArchived == false)
+        assertTrue(domain.filter.withErrors == true)
+        assertTrue(domain.filter.withLabels == true)
     }
 }

--- a/app/src/test/java/com/mydeck/app/io/db/CollectionDaoTest.kt
+++ b/app/src/test/java/com/mydeck/app/io/db/CollectionDaoTest.kt
@@ -39,6 +39,7 @@ class CollectionDaoTest {
         id: String,
         name: String,
         isPinned: Boolean = false,
+        created: Long = 0L,
     ) = CollectionEntity(
         id = id,
         name = name,
@@ -52,28 +53,31 @@ class CollectionDaoTest {
         readStatus = emptyList(),
         isMarked = null,
         isArchived = null,
+        hasErrors = null,
+        hasLabels = null,
         rangeStart = null,
         rangeEnd = null,
-        created = 0L,
+        created = created,
         updated = 0L,
     )
 
     @Test
-    fun `observeCollections returns entities ordered by isPinned DESC then name ASC`() = runTest {
+    fun `observeCollections returns entities ordered by isPinned DESC then created DESC`() = runTest {
         dao.upsertCollections(
             listOf(
-                entity("beta-id", "Beta", isPinned = false),
-                entity("zeta-id", "Zeta", isPinned = true),
-                entity("alpha-id", "Alpha", isPinned = false),
+                entity("old-id", "Old", isPinned = false, created = 100L),
+                entity("pinned-id", "Pinned", isPinned = true, created = 50L),
+                entity("new-id", "New", isPinned = false, created = 200L),
             )
         )
 
         val result = dao.observeCollections().first()
 
         assertEquals(3, result.size)
-        assertEquals("zeta-id", result[0].id)
-        assertEquals("alpha-id", result[1].id)
-        assertEquals("beta-id", result[2].id)
+        // Pinned first, then unpinned newest-first.
+        assertEquals("pinned-id", result[0].id)
+        assertEquals("new-id", result[1].id)
+        assertEquals("old-id", result[2].id)
     }
 
     @Test

--- a/app/src/test/java/com/mydeck/app/io/db/CollectionDaoTest.kt
+++ b/app/src/test/java/com/mydeck/app/io/db/CollectionDaoTest.kt
@@ -1,0 +1,126 @@
+package com.mydeck.app.io.db
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.mydeck.app.io.db.dao.CollectionDao
+import com.mydeck.app.io.db.model.CollectionEntity
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class CollectionDaoTest {
+
+    private lateinit var db: MyDeckDatabase
+    private lateinit var dao: CollectionDao
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            MyDeckDatabase::class.java
+        ).allowMainThreadQueries().build()
+        dao = db.getCollectionDao()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    private fun entity(
+        id: String,
+        name: String,
+        isPinned: Boolean = false,
+    ) = CollectionEntity(
+        id = id,
+        name = name,
+        isPinned = isPinned,
+        search = null,
+        title = null,
+        author = null,
+        site = null,
+        labels = null,
+        type = emptyList(),
+        readStatus = emptyList(),
+        isMarked = null,
+        isArchived = null,
+        rangeStart = null,
+        rangeEnd = null,
+        created = 0L,
+        updated = 0L,
+    )
+
+    @Test
+    fun `observeCollections returns entities ordered by isPinned DESC then name ASC`() = runTest {
+        dao.upsertCollections(
+            listOf(
+                entity("beta-id", "Beta", isPinned = false),
+                entity("zeta-id", "Zeta", isPinned = true),
+                entity("alpha-id", "Alpha", isPinned = false),
+            )
+        )
+
+        val result = dao.observeCollections().first()
+
+        assertEquals(3, result.size)
+        assertEquals("zeta-id", result[0].id)
+        assertEquals("alpha-id", result[1].id)
+        assertEquals("beta-id", result[2].id)
+    }
+
+    @Test
+    fun `upsertCollections with same id replaces existing entity`() = runTest {
+        dao.upsertCollections(listOf(entity("1", "A")))
+        dao.upsertCollections(listOf(entity("1", "B")))
+
+        val found = dao.getById("1")
+        assertNotNull(found)
+        assertEquals("B", found?.name)
+    }
+
+    @Test
+    fun `deleteById removes only the targeted entity`() = runTest {
+        dao.upsertCollections(
+            listOf(
+                entity("keep", "Keep"),
+                entity("remove", "Remove"),
+            )
+        )
+
+        dao.deleteById("remove")
+
+        val result = dao.observeCollections().first()
+        assertEquals(1, result.size)
+        assertEquals("keep", result[0].id)
+        assertNull(dao.getById("remove"))
+    }
+
+    @Test
+    fun `deleteAll empties the table`() = runTest {
+        dao.upsertCollections(
+            listOf(
+                entity("a", "A"),
+                entity("b", "B"),
+            )
+        )
+
+        dao.deleteAll()
+
+        val result = dao.observeCollections().first()
+        assertEquals(0, result.size)
+    }
+
+    @Test
+    fun `getById returns null for unknown id`() = runTest {
+        val result = dao.getById("does-not-exist")
+        assertNull(result)
+    }
+}

--- a/app/src/test/java/com/mydeck/app/io/db/MyDeckDatabaseMigrationTest.kt
+++ b/app/src/test/java/com/mydeck/app/io/db/MyDeckDatabaseMigrationTest.kt
@@ -455,7 +455,7 @@ class MyDeckDatabaseMigrationTest {
         val expectedColumns = listOf(
             "id", "name", "isPinned", "search", "title", "author", "site",
             "labels", "type", "readStatus", "isMarked", "isArchived",
-            "rangeStart", "rangeEnd", "created", "updated"
+            "hasErrors", "hasLabels", "rangeStart", "rangeEnd", "created", "updated"
         )
         expectedColumns.forEach { col ->
             assertTrue("Expected column '$col' in collections table", columns.containsKey(col))

--- a/app/src/test/java/com/mydeck/app/io/db/MyDeckDatabaseMigrationTest.kt
+++ b/app/src/test/java/com/mydeck/app/io/db/MyDeckDatabaseMigrationTest.kt
@@ -424,4 +424,45 @@ class MyDeckDatabaseMigrationTest {
         dbV17.close()
         db.close()
     }
+
+    @Test
+    @Throws(IOException::class)
+    fun migrate17To18CreatesCollectionsTable() {
+        val helper = MigrationTestHelper(
+            InstrumentationRegistry.getInstrumentation(),
+            MyDeckDatabase::class.java,
+            emptyList<AutoMigrationSpec>(), // workaround for https://issuetracker.google.com/issues/298459978
+            FrameworkSQLiteOpenHelperFactory()
+        )
+        val db = helper.createDatabase(TEST_DB, 17).apply {
+            close()
+        }
+
+        val dbV18 = helper.runMigrationsAndValidate(TEST_DB, 18, true, MyDeckDatabase.MIGRATION_17_18)
+
+        val columns = mutableMapOf<String, ContentValues>()
+        val info = dbV18.query("PRAGMA table_info('collections')")
+        try {
+            while (info.moveToNext()) {
+                val cv = ContentValues()
+                DatabaseUtils.cursorRowToContentValues(info, cv)
+                columns[cv.getAsString("name")] = cv
+            }
+        } finally {
+            info.close()
+        }
+
+        val expectedColumns = listOf(
+            "id", "name", "isPinned", "search", "title", "author", "site",
+            "labels", "type", "readStatus", "isMarked", "isArchived",
+            "rangeStart", "rangeEnd", "created", "updated"
+        )
+        expectedColumns.forEach { col ->
+            assertTrue("Expected column '$col' in collections table", columns.containsKey(col))
+        }
+        assertEquals(1, columns.getValue("id").getAsInteger("pk"))
+
+        dbV18.close()
+        db.close()
+    }
 }

--- a/app/src/test/java/com/mydeck/app/ui/list/BookmarkListViewModelTest.kt
+++ b/app/src/test/java/com/mydeck/app/ui/list/BookmarkListViewModelTest.kt
@@ -1508,7 +1508,25 @@ class BookmarkListViewModelTest {
     }
 
     @Test
-    fun `onDeleteCollection clears selection when deleting the active collection`() = runTest {
+    fun `onStageDeleteCollection hides it and leaves the active view without deleting yet`() = runTest {
+        val collection = sampleCollection()
+        collectionRepository.collectionsFlow.value = listOf(collection)
+        buildViewModelWithBookmarks()
+        backgroundScope.launch { viewModel.collections.collect {} }
+        backgroundScope.launch { viewModel.visibleCollections.collect {} }
+        advanceUntilIdle()
+        viewModel.onSelectCollection(collection.id)
+
+        viewModel.onStageDeleteCollection(collection.id)
+        advanceUntilIdle()
+
+        assertEquals(null, viewModel.selectedCollectionId.value)
+        assertEquals(emptyList<Collection>(), viewModel.visibleCollections.value)
+        assertEquals(null, collectionRepository.lastDeletedId) // not deleted until confirmed
+    }
+
+    @Test
+    fun `onConfirmDeleteCollection deletes via repository`() = runTest {
         val collection = sampleCollection()
         collectionRepository.collectionsFlow.value = listOf(collection)
         collectionRepository.deleteResult = Result.success(Unit)
@@ -1516,12 +1534,47 @@ class BookmarkListViewModelTest {
         backgroundScope.launch { viewModel.collections.collect {} }
         advanceUntilIdle()
         viewModel.onSelectCollection(collection.id)
+        viewModel.onStageDeleteCollection(collection.id)
 
-        viewModel.onDeleteCollection(collection.id)
+        viewModel.onConfirmDeleteCollection(collection.id)
         advanceUntilIdle()
 
-        assertEquals(null, viewModel.selectedCollectionId.value)
         assertEquals(collection.id, collectionRepository.lastDeletedId)
+    }
+
+    @Test
+    fun `onCancelDeleteCollection restores the staged collection as active`() = runTest {
+        val collection = sampleCollection()
+        collectionRepository.collectionsFlow.value = listOf(collection)
+        buildViewModelWithBookmarks()
+        backgroundScope.launch { viewModel.collections.collect {} }
+        backgroundScope.launch { viewModel.visibleCollections.collect {} }
+        advanceUntilIdle()
+        viewModel.onSelectCollection(collection.id)
+        viewModel.onStageDeleteCollection(collection.id)
+        advanceUntilIdle()
+
+        viewModel.onCancelDeleteCollection(collection.id)
+        advanceUntilIdle()
+
+        assertEquals(listOf(collection), viewModel.visibleCollections.value)
+        assertEquals(collection.id, viewModel.selectedCollectionId.value)
+        assertEquals(null, collectionRepository.lastDeletedId)
+    }
+
+    @Test
+    fun `onConfirmDeleteCollection emits an error message on failure`() = runTest {
+        val collection = sampleCollection()
+        collectionRepository.deleteResult = Result.failure(RuntimeException("boom"))
+        buildViewModelWithBookmarks()
+        viewModel.onStageDeleteCollection(collection.id)
+
+        viewModel.onConfirmDeleteCollection(collection.id)
+
+        assertEquals(
+            com.mydeck.app.R.string.collection_delete_error,
+            viewModel.collectionMessageEvent.first()
+        )
     }
 
     @Test

--- a/app/src/test/java/com/mydeck/app/ui/list/BookmarkListViewModelTest.kt
+++ b/app/src/test/java/com/mydeck/app/ui/list/BookmarkListViewModelTest.kt
@@ -9,8 +9,12 @@ import androidx.work.WorkManager
 import com.mydeck.app.R
 import com.mydeck.app.domain.BookmarkBatchUpdate
 import com.mydeck.app.domain.BookmarkRepository
+import com.mydeck.app.domain.CollectionRepository
 import com.mydeck.app.domain.HighlightsRepository
 import com.mydeck.app.domain.model.Bookmark
+import com.mydeck.app.domain.model.Collection
+import com.mydeck.app.domain.model.DrawerPreset
+import com.mydeck.app.domain.model.FilterFormState
 import com.mydeck.app.domain.model.BookmarkShareFormat
 import com.mydeck.app.domain.model.BookmarkCounts
 import com.mydeck.app.domain.model.BookmarkListItem
@@ -79,6 +83,7 @@ class BookmarkListViewModelTest {
     private lateinit var contentPackageManager: ContentPackageManager
     private lateinit var highlightsRepository: HighlightsRepository
     private lateinit var syncScheduler: SyncScheduler
+    private lateinit var collectionRepository: FakeCollectionRepository
 
     private lateinit var workInfoFlow: MutableStateFlow<List<WorkInfo>>
     private lateinit var initialSyncPerformedFlow: MutableStateFlow<Boolean>
@@ -98,6 +103,9 @@ class BookmarkListViewModelTest {
         contentPackageManager = mockk()
         highlightsRepository = mockk()
         syncScheduler = mockk(relaxed = true)
+        // A hand-written fake, not a MockK mock: MockK mishandles suspend functions returning the
+        // kotlin.Result value class (ClassCastException). The fake returns Results directly.
+        collectionRepository = FakeCollectionRepository()
         coEvery { contentSyncPolicyEvaluator.shouldAutoFetchContent() } returns false
         coEvery { highlightsRepository.requestRefresh(any()) } returns Result.success(Unit)
 
@@ -163,6 +171,7 @@ class BookmarkListViewModelTest {
         contentSyncPolicyEvaluator,
         contentPackageManager,
         syncScheduler,
+        collectionRepository,
         connectivityMonitor
     )
 
@@ -188,6 +197,7 @@ class BookmarkListViewModelTest {
             contentSyncPolicyEvaluator,
             contentPackageManager,
             syncScheduler,
+            collectionRepository,
             connectivityMonitor
         )
         // Since we emit empty list by default from mock, and filter/query are empty/default,
@@ -212,6 +222,7 @@ class BookmarkListViewModelTest {
             contentSyncPolicyEvaluator,
             contentPackageManager,
             syncScheduler,
+            collectionRepository,
             connectivityMonitor
         )
         advanceUntilIdle()
@@ -239,6 +250,7 @@ class BookmarkListViewModelTest {
             contentSyncPolicyEvaluator,
             contentPackageManager,
             syncScheduler,
+            collectionRepository,
             connectivityMonitor
         )
 
@@ -266,6 +278,7 @@ class BookmarkListViewModelTest {
             contentSyncPolicyEvaluator,
             contentPackageManager,
             syncScheduler,
+            collectionRepository,
             connectivityMonitor
         )
         // Just verify that it doesn't throw an exception for now
@@ -288,6 +301,7 @@ class BookmarkListViewModelTest {
             contentSyncPolicyEvaluator,
             contentPackageManager,
             syncScheduler,
+            collectionRepository,
             connectivityMonitor
         )
 
@@ -312,6 +326,7 @@ class BookmarkListViewModelTest {
             contentSyncPolicyEvaluator,
             contentPackageManager,
             syncScheduler,
+            collectionRepository,
             connectivityMonitor
         )
 
@@ -336,6 +351,7 @@ class BookmarkListViewModelTest {
             contentSyncPolicyEvaluator,
             contentPackageManager,
             syncScheduler,
+            collectionRepository,
             connectivityMonitor
         )
 
@@ -368,6 +384,7 @@ class BookmarkListViewModelTest {
             contentSyncPolicyEvaluator,
             contentPackageManager,
             syncScheduler,
+            collectionRepository,
             connectivityMonitor
         )
         viewModel.onClickMyList()
@@ -392,6 +409,7 @@ class BookmarkListViewModelTest {
             contentSyncPolicyEvaluator,
             contentPackageManager,
             syncScheduler,
+            collectionRepository,
             connectivityMonitor
         )
         viewModel.onClickArchive()
@@ -415,6 +433,7 @@ class BookmarkListViewModelTest {
             contentSyncPolicyEvaluator,
             contentPackageManager,
             syncScheduler,
+            collectionRepository,
             connectivityMonitor
         )
         viewModel.onClickFavorite()
@@ -438,6 +457,7 @@ class BookmarkListViewModelTest {
             contentSyncPolicyEvaluator,
             contentPackageManager,
             syncScheduler,
+            collectionRepository,
             connectivityMonitor
         )
         viewModel.onClickSettings()
@@ -461,6 +481,7 @@ class BookmarkListViewModelTest {
             contentSyncPolicyEvaluator,
             contentPackageManager,
             syncScheduler,
+            collectionRepository,
             connectivityMonitor
         )
         val bookmarkId = "someBookmarkId"
@@ -537,6 +558,7 @@ class BookmarkListViewModelTest {
             contentSyncPolicyEvaluator,
             contentPackageManager,
             syncScheduler,
+            collectionRepository,
             connectivityMonitor
         )
 
@@ -568,6 +590,7 @@ class BookmarkListViewModelTest {
             contentSyncPolicyEvaluator,
             contentPackageManager,
             syncScheduler,
+            collectionRepository,
             connectivityMonitor
         )
         viewModel.openCreateBookmarkDialog()
@@ -588,6 +611,7 @@ class BookmarkListViewModelTest {
             contentSyncPolicyEvaluator,
             contentPackageManager,
             syncScheduler,
+            collectionRepository,
             connectivityMonitor
         )
         viewModel.openCreateBookmarkDialog()
@@ -610,6 +634,7 @@ class BookmarkListViewModelTest {
                 contentSyncPolicyEvaluator,
                 contentPackageManager,
             syncScheduler,
+                collectionRepository,
                 connectivityMonitor
             )
             viewModel.openCreateBookmarkDialog()
@@ -640,6 +665,7 @@ class BookmarkListViewModelTest {
                 contentSyncPolicyEvaluator,
                 contentPackageManager,
             syncScheduler,
+                collectionRepository,
                 connectivityMonitor
             )
             viewModel.openCreateBookmarkDialog()
@@ -669,6 +695,7 @@ class BookmarkListViewModelTest {
             contentSyncPolicyEvaluator,
             contentPackageManager,
             syncScheduler,
+            collectionRepository,
             connectivityMonitor
         )
         viewModel.openCreateBookmarkDialog()
@@ -696,6 +723,7 @@ class BookmarkListViewModelTest {
             contentSyncPolicyEvaluator,
             contentPackageManager,
             syncScheduler,
+            collectionRepository,
             connectivityMonitor
         )
         viewModel.openCreateBookmarkDialog()
@@ -725,6 +753,7 @@ class BookmarkListViewModelTest {
             contentSyncPolicyEvaluator,
             contentPackageManager,
             syncScheduler,
+            collectionRepository,
             connectivityMonitor
         )
         viewModel.openCreateBookmarkDialog()
@@ -757,6 +786,7 @@ class BookmarkListViewModelTest {
             contentSyncPolicyEvaluator,
             contentPackageManager,
             syncScheduler,
+            collectionRepository,
             connectivityMonitor
         )
 
@@ -785,6 +815,7 @@ class BookmarkListViewModelTest {
                 contentSyncPolicyEvaluator,
                 contentPackageManager,
             syncScheduler,
+                collectionRepository,
                 connectivityMonitor
             )
 
@@ -825,6 +856,7 @@ class BookmarkListViewModelTest {
                 contentSyncPolicyEvaluator,
                 contentPackageManager,
             syncScheduler,
+                collectionRepository,
                 connectivityMonitor
             )
 
@@ -889,6 +921,7 @@ class BookmarkListViewModelTest {
                 contentSyncPolicyEvaluator,
                 contentPackageManager,
             syncScheduler,
+                collectionRepository,
                 connectivityMonitor
             )
 
@@ -953,6 +986,7 @@ class BookmarkListViewModelTest {
                 contentSyncPolicyEvaluator,
                 contentPackageManager,
             syncScheduler,
+                collectionRepository,
                 connectivityMonitor
             )
 
@@ -1016,6 +1050,7 @@ class BookmarkListViewModelTest {
                 contentSyncPolicyEvaluator,
                 contentPackageManager,
             syncScheduler,
+                collectionRepository,
                 connectivityMonitor
             )
 
@@ -1080,6 +1115,7 @@ class BookmarkListViewModelTest {
                 contentSyncPolicyEvaluator,
                 contentPackageManager,
             syncScheduler,
+                collectionRepository,
                 connectivityMonitor
             )
 
@@ -1144,6 +1180,7 @@ class BookmarkListViewModelTest {
                 contentSyncPolicyEvaluator,
                 contentPackageManager,
             syncScheduler,
+                collectionRepository,
                 connectivityMonitor
             )
 
@@ -1208,6 +1245,7 @@ class BookmarkListViewModelTest {
                 contentSyncPolicyEvaluator,
                 contentPackageManager,
             syncScheduler,
+                collectionRepository,
                 connectivityMonitor
             )
 
@@ -1272,6 +1310,7 @@ class BookmarkListViewModelTest {
                 contentSyncPolicyEvaluator,
                 contentPackageManager,
             syncScheduler,
+                collectionRepository,
                 connectivityMonitor
             )
 
@@ -1336,6 +1375,7 @@ class BookmarkListViewModelTest {
                 contentSyncPolicyEvaluator,
                 contentPackageManager,
             syncScheduler,
+                collectionRepository,
                 connectivityMonitor
             )
 
@@ -1385,6 +1425,7 @@ class BookmarkListViewModelTest {
             contentSyncPolicyEvaluator,
             contentPackageManager,
             syncScheduler,
+            collectionRepository,
             connectivityMonitor
         )
 
@@ -1392,6 +1433,145 @@ class BookmarkListViewModelTest {
         viewModel.onClickLabel(label)
 
         assertEquals(label, viewModel.activeLabel.value)
+    }
+
+    // --- Collections ---
+
+    private fun sampleCollection(
+        id: String = "col-1",
+        name: String = "Tech reads",
+        filter: FilterFormState = FilterFormState(site = "example.com"),
+    ) = Collection(
+        id = id,
+        name = name,
+        isPinned = false,
+        filter = filter,
+        created = kotlinx.datetime.Clock.System.now(),
+        updated = kotlinx.datetime.Clock.System.now(),
+    )
+
+    private fun buildViewModelWithBookmarks() {
+        coEvery { settingsDataStore.isInitialSyncPerformed() } returns false
+        every { bookmarkRepository.observeFilteredBookmarkListItems(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns flowOf(bookmarks)
+        viewModel = createViewModel()
+    }
+
+    @Test
+    fun `onSelectCollection sets selectedCollectionId and applies its filter`() = runTest {
+        val collection = sampleCollection()
+        collectionRepository.collectionsFlow.value = listOf(collection)
+        buildViewModelWithBookmarks()
+        backgroundScope.launch { viewModel.collections.collect {} }
+        advanceUntilIdle()
+
+        viewModel.onSelectCollection(collection.id)
+
+        assertEquals(collection.id, viewModel.selectedCollectionId.value)
+        assertEquals(collection.filter, viewModel.filterFormState.value)
+    }
+
+    @Test
+    fun `onSelectCollection ignores unknown id`() = runTest {
+        buildViewModelWithBookmarks()
+
+        viewModel.onSelectCollection("does-not-exist")
+
+        assertEquals(null, viewModel.selectedCollectionId.value)
+    }
+
+    @Test
+    fun `onClearCollection clears selectedCollectionId`() = runTest {
+        val collection = sampleCollection()
+        collectionRepository.collectionsFlow.value = listOf(collection)
+        buildViewModelWithBookmarks()
+        backgroundScope.launch { viewModel.collections.collect {} }
+        advanceUntilIdle()
+        viewModel.onSelectCollection(collection.id)
+
+        viewModel.onClearCollection()
+
+        assertEquals(null, viewModel.selectedCollectionId.value)
+    }
+
+    @Test
+    fun `onSelectDrawerPreset clears active collection`() = runTest {
+        val collection = sampleCollection()
+        collectionRepository.collectionsFlow.value = listOf(collection)
+        buildViewModelWithBookmarks()
+        backgroundScope.launch { viewModel.collections.collect {} }
+        advanceUntilIdle()
+        viewModel.onSelectCollection(collection.id)
+
+        viewModel.onSelectDrawerPreset(DrawerPreset.ARCHIVE)
+
+        assertEquals(null, viewModel.selectedCollectionId.value)
+    }
+
+    @Test
+    fun `onSaveCurrentFilterAsCollection selects the created collection on success`() = runTest {
+        val created = sampleCollection(id = "new-id")
+        collectionRepository.createResult = Result.success(created)
+        buildViewModelWithBookmarks()
+
+        viewModel.onSaveCurrentFilterAsCollection("My collection")
+        advanceUntilIdle()
+
+        assertEquals("new-id", viewModel.selectedCollectionId.value)
+        assertEquals("My collection", collectionRepository.lastCreateName)
+    }
+
+    @Test
+    fun `onSaveCurrentFilterAsCollection does not select on failure`() = runTest {
+        collectionRepository.createResult = Result.failure(RuntimeException("boom"))
+        buildViewModelWithBookmarks()
+
+        viewModel.onSaveCurrentFilterAsCollection("My collection")
+        advanceUntilIdle()
+
+        assertEquals(null, viewModel.selectedCollectionId.value)
+    }
+
+    @Test
+    fun `onDeleteCollection clears selection when deleting the active collection`() = runTest {
+        val collection = sampleCollection()
+        collectionRepository.collectionsFlow.value = listOf(collection)
+        collectionRepository.deleteResult = Result.success(Unit)
+        buildViewModelWithBookmarks()
+        backgroundScope.launch { viewModel.collections.collect {} }
+        advanceUntilIdle()
+        viewModel.onSelectCollection(collection.id)
+
+        viewModel.onDeleteCollection(collection.id)
+        advanceUntilIdle()
+
+        assertEquals(null, viewModel.selectedCollectionId.value)
+        assertEquals(collection.id, collectionRepository.lastDeletedId)
+    }
+
+    @Test
+    fun `onUpdateActiveCollection updates the active collection with current filter`() = runTest {
+        val collection = sampleCollection()
+        collectionRepository.collectionsFlow.value = listOf(collection)
+        collectionRepository.updateResult = Result.success(collection)
+        buildViewModelWithBookmarks()
+        backgroundScope.launch { viewModel.collections.collect {} }
+        advanceUntilIdle()
+        viewModel.onSelectCollection(collection.id)
+
+        viewModel.onUpdateActiveCollection("Renamed")
+        advanceUntilIdle()
+
+        assertEquals(collection.id, collectionRepository.lastUpdatedId)
+    }
+
+    @Test
+    fun `onUpdateActiveCollection is a no-op when no collection is active`() = runTest {
+        buildViewModelWithBookmarks()
+
+        viewModel.onUpdateActiveCollection("Renamed")
+        advanceUntilIdle()
+
+        assertEquals(null, collectionRepository.lastUpdatedId)
     }
 
     @Test
@@ -1411,6 +1591,7 @@ class BookmarkListViewModelTest {
             contentSyncPolicyEvaluator,
             contentPackageManager,
             syncScheduler,
+            collectionRepository,
             connectivityMonitor
         )
 
@@ -1445,6 +1626,7 @@ class BookmarkListViewModelTest {
             contentSyncPolicyEvaluator,
             contentPackageManager,
             syncScheduler,
+            collectionRepository,
             connectivityMonitor
         )
 
@@ -1473,6 +1655,7 @@ class BookmarkListViewModelTest {
             contentSyncPolicyEvaluator,
             contentPackageManager,
             syncScheduler,
+            collectionRepository,
             connectivityMonitor
         )
 
@@ -2466,4 +2649,42 @@ class BookmarkListViewModelTest {
             published = null
         )
     )
+}
+
+/**
+ * Hand-written fake for [CollectionRepository]. Used instead of a MockK mock because MockK
+ * mishandles suspend functions whose return type is the inline value class [Result], producing a
+ * ClassCastException at the call site.
+ */
+private class FakeCollectionRepository : CollectionRepository {
+    val collectionsFlow = MutableStateFlow<List<Collection>>(emptyList())
+    var refreshResult: Result<Unit> = Result.success(Unit)
+    var createResult: Result<Collection> = Result.failure(NotImplementedError())
+    var updateResult: Result<Collection> = Result.failure(NotImplementedError())
+    var deleteResult: Result<Unit> = Result.success(Unit)
+
+    var lastCreateName: String? = null
+    var lastCreateFilter: FilterFormState? = null
+    var lastUpdatedId: String? = null
+    var lastDeletedId: String? = null
+
+    override fun observeCollections() = collectionsFlow
+
+    override suspend fun refreshCollections(): Result<Unit> = refreshResult
+
+    override suspend fun createCollection(name: String, filter: FilterFormState): Result<Collection> {
+        lastCreateName = name
+        lastCreateFilter = filter
+        return createResult
+    }
+
+    override suspend fun updateCollection(id: String, name: String, filter: FilterFormState): Result<Collection> {
+        lastUpdatedId = id
+        return updateResult
+    }
+
+    override suspend fun deleteCollection(id: String): Result<Unit> {
+        lastDeletedId = id
+        return deleteResult
+    }
 }

--- a/app/src/test/java/com/mydeck/app/ui/list/BookmarkListViewModelTest.kt
+++ b/app/src/test/java/com/mydeck/app/ui/list/BookmarkListViewModelTest.kt
@@ -1575,6 +1575,65 @@ class BookmarkListViewModelTest {
     }
 
     @Test
+    fun `onCreateCollection persists the explicit filter and selects the created collection`() = runTest {
+        val explicitFilter = FilterFormState(author = "Ada")
+        val created = sampleCollection(id = "made-id", filter = explicitFilter)
+        collectionRepository.createResult = Result.success(created)
+        buildViewModelWithBookmarks()
+        backgroundScope.launch { viewModel.collections.collect {} }
+
+        viewModel.onCreateCollection("New one", explicitFilter)
+        advanceUntilIdle()
+
+        assertEquals("New one", collectionRepository.lastCreateName)
+        assertEquals(explicitFilter, collectionRepository.lastCreateFilter)
+        assertEquals("made-id", viewModel.selectedCollectionId.value)
+        assertEquals(explicitFilter, viewModel.filterFormState.value)
+        assertEquals(null, viewModel.activeLabel.value)
+    }
+
+    @Test
+    fun `onCreateCollection does not select on failure`() = runTest {
+        collectionRepository.createResult = Result.failure(RuntimeException("boom"))
+        buildViewModelWithBookmarks()
+
+        viewModel.onCreateCollection("New one", FilterFormState(author = "Ada"))
+        advanceUntilIdle()
+
+        assertEquals(null, viewModel.selectedCollectionId.value)
+    }
+
+    @Test
+    fun `onCreateCollection does not disturb the visible list filter on failure`() = runTest {
+        collectionRepository.createResult = Result.failure(RuntimeException("boom"))
+        buildViewModelWithBookmarks()
+        val before = viewModel.filterFormState.value
+
+        viewModel.onCreateCollection("New one", FilterFormState(author = "Ada"))
+        advanceUntilIdle()
+
+        assertEquals(before, viewModel.filterFormState.value)
+    }
+
+    @Test
+    fun `selectedCollection reflects the active collection and clears on deselect`() = runTest {
+        val collection = sampleCollection()
+        collectionRepository.collectionsFlow.value = listOf(collection)
+        buildViewModelWithBookmarks()
+        backgroundScope.launch { viewModel.collections.collect {} }
+        backgroundScope.launch { viewModel.selectedCollection.collect {} }
+        advanceUntilIdle()
+
+        viewModel.onSelectCollection(collection.id)
+        advanceUntilIdle()
+        assertEquals(collection, viewModel.selectedCollection.value)
+
+        viewModel.onClearCollection()
+        advanceUntilIdle()
+        assertEquals(null, viewModel.selectedCollection.value)
+    }
+
+    @Test
     fun `onRenameLabel calls repository and updates activeLabel if label was active`() = runTest {
         coEvery { settingsDataStore.isInitialSyncPerformed() } returns false
         every { bookmarkRepository.observeFilteredBookmarkListItems(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns flowOf(bookmarks)

--- a/app/src/test/java/com/mydeck/app/ui/list/BookmarkListViewModelTest.kt
+++ b/app/src/test/java/com/mydeck/app/ui/list/BookmarkListViewModelTest.kt
@@ -1508,30 +1508,6 @@ class BookmarkListViewModelTest {
     }
 
     @Test
-    fun `onSaveCurrentFilterAsCollection selects the created collection on success`() = runTest {
-        val created = sampleCollection(id = "new-id")
-        collectionRepository.createResult = Result.success(created)
-        buildViewModelWithBookmarks()
-
-        viewModel.onSaveCurrentFilterAsCollection("My collection")
-        advanceUntilIdle()
-
-        assertEquals("new-id", viewModel.selectedCollectionId.value)
-        assertEquals("My collection", collectionRepository.lastCreateName)
-    }
-
-    @Test
-    fun `onSaveCurrentFilterAsCollection does not select on failure`() = runTest {
-        collectionRepository.createResult = Result.failure(RuntimeException("boom"))
-        buildViewModelWithBookmarks()
-
-        viewModel.onSaveCurrentFilterAsCollection("My collection")
-        advanceUntilIdle()
-
-        assertEquals(null, viewModel.selectedCollectionId.value)
-    }
-
-    @Test
     fun `onDeleteCollection clears selection when deleting the active collection`() = runTest {
         val collection = sampleCollection()
         collectionRepository.collectionsFlow.value = listOf(collection)
@@ -1549,29 +1525,46 @@ class BookmarkListViewModelTest {
     }
 
     @Test
-    fun `onUpdateActiveCollection updates the active collection with current filter`() = runTest {
+    fun `onUpdateCollection persists explicit name and filter and refreshes the active filter`() = runTest {
         val collection = sampleCollection()
+        val savedFilter = FilterFormState(author = "Grace")
+        val saved = sampleCollection(name = "Renamed", filter = savedFilter)
         collectionRepository.collectionsFlow.value = listOf(collection)
-        collectionRepository.updateResult = Result.success(collection)
+        collectionRepository.updateResult = Result.success(saved)
         buildViewModelWithBookmarks()
         backgroundScope.launch { viewModel.collections.collect {} }
+        backgroundScope.launch { viewModel.selectedCollection.collect {} }
         advanceUntilIdle()
         viewModel.onSelectCollection(collection.id)
 
-        viewModel.onUpdateActiveCollection("Renamed")
+        val editedFilter = FilterFormState(author = "Grace")
+        viewModel.onUpdateCollection(collection.id, "Renamed", editedFilter)
         advanceUntilIdle()
 
         assertEquals(collection.id, collectionRepository.lastUpdatedId)
+        assertEquals("Renamed", collectionRepository.lastUpdateName)
+        assertEquals(editedFilter, collectionRepository.lastUpdateFilter)
+        // Active collection's applied filter is refreshed to the persisted (round-tripped) result.
+        assertEquals(savedFilter, viewModel.filterFormState.value)
     }
 
     @Test
-    fun `onUpdateActiveCollection is a no-op when no collection is active`() = runTest {
+    fun `onUpdateCollection does not change the visible filter for a non-active collection`() = runTest {
+        val active = sampleCollection(id = "active", filter = FilterFormState(site = "a.com"))
+        val other = sampleCollection(id = "other")
+        collectionRepository.collectionsFlow.value = listOf(active, other)
+        collectionRepository.updateResult = Result.success(other)
         buildViewModelWithBookmarks()
+        backgroundScope.launch { viewModel.collections.collect {} }
+        advanceUntilIdle()
+        viewModel.onSelectCollection(active.id)
+        val applied = viewModel.filterFormState.value
 
-        viewModel.onUpdateActiveCollection("Renamed")
+        viewModel.onUpdateCollection(other.id, "Other renamed", FilterFormState(title = "x"))
         advanceUntilIdle()
 
-        assertEquals(null, collectionRepository.lastUpdatedId)
+        assertEquals("other", collectionRepository.lastUpdatedId)
+        assertEquals(applied, viewModel.filterFormState.value)
     }
 
     @Test
@@ -2725,6 +2718,8 @@ private class FakeCollectionRepository : CollectionRepository {
     var lastCreateName: String? = null
     var lastCreateFilter: FilterFormState? = null
     var lastUpdatedId: String? = null
+    var lastUpdateName: String? = null
+    var lastUpdateFilter: FilterFormState? = null
     var lastDeletedId: String? = null
 
     override fun observeCollections() = collectionsFlow
@@ -2739,6 +2734,8 @@ private class FakeCollectionRepository : CollectionRepository {
 
     override suspend fun updateCollection(id: String, name: String, filter: FilterFormState): Result<Collection> {
         lastUpdatedId = id
+        lastUpdateName = name
+        lastUpdateFilter = filter
         return updateResult
     }
 

--- a/app/src/test/java/com/mydeck/app/worker/BookmarkMetadataSyncCoordinatorWorkerTest.kt
+++ b/app/src/test/java/com/mydeck/app/worker/BookmarkMetadataSyncCoordinatorWorkerTest.kt
@@ -5,6 +5,7 @@ import androidx.work.Data
 import androidx.work.ListenableWorker
 import androidx.work.WorkerParameters
 import com.mydeck.app.domain.BookmarkRepository
+import com.mydeck.app.domain.CollectionRepository
 import com.mydeck.app.domain.HighlightsRepository
 import com.mydeck.app.domain.sync.BookmarkMetadataSyncCoordinator
 import com.mydeck.app.domain.usecase.FreshnessMarkerUseCase
@@ -206,7 +207,10 @@ class BookmarkMetadataSyncCoordinatorWorkerTest {
             bookmarkRepository = bookmarkRepository,
             settingsDataStore = settingsDataStore,
             highlightsRepository = highlightsRepository,
-            bookmarkMetadataSyncCoordinator = coordinator
+            bookmarkMetadataSyncCoordinator = coordinator,
+            collectionRepository = mockk<CollectionRepository>().also {
+                coEvery { it.refreshCollections() } returns Result.success(Unit)
+            }
         )
     }
 
@@ -235,7 +239,10 @@ class BookmarkMetadataSyncCoordinatorWorkerTest {
             loadBookmarksUseCase = loadBookmarksUseCase,
             freshnessMarkerUseCase = freshnessMarkerUseCase,
             highlightsRepository = highlightsRepository,
-            bookmarkMetadataSyncCoordinator = coordinator
+            bookmarkMetadataSyncCoordinator = coordinator,
+            collectionRepository = mockk<CollectionRepository>().also {
+                coEvery { it.refreshCollections() } returns Result.success(Unit)
+            }
         )
     }
 }

--- a/app/src/test/java/com/mydeck/app/worker/FullSyncWorkerTest.kt
+++ b/app/src/test/java/com/mydeck/app/worker/FullSyncWorkerTest.kt
@@ -6,6 +6,7 @@ import androidx.work.ListenableWorker
 import androidx.work.WorkerParameters
 import com.mydeck.app.domain.BookmarkAnnotationSyncReason
 import com.mydeck.app.domain.BookmarkRepository
+import com.mydeck.app.domain.CollectionRepository
 import com.mydeck.app.domain.HighlightsRefreshReason
 import com.mydeck.app.domain.HighlightsRepository
 import com.mydeck.app.domain.SyncPriority
@@ -60,6 +61,24 @@ class FullSyncWorkerTest {
                 priority = SyncPriority.Normal
             )
         }
+    }
+
+    @Test
+    fun `doWork refreshes collections after a successful sync`() = runTest {
+        val fixture = fixture()
+
+        coEvery { fixture.bookmarkRepository.performDeltaSync(any()) } returns BookmarkRepository.SyncResult.Success(
+            countDeleted = 0,
+            countUpdated = 0,
+            updatedIds = emptyList(),
+            maxServerTime = Clock.System.now()
+        )
+        coEvery { fixture.loadBookmarksUseCase.enqueueContentSyncIfNeeded() } returns Unit
+
+        val result = fixture.worker.doWork()
+
+        assertTrue(result::class == ListenableWorker.Result.success()::class)
+        coVerify(exactly = 1) { fixture.collectionRepository.refreshCollections() }
     }
 
     @Test
@@ -199,6 +218,7 @@ class FullSyncWorkerTest {
         val loadBookmarksUseCase = mockk<LoadBookmarksUseCase>()
         val freshnessMarkerUseCase = mockk<FreshnessMarkerUseCase>()
         val highlightsRepository = mockk<HighlightsRepository>()
+        val collectionRepository = mockk<CollectionRepository>()
 
         coEvery { bookmarkRepository.syncPendingActions() } returns BookmarkRepository.UpdateResult.Success
         coEvery { settingsDataStore.getLastSyncTimestamp() } returns Clock.System.now()
@@ -206,6 +226,7 @@ class FullSyncWorkerTest {
         coEvery { settingsDataStore.saveLastSyncTimestamp(any()) } returns Unit
         coEvery { settingsDataStore.saveLastFullSyncTimestamp(any()) } returns Unit
         coEvery { highlightsRepository.requestRefresh(any()) } returns Result.success(Unit)
+        coEvery { collectionRepository.refreshCollections() } returns Result.success(Unit)
 
         val worker = FullSyncWorker(
             appContext = mockk<Context>(relaxed = true),
@@ -215,7 +236,8 @@ class FullSyncWorkerTest {
             loadBookmarksUseCase = loadBookmarksUseCase,
             freshnessMarkerUseCase = freshnessMarkerUseCase,
             highlightsRepository = highlightsRepository,
-            bookmarkMetadataSyncCoordinator = BookmarkMetadataSyncCoordinator()
+            bookmarkMetadataSyncCoordinator = BookmarkMetadataSyncCoordinator(),
+            collectionRepository = collectionRepository
         )
         return Fixture(
             worker = worker,
@@ -224,6 +246,7 @@ class FullSyncWorkerTest {
             loadBookmarksUseCase = loadBookmarksUseCase,
             freshnessMarkerUseCase = freshnessMarkerUseCase,
             highlightsRepository = highlightsRepository,
+            collectionRepository = collectionRepository,
         )
     }
 
@@ -234,5 +257,6 @@ class FullSyncWorkerTest {
         val loadBookmarksUseCase: LoadBookmarksUseCase,
         val freshnessMarkerUseCase: FreshnessMarkerUseCase,
         val highlightsRepository: HighlightsRepository,
+        val collectionRepository: CollectionRepository,
     )
 }

--- a/app/src/test/java/com/mydeck/app/worker/LoadBookmarksWorkerTest.kt
+++ b/app/src/test/java/com/mydeck/app/worker/LoadBookmarksWorkerTest.kt
@@ -6,6 +6,7 @@ import androidx.work.ListenableWorker
 import androidx.work.WorkerParameters
 import com.mydeck.app.domain.BookmarkAnnotationSyncReason
 import com.mydeck.app.domain.BookmarkRepository
+import com.mydeck.app.domain.CollectionRepository
 import com.mydeck.app.domain.HighlightsRefreshReason
 import com.mydeck.app.domain.HighlightsRepository
 import com.mydeck.app.domain.SyncPriority
@@ -96,7 +97,10 @@ class LoadBookmarksWorkerTest {
             bookmarkRepository = bookmarkRepository,
             settingsDataStore = settingsDataStore,
             highlightsRepository = highlightsRepository,
-            bookmarkMetadataSyncCoordinator = BookmarkMetadataSyncCoordinator()
+            bookmarkMetadataSyncCoordinator = BookmarkMetadataSyncCoordinator(),
+            collectionRepository = mockk<CollectionRepository>().also {
+                coEvery { it.refreshCollections() } returns Result.success(Unit)
+            }
         )
 
         val result = worker.doWork()
@@ -123,6 +127,7 @@ class LoadBookmarksWorkerTest {
         val bookmarkRepository = mockk<BookmarkRepository>()
         val settingsDataStore = mockk<SettingsDataStore>()
         val highlightsRepository = mockk<HighlightsRepository>()
+        val collectionRepository = mockk<CollectionRepository>()
         val updatedIds = listOf("bk-1", "bk-2")
 
         coEvery { settingsDataStore.getLastSyncTimestamp() } returns Instant.parse("2026-03-10T08:00:00Z")
@@ -140,6 +145,7 @@ class LoadBookmarksWorkerTest {
         coEvery { settingsDataStore.saveLastSyncTimestamp(any()) } returns Unit
         coEvery { settingsDataStore.isInitialSyncPerformed() } returns true
         coEvery { highlightsRepository.requestRefresh(any()) } returns Result.success(Unit)
+        coEvery { collectionRepository.refreshCollections() } returns Result.success(Unit)
         coEvery {
             highlightsRepository.requestBookmarkAnnotationChecks(
                 bookmarkIds = updatedIds,
@@ -155,7 +161,8 @@ class LoadBookmarksWorkerTest {
             bookmarkRepository = bookmarkRepository,
             settingsDataStore = settingsDataStore,
             highlightsRepository = highlightsRepository,
-            bookmarkMetadataSyncCoordinator = BookmarkMetadataSyncCoordinator()
+            bookmarkMetadataSyncCoordinator = BookmarkMetadataSyncCoordinator(),
+            collectionRepository = collectionRepository
         )
 
         val result = worker.doWork()
@@ -172,6 +179,7 @@ class LoadBookmarksWorkerTest {
         coVerify(exactly = 1) {
             highlightsRepository.requestRefresh(HighlightsRefreshReason.APP_OPEN)
         }
+        coVerify(exactly = 1) { collectionRepository.refreshCollections() }
     }
 
     @Test
@@ -209,7 +217,10 @@ class LoadBookmarksWorkerTest {
             bookmarkRepository = bookmarkRepository,
             settingsDataStore = settingsDataStore,
             highlightsRepository = highlightsRepository,
-            bookmarkMetadataSyncCoordinator = BookmarkMetadataSyncCoordinator()
+            bookmarkMetadataSyncCoordinator = BookmarkMetadataSyncCoordinator(),
+            collectionRepository = mockk<CollectionRepository>().also {
+                coEvery { it.refreshCollections() } returns Result.success(Unit)
+            }
         )
 
         val result = worker.doWork()
@@ -275,7 +286,10 @@ class LoadBookmarksWorkerTest {
             bookmarkRepository = bookmarkRepository,
             settingsDataStore = settingsDataStore,
             highlightsRepository = highlightsRepository,
-            bookmarkMetadataSyncCoordinator = BookmarkMetadataSyncCoordinator()
+            bookmarkMetadataSyncCoordinator = BookmarkMetadataSyncCoordinator(),
+            collectionRepository = mockk<CollectionRepository>().also {
+                coEvery { it.refreshCollections() } returns Result.success(Unit)
+            }
         )
 
         val result = worker.doWork()

--- a/docs/specs/collections-feature-design.md
+++ b/docs/specs/collections-feature-design.md
@@ -8,7 +8,9 @@
 
 ## Overview
 
-Collections allow users to save named sets of filter criteria as persistent, server-side entities. When selected from the sidebar drawer, the bookmark list updates to show only bookmarks matching those saved filters. Collections are managed server-side via the Readeck API and cached locally in Room for offline availability and reactive UI updates.
+Collections allow users to save named sets of filter criteria as persistent, server-side entities. Users browse and create them on a dedicated **Collections screen** (reached from a "Collections" entry in the navigation drawer's Tools group), and selecting one opens the bookmark list as an **active-collection view** showing only bookmarks matching those saved filters. A single collection may also be surfaced as a custom view selector in the drawer/rail (see the Navigation Settings spec). Collections are managed server-side via the Readeck API and cached locally in Room for offline availability and reactive UI updates.
+
+> **UI note (2026-06-28):** This document's original UI sketch placed collections as an inline list inside the navigation drawer with per-item actions (including Duplicate). That was superseded by the screen-based design below, agreed with the maintainer. The data / repository / ViewModel layers (slice C1) are unaffected; only the UI sections changed. See `collections-nav-rollout-plan.md` §11.
 
 ---
 
@@ -39,6 +41,10 @@ Collection logic goes into a dedicated `CollectionRepository` rather than extend
 ### 5. Pagination
 
 The `GET /bookmarks/collections` endpoint supports pagination via `limit`/`offset`. The refresh implementation should page through all results (e.g. 100 per page) and replace the local cache atomically.
+
+### 6. UI: dedicated Collections screen, not an inline drawer list
+
+Collections are browsed and created on a dedicated **Collections screen** modeled on the Highlights screen, reached from a single **"Collections"** entry in the drawer's Tools group (below Highlights). The selected-collection state on the main list mirrors the **active-label list view** (collection name as the app-bar title + a leading icon, no chips for the collection's own criteria). There is **no** inline drawer list of collections and **no Duplicate action**. Create and edit share one unified **collection editor sheet**. See "UI Components".
 
 ---
 
@@ -293,10 +299,10 @@ val collections: StateFlow<List<Collection>> = collectionRepository
 
 fun onSelectCollection(collectionId: String) {
     val collection = collections.value.find { it.id == collectionId } ?: return
-    _selectedCollectionId.value = collectionId
-    _drawerPreset.value = null
+    _selectedCollectionId.value = collectionId   // discriminator; drives the active-collection view
     _filterFormState.value = collection.filter
-    // Close drawer, trigger list refresh
+    // navigate to the main list; app bar shows the collection name + leading icon
+    // (no _drawerPreset = null — _drawerPreset is non-nullable; see rollout-plan §11. As built in C1.)
 }
 
 fun onClearCollection() {
@@ -335,47 +341,54 @@ fun onDeleteCollection(id: String) {
 
 ## UI Components
 
-### `AppDrawerContent.kt` — Collections Section
+The collections UI reuses two existing app patterns: the **Highlights screen** (browsing/creating) and the **active-label list view** (the selected-collection state). Collections are **not** rendered inline in the navigation drawer.
 
-Add a "Collections" section below the existing Labels section. The section should:
+### Navigation drawer / rail — "Collections" entry
 
-- Show a "Collections" header with a trailing `+` `IconButton` to trigger collection creation.
-- Display each collection as a `NavigationDrawerItem`. Pinned collections render with a pin indicator.
-- Highlight the item when `selectedCollectionId == collection.id`.
-- Show a `MoreVert` icon button per item (or support long-press) that opens a dropdown menu with:
-  - **Edit** — opens filter sheet pre-filled with the collection's filter, and on Apply calls `onUpdateActiveCollection`.
-  - **Duplicate** — calls `onSaveCurrentFilterAsCollection` with a copy of the collection's filter.
-  - **Delete** — shows confirmation dialog, then calls `onDeleteCollection`.
+Add a single **"Collections"** item to the drawer's **Tools** group, directly below **Highlights** (a single entry, like Highlights and Labels — not an expanded list). Selecting it navigates to the Collections screen. The same entry appears in the wide-layout navigation rail. (For this branch the entry is added to the existing static drawer/rail; the Navigation Settings feature later makes the drawer/rail data-driven.)
 
-The composable receives collections data and callbacks via its existing parameter pattern.
+### Collections screen
 
-```kotlin
-// Sketch of new section within AppDrawerContent
-if (collections.isNotEmpty()) {
-    Divider()
-    CollectionsSectionHeader(onCreateClick = onCreateCollection)
-    collections.forEach { collection ->
-        CollectionDrawerItem(
-            collection = collection,
-            selected = selectedCollectionId == collection.id,
-            onSelect = { onSelectCollection(collection.id) },
-            onEdit = { onEditCollection(collection.id) },
-            onDuplicate = { onDuplicateCollection(collection.id) },
-            onDelete = { onDeleteCollection(collection.id) },
-        )
-    }
-}
-```
+A dedicated screen (route + screen + state, modeled on the Highlights screen):
 
-### Filter Bottom Sheet — "Save as Collection"
+- Each collection renders as a **card** showing the **name** and **created date/time** only — no per-card action icons (parity with Highlights cards).
+- **Tap a card** → `onSelectCollection(id)`; navigate to the main bookmark list as the active-collection view (below).
+- A **FAB** ("New Collection") opens the **collection editor sheet** (empty) to compose and save a new collection.
+- **Empty state** (M3 pattern) when there are no collections, inviting creation via the FAB.
+- Future / out of scope for v1: sort/filter controls in the app bar — the screen reserves app-bar space for these, which is why create is a FAB rather than an app-bar action.
 
-Add a **"Save as Collection"** outlined button at the bottom of `FilterBottomSheet.kt`, between the Reset and Apply buttons. It is only enabled when `filterFormState.hasActiveFilters()`. Pressing it opens a `AlertDialog` with a name `TextField` and a Confirm button.
+### Active-collection view (main bookmark list)
 
-### `BookmarkListScreen` — Active Collection Banner
+When a collection is selected, the main list mirrors the **active-label list view**:
 
-When `selectedCollectionId != null`, render a `SuggestionChip` or `AssistChip` below the `FilterBar` row showing the collection name. The chip has two trailing icon buttons:
-- ✏️ **Edit**: opens the filter sheet, allowing filter modification and save.
-- 🗑 **Delete**: shows confirmation, then calls `onDeleteCollection`.
+- The **top app bar** shows the **collection name as the title** with a **leading icon** to its left (same treatment as a label-filtered list). All other app-bar actions and overflow items mirror the normal list.
+- **No filter chips** are shown for the collection's own criteria — an active collection reads as an ordinary list view.
+- If the user **applies an additional filter** on top of the active collection, those **added criteria render as chips** (the collection stays the active view; the app-bar title remains the collection name). The saved collection is unchanged until explicitly saved.
+- While a collection is active, the **overflow menu** gains **Edit collection** and **Delete collection**:
+  - **Edit collection** → opens the editor sheet pre-filled with the **combined** filter (the collection's saved criteria + any currently-applied additional filter) and the existing name.
+  - **Delete collection** → confirmation dialog → `onDeleteCollection(id)`.
+
+### Collection editor sheet (unified create + edit)
+
+A single reusable sheet = the filter-criteria controls (reusing `FilterBottomSheet`'s controls) **plus a name `TextField` at the top**. Three entry points:
+
+| Entry point | Pre-fill | Buttons |
+|---|---|---|
+| FAB (Collections screen) | empty criteria, blank name | Save / Cancel |
+| Main-list overflow "Save as Collection" (filter active, no collection selected) | current filter, blank name | Save / Cancel |
+| Overflow "Edit collection" (collection active) | combined filter + existing name | Save / Delete (+ Cancel) |
+
+- **Save**, no active collection → `onSaveCurrentFilterAsCollection(name)` (create).
+- **Save**, editing → `onUpdateActiveCollection(name)` (persists the combined filter under the name; **rename is supported** via the name field).
+- **Delete** (edit mode) → confirmation → `onDeleteCollection(id)`.
+- Save is disabled until the name is non-blank.
+
+### Main-list overflow — create entry
+
+The main-list overflow is a small state machine:
+- **no collection + active filter** → show **"Save as Collection"** (opens the editor sheet pre-filled with the current filter).
+- **no collection + no filter** → nothing (create lives on the Collections screen FAB).
+- **collection active** → show **Edit collection** + **Delete collection** (never "Save as Collection").
 
 ---
 
@@ -384,16 +397,19 @@ When `selectedCollectionId != null`, render a `SuggestionChip` or `AssistChip` b
 Add to `app/src/main/res/values/strings.xml` and all language files per `CLAUDE.md`:
 
 ```xml
-<string name="collections_section_header">Collections</string>
-<string name="collection_create_button">New Collection</string>
+<string name="collections_drawer_item">Collections</string>
+<string name="collections_screen_title">Collections</string>
+<string name="collection_create_fab">New Collection</string>
 <string name="collection_name_hint">Collection name</string>
-<string name="collection_save_filter_button">Save as Collection</string>
-<string name="collection_edit_action">Edit</string>
-<string name="collection_duplicate_action">Duplicate</string>
-<string name="collection_delete_action">Delete</string>
-<string name="collection_delete_confirm_title">Delete Collection?</string>
+<string name="collection_editor_save">Save</string>
+<string name="collection_save_as_action">Save as Collection</string>
+<string name="collection_edit_action">Edit collection</string>
+<string name="collection_delete_action">Delete collection</string>
+<string name="collection_delete_confirm_title">Delete collection?</string>
 <string name="collection_delete_confirm_message">"%s" will be permanently deleted.</string>
-<string name="collection_active_label">Collection: %s</string>
+<string name="collections_empty_title">No collections yet</string>
+<string name="collections_empty_message">Save a filter as a collection to see it here.</string>
+<string name="collection_save_error">Failed to save collection</string>
 <string name="collection_update_error">Failed to update collection</string>
 <string name="collection_delete_error">Failed to delete collection</string>
 <string name="collection_load_error">Failed to load collections</string>
@@ -424,8 +440,8 @@ Add to `app/src/main/res/values/strings.xml` and all language files per `CLAUDE.
 7. **Repository impl** — Implement `CollectionRepositoryImpl` using DAO + API.
 8. **DI** — Add Hilt bindings for `CollectionRepository` in the appropriate `@Module`.
 9. **ViewModel** — Inject `CollectionRepository` into `BookmarkListViewModel`; add state and functions.
-10. **`AppDrawerContent`** — Add Collections section with full CRUD UI.
-11. **`FilterBottomSheet`** — Add "Save as Collection" button.
-12. **`BookmarkListScreen`** — Add active-collection banner chip.
-13. **String resources** — Add all new strings to all 10 locale files.
-14. **Tests** — Unit tests for adapter, DAO queries, `CollectionRepositoryImpl`, and `BookmarkListViewModel` collection logic.
+10. **Drawer/rail "Collections" entry + Collections screen** *(Slice C2)* — add the Tools-group "Collections" item (below Highlights) to `AppDrawerContent` (Compact + Expanded) and `AppNavigationRailContent`; build the Collections screen (route + screen + state) with name/created cards, FAB, and empty state; tap → `onSelectCollection` → active-collection view.
+11. **Active-collection view** *(Slice C3)* — main-list app-bar title + leading icon mirroring the active-label view; chips for filters added on top of a collection; overflow **Edit collection** / **Delete collection**.
+12. **Collection editor sheet + main-list "Save as Collection"** *(Slice C3)* — unified create/edit sheet (filter controls + name field; Save / Delete); main-list overflow "Save as Collection" when a filter is active and no collection is selected.
+13. **String resources** — add all new strings to all 10 locale files (distributed into C2/C3 as each is needed).
+14. **Tests** — adapter, DAO queries, `CollectionRepositoryImpl`, `BookmarkListViewModel` collection logic, plus the editor-sheet / active-collection state logic. (No Duplicate.)

--- a/docs/specs/collections-feature-design.md
+++ b/docs/specs/collections-feature-design.md
@@ -81,9 +81,9 @@ data class Collection(
 | `progress` (`Set<ProgressFilter>`) | `read_status` (`List<String>`) | `ProgressFilter` enum → `"unread"` / `"reading"` / `"read"` |
 | `isFavorite`            | `is_marked`      | Nullable Boolean passthrough                                        |
 | `isArchived`            | `is_archived`    | Nullable Boolean passthrough                                        |
-| `isLoaded`              | _(no equivalent)_ | **Omit when persisting; default `null` when loading**              |
-| `withLabels`            | _(no equivalent)_ | **Omit when persisting; default `null` when loading**              |
-| `withErrors`            | _(no equivalent)_ | **Omit when persisting; default `null` when loading**              |
+| `isLoaded` ("Downloaded")| _(no equivalent)_ | **Device-local** (content persisted on device). The server's `is_loaded` is a *different* concept (server-side fetch), so there is no collection equivalent — omit on persist, `null` on load, and **hide its control in the collection editor sheet**. The device-local "available offline" need is served by the Nav spec's Offline Content view, not by collections. |
+| `withLabels`            | `has_labels`     | Nullable Boolean passthrough. **Server-supported — confirmed round-trip** (overturns the original "no equivalent" claim). |
+| `withErrors`            | `has_errors`     | Nullable Boolean passthrough. **Server-supported — confirmed round-trip** (overturns the original "no equivalent" claim). |
 
 Add the adapter as extension functions in a new file `domain/model/CollectionFilterAdapter.kt`:
 

--- a/docs/specs/collections-nav-rollout-plan.md
+++ b/docs/specs/collections-nav-rollout-plan.md
@@ -1,0 +1,238 @@
+# Collections + Navigation Settings — Consolidated Rollout Plan
+
+**Date:** 2026-06-27
+**Coordinator thread:** this document is produced and maintained by the coordinator session.
+**Target release:** MyDeck **v0.15.0** (headline: Collections). Port to Readeck for Android **v1.1.0** later.
+**Source specs:**
+- `docs/specs/collections-feature-design.md` (ships first)
+- `docs/specs/navigation-settings-spec.md` (depends on Collections; ships second)
+- `docs/porting/mydeck-readeck-port.md` (port harness; per-feature checklist built post-merge)
+
+---
+
+## 1. Purpose
+
+A single, sequenced execution plan for rolling out Collections and then Navigation
+Settings with engineering rigor and tight agent-usage efficiency. It defines:
+
+- the **slice sequence** for each spec,
+- the **six-phase cycle** every slice runs through,
+- the **branch / PR model**,
+- the **thread + sub-agent model** (how work is dispatched to keep the coordinator lean), and
+- the **rebase protocol** for absorbing intervening hotfixes that may land on `main` first.
+
+This plan is intentionally process-heavy because either feature may have to merge *on top of*
+an unplanned hotfix before it ships.
+
+---
+
+## 2. Sequencing & dependencies
+
+1. **Collections first.** `feat/collections` → PR → merge to `main`.
+2. **Navigation Settings second.** `feat/navigation-settings`, branched from `main` **after**
+   Collections merges. Nav hard-depends on Collections runtime API
+   (`CollectionRepository.observeCollections()`, `BookmarkListViewModel.onSelectCollection(id)`,
+   the `Collection` domain model). Do **not** start Nav coding against an unmerged Collections branch.
+
+The hard ordering is non-negotiable and is stated in the Nav spec's header.
+
+---
+
+## 3. Branch & PR model
+
+- **One feature branch per spec doc**, branched from freshly-pulled `main`:
+  - `feat/collections`
+  - `feat/navigation-settings` (cut only after Collections merges)
+- The **coordinator creates each feature branch** before handing off the first slice prompt for it.
+- Each **slice is committed** on the feature branch after its tests pass and the user signs off on
+  the interactive check (focused, well-scoped commits).
+- At branch end the coordinator + user **prepare the PR together**; the **user pushes and opens/merges
+  the PR** (per repo rule: state-changing git/GitHub actions are proposed, not executed by agents).
+- `gh` is for read-only inspection only, and always with `--repo NateEaton/mydeck-android`.
+
+---
+
+## 4. Thread & sub-agent model (efficiency)
+
+**Coordinator (this thread):** stays lean — plans, cuts branches, hands off kickoff prompts, runs the
+per-branch check-ins and PR prep. Does **not** do the bulk implementation reading/coding itself.
+
+**Grouped threads (3 total).** Each thread is a fresh Claude Code session the user starts in this
+working copy, on the branch the coordinator already created. Each thread runs **multiple slices** with a
+commit + user check-in at every commit point:
+
+| Thread | Branch | Slices |
+|--------|--------|--------|
+| **T1 — Collections backend** | `feat/collections` | C1 (data + repository + ViewModel) |
+| **T2 — Collections UI** | `feat/collections` | C2 (drawer section), C3 (filter-sheet save + active banner) |
+| **T3 — Navigation Settings** | `feat/navigation-settings` | N1 (data-driven refactor), N2 (model + offline + navItems), N3 (settings screen) |
+
+**Sub-agent usage inside each thread (mandated in the kickoff prompt):** the thread's lead agent
+delegates fan-out and mechanical work to **Sonnet or Haiku** sub-agents — e.g. scouting the codebase
+(grep/ls before reads), propagating strings across the 10 locale files, writing repetitive unit tests,
+and the light per-slice self-review. The lead agent reserves itself for design judgment, integration,
+and the user check-ins. This keeps Opus tokens focused.
+
+If a thread's context gets heavy (esp. T3), the coordinator may split it into a follow-on thread at a
+commit boundary rather than letting one session bloat.
+
+---
+
+## 5. The standard per-slice cycle (six phases)
+
+Every slice runs these phases in order. Phases 4 (interactive) and 6's depth scale to the slice.
+
+1. **Design review.** Lead agent reads only the relevant spec section, then **scouts before reading**
+   (grep/ls) to confirm current code shape. Surfaces any spec↔code mismatch to the user **before**
+   coding (e.g. the Offline DAO must match the real list-source type — `@RawQuery`+`FilterFormState`
+   vs `PagingSource`; confirm, don't assume). Drops inline **port-divergence flags** where package
+   names, flavors, channel ids, branding, or DB version numbers will need transforming for the port.
+2. **Coding.** Implement following existing patterns. New strings → `values/strings.xml` **and all 9
+   locale files** with English placeholders. User-visible changes → update the English user-guide files.
+3. **Automated batch tests.** Write/extend unit tests for the slice. Run the aggregate suite (§7).
+4. **Interactive testing (user).** Only where there's a user-facing surface. The agent gives the user
+   **concrete, numbered manual steps** and offers a device build via `./scripts/install-phone.sh`
+   (Pixel 9). User runs on device and reports. Backend-only slices skip this.
+5. **Verification cycle.** Re-run the three aggregate gradle tasks green (§7). Confirm **no DB migration
+   version drift** (§8) and no lint/string-coverage regressions.
+6. **Code review cycle (light, per-slice).** A Sonnet sub-agent reviews the slice diff against the spec
+   section for correctness, reuse, and pattern-fit. Address findings. **Commit** after green + user
+   sign-off.
+
+**Per-branch deep review (hybrid model).** Once, at the end of each feature branch and before PR prep,
+the **user runs `/code-review ultra`** (the coordinator cannot trigger it). This catches cross-slice
+issues in one pass. Findings are triaged with the coordinator, fixed, re-verified, then PR prep.
+
+---
+
+## 6. Slice breakdown
+
+### Branch 1 — `feat/collections`
+
+Source: `docs/specs/collections-feature-design.md` (its §"Implementation Sequence" steps 1–14).
+
+**Slice C1 — Data + repository + ViewModel (spec steps 1–9).** Backend only; no interactive surface.
+- DTOs (`CollectionDto`, `CreateCollectionDto`/`UpdateCollectionDto`), four `ReadeckApi` methods.
+- `Collection` domain model + `CollectionFilterAdapter` (bi-directional, with the field-mapping table —
+  note the local-only `isLoaded`/`withLabels`/`withErrors` are dropped on persist, null on load).
+- Room: `CollectionEntity`, `CollectionDao`, **DB v7→v8 + `MIGRATION_7_8`**, exported schema JSON,
+  migration test.
+- `CollectionRepository` interface + impl (paginate refresh, atomic cache replace; soft-delete via
+  PATCH `is_deleted=true`). Hilt binding.
+- `BookmarkListViewModel`: inject repo; add `selectedCollectionId`, `collections`, and the
+  create/update/delete/select/clear/refresh functions.
+- **Tests:** adapter round-trip, DAO queries, repo impl (success + error paths), VM collection logic.
+- **Interactive:** none (covered by unit tests). Phase 4 skipped.
+
+**Slice C2 — Drawer Collections section (spec step 10 + strings).**
+- `AppDrawerContent` Collections section: header + `+` create, per-item `NavigationDrawerItem` with
+  pin indicator, selected highlight, overflow menu (Edit / Duplicate / Delete + confirm dialog).
+- Wire create/select/edit/duplicate/delete callbacks through `AppShell`.
+- Strings for the section (10 locale files).
+- **Interactive:** create a collection, select it (list filters), edit, duplicate, delete (+ confirm).
+
+**Slice C3 — Filter-sheet save + active-collection banner (spec steps 11–12 + strings + docs).**
+- `FilterBottomSheet`: "Save as Collection" outlined button (enabled only when
+  `hasActiveFilters()`), name dialog.
+- `BookmarkListScreen`: active-collection chip/banner below the FilterBar with edit + delete actions.
+- Strings (10 files) + user-guide updates (`your-bookmarks.md`, and `reading.md`/`organising.md` only
+  if behavior there changes).
+- **Interactive:** apply a filter → Save as Collection → confirm it appears + selects; banner edit/delete.
+
+> Note: spec lists "strings" and "tests" as terminal steps 13–14; this plan distributes them into each
+> slice (strings/docs/tests land with the code that needs them), which is the lint- and review-safe order.
+
+### Branch 2 — `feat/navigation-settings`
+
+Source: `docs/specs/navigation-settings-spec.md` (its §"Implementation Sequence" steps 1–9).
+Cut **after** Collections merges.
+
+**Slice N1 — Data-driven drawer/rail refactor (spec step 1). Riskiest; lands first, no behavior change.**
+- Introduce `NavItem`; convert `AppDrawerContent` + `AppNavigationRailContent` + `AppShell` to render
+  from a `List<NavItem>` with a single `onSelect`, built from a hardcoded default that **reproduces
+  today's drawer exactly**.
+- **Interactive:** strict visual/behavioral **parity check** vs current build (drawer + wide-layout rail).
+- Commit only after parity is confirmed on device.
+
+**Slice N2 — Model + persistence + Offline view + navItems builder (spec steps 2–4).**
+- `NavView` enum, `NavigationSettings` (+ `DEFAULT` reproducing today's drawer), `SettingsDataStore`
+  JSON persistence with **tolerant deserialization** (unknown enums dropped, missing views default —
+  port-safety).
+- `DrawerPreset.OFFLINE`; offline DAO query (match the real list-source type — confirm in design review);
+  `onSelectOfflineView()`; list-source branch.
+- `navItems` builder in `BookmarkListViewModel` (group order, visibility filter, custom-view label =
+  collection name, selection marking, deleted-collection → MY_LIST fallback).
+- **Tests:** (de)serialization incl. dropping unknown/missing `NavView`; offline DAO (archived-with-
+  package included, archive state ignored); navItems builder ordering/visibility/fallback.
+- **Interactive:** light — enable offline view via a temporary hook or once N3 exists; primarily unit-tested.
+
+**Slice N3 — Navigation settings screen (spec steps 5–8).**
+- `NavigationSettingsRoute` + `NavigationSettingsScreen` + `NavigationSettingsViewModel` (UiSettings*
+  pattern), `SettingsScreen` entry `ListItem`.
+- Toggles with **min-one-standard-view** enforcement, within-group reorder, custom-view switch +
+  `ExposedDropdownMenu` (+ empty-state "Add a collection…"), Offline switch.
+- **Back-navigation** from "Add a collection…" → Collections → back to Nav settings (explicit
+  `popUpTo`/return-route; keep explicit for the port).
+- **Long-name handling** (ellipsis + full `contentDescription`) in dropdown + drawer/rail row.
+- Strings (10 files) + user-guide (`settings.md` new Navigation section; `your-bookmarks.md` note).
+- **Interactive:** toggle/reorder views, custom view selection + empty-state add-collection round-trip,
+  offline view shows packaged bookmarks incl. archived, long-name ellipsis.
+
+---
+
+## 7. Verification commands (every slice, phase 5)
+
+```
+./gradlew :app:assembleDebugAll
+./gradlew :app:testDebugUnitTestAll
+./gradlew :app:lintDebugAll
+```
+
+Device build/install for interactive phases: `./scripts/install-phone.sh` (Pixel 9, wireless ADB).
+
+---
+
+## 8. Rebase / intervening-hotfix protocol
+
+A hotfix may land on `main` before either branch merges. The protocol:
+
+- **Highest-risk collision = the DB migration.** Collections bumps DB **v7→v8** with `MIGRATION_7_8`.
+  If an intervening fix also bumps the DB version, renumber the Collections migration to the new
+  `vN→vN+1`, regenerate the exported schema JSON for the new version, and re-run the migration test.
+  The migration is isolated within C1 specifically to make this renumber cheap.
+- When `main` moves, **rebase the feature branch on the new `main`** (coordinator proposes the commands;
+  user runs pushes/force-pushes). Re-run §7 verification after any rebase.
+- Nav's only schema-ish change is `DrawerPreset.OFFLINE` (an enum value, no migration) — low rebase risk.
+- After any rebase, re-confirm string-coverage lint (intervening fixes may add strings to the locale set).
+
+---
+
+## 9. Localization & documentation obligations (every slice)
+
+- New strings → `values/strings.xml` **and** all 9 locale folders (de, es, fr, gl, pl, pt, ru, uk,
+  zh-rCN) with English placeholders. The lint check enforces full coverage.
+- User-visible features → English user-guide files in `app/src/main/assets/guide/en/`
+  (`your-bookmarks.md`, `settings.md`, `reading.md`, `organising.md` as applicable), updated in the
+  same slice/commit as the code.
+
+---
+
+## 10. Porting (deferred artifacts; inline flags now)
+
+Per the user's decision and methodology §8, the **port spec + port agent prompt are built after each
+source PR merges**, finalized against shipped code. During coding, slice agents **must leave inline
+port-divergence flags** (package root, flavor/variant task names, notification channel ids, branding
+strings/assets, DB version numbers, locale set) so the post-merge checklist can be seeded from fresh,
+accurate markers. The port itself runs **in the Readeck repo (TARGET)** following the §6 procedure and
+§5 migration-renumber rule; do not hard-code the "MyDeck" brand anywhere that blocks the port.
+
+---
+
+## 11. Kickoff prompt template (coordinator → slice thread)
+
+The coordinator delivers a concrete prompt per thread (not all at once), as raw markdown for the user to
+paste into a fresh session. Each prompt includes: repo + branch (already created), the spec doc + exact
+sections for the thread's slices, the six-phase cycle, the §7 verify commands, the sub-agent mandate
+(Sonnet/Haiku for scouting/strings/repetitive tests/light review), the port-flag instruction, the
+localization/docs obligations, and **explicit stop-and-check-in at every commit point** (do not plow
+through multiple slices without the user's interactive sign-off).

--- a/docs/specs/collections-nav-rollout-plan.md
+++ b/docs/specs/collections-nav-rollout-plan.md
@@ -228,7 +228,43 @@ accurate markers. The port itself runs **in the Readeck repo (TARGET)** followin
 
 ---
 
-## 11. Kickoff prompt template (coordinator → slice thread)
+## 11. Spec drift reconciliation (living — confirmed against current code)
+
+The specs predate the current codebase by several schema versions. Confirmed deltas (verified, do
+not re-litigate per thread):
+
+**C1 (confirmed against code + `docs/openapi-spec.json`):**
+- **DB version:** spec's "v7→v8 / `MIGRATION_7_8`" is stale — current DB is **v17**
+  (`MyDeckDatabase.kt:25`) and `MIGRATION_7_8` already exists. Implement **v17→v18 / `MIGRATION_17_18`**,
+  register in `DatabaseModule.kt`, generate `app/schemas/.../18.json`, write a `migrate17To18` test.
+  (Port flag: DB version number — renumbers again for the Readeck port per §8/methodology §5.)
+- **Serialization:** project uses **kotlinx.serialization** (`@Serializable`/`@SerialName`,
+  `explicitNulls=false`), not Gson `@SerializedName`. Write DTOs like `EditBookmarkDto.kt`; sparse
+  Create/Patch bodies fall out of `explicitNulls=false`.
+- **FilterFormState local-only fields:** beyond the spec's `isLoaded`/`withLabels`/`withErrors`, the
+  model now also has `minReadingTime`, `maxReadingTime`, `includeNullReadingTime`, `minWordCount`,
+  `maxWordCount`, `includeNullWordCount` — no `CollectionDto` equivalents. Treat all as local-only
+  (dropped on persist, default on load). Saved collections won't preserve reading-time/word-count filters.
+- **`onSelectCollection` discriminator:** `_drawerPreset` is non-nullable (`MutableStateFlow<DrawerPreset>`,
+  defaults `MY_LIST`). Use `selectedCollectionId != null` as the discriminator; do not assign
+  `_drawerPreset = null` (won't compile). Drawer visual deselect is a C2 concern.
+- **Create-id mechanism (verified via OpenAPI):** `POST /bookmarks/collections` → **201 + `Location`
+  header**; body is only the generic `message` schema (no id, no object); no custom header. Keep POST
+  typed `Response<StatusMessageDto>`; read `Location`, take the trailing path segment, then
+  `getCollectionById(id)` to hydrate + cache. Add a `LOCATION = "location"` constant to
+  `ReadeckApi.Header` (alongside `bookmark-id`, `total-pages`, …).
+
+**Anchors downstream threads (C2/C3/N1/N2/N3) must verify in their own design-review phase** (the
+per-slice design review is demonstrably catching drift, so we verify at slice start rather than in one
+upfront pass): current `DrawerPreset` enum values; `AppDrawerContent` / `AppNavigationRailContent` /
+`AppShell` callback surface; the **list-source type** the standard query uses (`@RawQuery`+`FilterFormState`
+vs `PagingSource`) — this gates N2's offline query design; the `SettingsDataStore` JSON-persistence
+pattern; and whether `BookmarkCounts` already exposes an archive-inclusive offline-content total for the
+N2 badge.
+
+---
+
+## 12. Kickoff prompt template (coordinator → slice thread)
 
 The coordinator delivers a concrete prompt per thread (not all at once), as raw markdown for the user to
 paste into a fresh session. Each prompt includes: repo + branch (already created), the spec doc + exact

--- a/docs/specs/collections-nav-rollout-plan.md
+++ b/docs/specs/collections-nav-rollout-plan.md
@@ -284,6 +284,24 @@ N2 badge.
 
 ---
 
+**Collection filter fields — final mapping (2026-06-28, verified against the live server):**
+- `withErrors → has_errors` and `withLabels → has_labels` **are server-supported** and round-trip
+  (maintainer created native-UI collections; both returned `true`). They were dropped in error by C1's
+  original "no API equivalent" reading. **Add these two** Boolean columns to the DTOs/entity/adapter;
+  amend `MIGRATION_17_18` + `18.json` in place (C1 unmerged — no new migration version).
+- The app's **"Downloaded"** filter is **device-local** (content persisted on device) and is **excluded**
+  from collections. The server's `is_loaded` is a *different* concept (server-side fetch), so there is no
+  collection equivalent — treat the device field as local-only (drop on persist) and **hide its control
+  in the collection editor sheet**. (Verify which `FilterFormState` field backs the "Downloaded" control;
+  the original spec called it `isLoaded`.)
+- The 6 reading-time/word-count fields stay local-only/dropped (not in the API vocabulary).
+- The device-local "available offline" need is already covered by the **Navigation Settings spec** — its
+  predefined **Offline Content view** (`NavView.OFFLINE`, default off, user-enableable) plus the **custom
+  collection view** (`NavView.CUSTOM`). No new spec work; a mobile-only collection field would require a
+  future server enhancement and is out of scope.
+
+---
+
 ## 12. Kickoff prompt template (coordinator → slice thread)
 
 The coordinator delivers a concrete prompt per thread (not all at once), as raw markdown for the user to

--- a/docs/specs/collections-nav-rollout-plan.md
+++ b/docs/specs/collections-nav-rollout-plan.md
@@ -264,6 +264,26 @@ N2 badge.
 
 ---
 
+**C2/C3 UI model (2026-06-28 — supersedes the Collections spec's original drawer-section UI; specs now updated to match):**
+- Collections are **not** an inline drawer list. A single **"Collections"** item in the Tools group
+  (below Highlights) opens a dedicated **Collections screen** — Highlights-style cards (name + created
+  date/time, no per-card actions), a **FAB** to create, tap a card → active-collection view.
+- **Active-collection view** mirrors the **active-label list view**: collection name as the app-bar
+  title + leading icon, no chips for the collection's own criteria. Filters added on top render as
+  chips. Overflow gains **Edit collection** / **Delete collection** while a collection is active.
+- **Unified collection editor sheet** = filter controls + name field. Entry points: FAB (empty);
+  main-list overflow **"Save as Collection"** (filter active, no collection selected; pre-filled);
+  **Edit collection** (combined filter + existing name; Save + Delete). **Rename is supported** via the
+  name field.
+- **Duplicate: dropped** — no `onDuplicateCollection`. (Retires one MockK-fake test case.)
+- **Nav custom view** = one collection surfaced as a view selector with a **fixed app-chosen icon** (no
+  icon picker in v1); complementary to, and separate from, the Collections screen.
+- **Re-slice unchanged** in count: C2 = Collections screen + drawer/rail entry + select→active view;
+  C3 = active-collection app-bar state + overflow create/edit/delete + editor sheet. C1 backend is
+  unaffected (its VM functions still fit; only the never-built `onDuplicateCollection` is dropped).
+
+---
+
 ## 12. Kickoff prompt template (coordinator → slice thread)
 
 The coordinator delivers a concrete prompt per thread (not all at once), as raw markdown for the user to

--- a/docs/specs/navigation-settings-spec.md
+++ b/docs/specs/navigation-settings-spec.md
@@ -86,7 +86,7 @@ items across groups, and there is no user-placed divider entity in v1.
 |--------------|-------------------------------------------------------------|--------------------------------------------------|
 | **Status**   | My List, Archive, Favourites                                | —                                                |
 | **Type**     | Articles, Videos, Pictures, *Custom view*, *Offline Content*| —                                                |
-| **Tools**    | —                                                           | Labels, Highlights                               |
+| **Tools**    | —                                                           | Labels, Highlights, Collections                  |
 | **Footer**   | —                                                           | Settings, User Guide, About                      |
 
 Custom view and Offline Content live in the **Type** group and are reorderable
@@ -112,6 +112,14 @@ A custom view *is* a saved Collection. Selecting it calls the existing
 `onSelectCollection(collectionId)` from the Collections spec — no new list/query
 path. Only **one** custom view is supported in v1 (multiple is a future
 extension).
+
+The custom view is surfaced with a single **fixed, app-chosen icon** signifying a
+user-defined view — there is **no per-view icon picker** in v1. The custom view is
+the *only* place a collection appears as a drawer/rail item; the collection list
+itself lives on the dedicated **Collections screen** (a fixed Tools-group entry,
+per the Collections spec) and is **never** rendered inline in the drawer. (The
+original Collections spec sketch of an inline drawer list was superseded; see that
+spec's UI note.)
 
 ### 4. Offline Content is a new local-only view
 


### PR DESCRIPTION
## Collections

Adds **Collections** to MyDeck — server-side saved filter views, cached locally and surfaced on their own screen. A collection is a named set of filter criteria you can return to with one tap; it's created/edited/deleted through the Readeck Collections API and kept in sync with the server.

### What's included

**Backend (data, repository, ViewModel)**
- `CollectionDto` / create + update DTOs, four `ReadeckApi` endpoints, `Collection` domain model, and a bi-directional `CollectionFilterAdapter`.
- Room: `CollectionEntity`, `CollectionDao`, `MIGRATION_17_18` (DB v17 → v18) + exported schema + migration test.
- `CollectionRepository` (paginated refresh with atomic cache replace; create hydrates via the `Location` header; real DELETE endpoint; PATCH re-fetch).
- `BookmarkListViewModel` gains collection state + create/update/delete/select/clear/refresh.

**UI (screen-based)**
- Dedicated **Collections** screen (Highlights-style cards + Extended FAB), reached from a drawer/rail entry with a live count badge.
- Selecting a collection opens it as the active list view (collection name + leading icon in the app bar; the collection's own criteria don't show as chips, but filters layered on top do).
- Unified editor sheet (shared filter controls + name field) with three entry points: FAB "New Collection", main-list overflow "Save as Collection", and "Edit collection".
- Overflow **Edit / Delete** for the active collection; delete uses a deferred-commit snackbar + **Undo** (mirrors bookmark delete).
- Sort dropdown on the Collections screen (Added date / Name, each toggling direction).

### Field mapping (server vs device-local)
- `withErrors → has_errors` and `withLabels → has_labels` are server-supported and persist in collections.
- **Downloaded** (`isLoaded`) and **Length** (reading time / word count) are device-local with no server equivalent. Rather than silently dropping them, the editor shows those controls in place as non-editable **"Unavailable"** (normal label/outline, greyed value; the Downloaded control renders as a single pill sized to match the tri-state rows) with a long-press tooltip explaining they can't be saved but still work on the list.

### Sync
Collections refresh through **both** sync workers — `LoadBookmarksWorker` (app open, pull-to-refresh) and `FullSyncWorker` (periodic auto-sync, "Sync Now") — alongside the existing highlights refresh, best-effort so a collections failure never fails a bookmark sync. 

### Docs & localization
- User guide: Collections documented in Your Bookmarks + drawer list; Highlights drawer bullet trimmed and its refresh notes moved to the Highlights page.
- README Key Features updated.
- New strings added across all 10 locales (English placeholders).

### Testing
- `:app:assembleDebugAll`, `:app:testDebugUnitTestAll`, `:app:lintDebugAll` all green.
- Device-verified on a Pixel 9 and on Pixel 9 / Pixel Tablet emulators (create, select, edit, rename, delete + Undo, sort, count badge, cold-start population, "Unavailable" editor treatment).

### Notes
- Branch is rebased on top of the `reader_settings` emergency fix (#214) already on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)