### PR TITLE
feature/auth-compat-welcome-guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Welcome screen quick-access buttons: reach **About**, the **User Guide**, and **Logs** before connecting to a server — handy when diagnosing a connection problem.
+- The in-app User Guide now has a **search field** to look up a feature by name, and **Labels**, **Highlights**, **Collections**, and **Offline Reading** each have their own page in the guide's table of contents.
+
+### Changed
+
+- Clearer sign-in errors: connecting to a Readeck server older than 0.21 now explains the server needs updating, and pointing at something that isn't a Readeck server says so, instead of showing a generic error.
+- User Guide reorganized to reduce duplication — offline-reading and download-status details now live on a single Offline Reading page, and labels and collections have their own pages.
+
 ## [0.14.4] - 2026-06-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Welcome screen quick-access buttons: reach **About**, the **User Guide**, and **Logs** before connecting to a server — handy when diagnosing a connection problem.
-- The in-app User Guide now has a **search field** to look up a feature by name, and **Labels**, **Highlights**, **Collections**, and **Offline Reading** each have their own page in the guide's table of contents.
+- The in-app User Guide now has a **search field** to look up a feature by name — tapping a result opens the page, jumps to the match, and highlights every occurrence of the term — and **Labels**, **Highlights**, **Collections**, and **Offline Reading** each have their own page in the guide's table of contents.
 
 ### Changed
 

--- a/app/src/main/assets/guide/en/collections.md
+++ b/app/src/main/assets/guide/en/collections.md
@@ -1,0 +1,23 @@
+# Collections
+
+A **collection** is a saved set of filter criteria you can return to with a single tap — a durable version of a filter you find yourself applying often.
+
+Open **Collections** from the navigation drawer (or the navigation rail in wide layouts) to see all your collections, each shown as a card with its name and the date it was created.
+
+## Creating a Collection
+
+To create one, tap the **New Collection** button. A sheet opens with the same filter controls as the filter sheet, plus a **name** field at the top. Set the criteria you want, give the collection a name, and tap **Save** (Save stays disabled until you enter a name). MyDeck opens the new collection right away.
+
+**Saving the current filter as a collection.** When you've applied a filter to an ordinary list (so chips are showing), open the **⋮ overflow menu** and tap **Save as Collection**. The editor opens pre-filled with your current filter; name it and tap Save to keep it.
+
+## Opening a Collection
+
+Tap any collection card to open it. The list then shows that collection as its own view: the top bar displays the collection's name with a leading icon, and the collection's own criteria are not shown as filter chips — it reads like an ordinary list. To leave a collection, pick any other view (My List, Archive, a label, etc.) from the navigation drawer.
+
+**Layering filters on a collection.** While viewing a collection you can still apply additional filters (⋮ → Filter). Those extra criteria appear as chips on top of the collection; the app-bar title stays the collection's name, and the saved collection is unchanged until you explicitly save. Dismiss a chip (or tap **Reset** in the filter sheet) to return to just the collection's own criteria.
+
+## Editing, Renaming, and Deleting
+
+While a collection is active, the **⋮ overflow menu** offers **Edit collection** and **Delete collection**. Edit opens the editor pre-filled with the collection's criteria (plus any filter you've layered on) and its current name — change the name to rename it, adjust the criteria, and Save. Delete (from the overflow or the editor's **Delete** button) removes the collection and shows a **"Collection deleted"** snackbar with **Undo** — the removal is held until the snackbar goes away, so tap Undo to keep it. (This mirrors deleting a bookmark; see [Organizing](./organizing.md).)
+
+Note: the **Downloaded** filter and the **Length** (reading time / word count) filters are specific to this device and aren't stored in collections, so they don't appear in the collection editor. They remain available in the normal list filter. See [Offline Reading](./offline-reading.md) for how the Downloaded status works.

--- a/app/src/main/assets/guide/en/getting-started.md
+++ b/app/src/main/assets/guide/en/getting-started.md
@@ -12,7 +12,9 @@ The standard MyDeck app accepts `https://` URLs only. If you enter an `http://` 
 
 A separate **HTTP-enabled APK** is published for setups that genuinely cannot use HTTPS (for example, connecting directly to a tailnet IP over HTTP). It installs alongside the standard app as its own package and shows an insecure-connection warning when you enter an `http://` URL.
 
-If the URL is invalid or the server cannot be reached, an error message will appear below the field. Double-check the address and make sure your device has network access to the server.
+MyDeck requires a Readeck server running **version 0.21 or later** (the first release to support the sign-in method MyDeck uses). If you enter the address of an older server, MyDeck tells you the server is too old and needs updating rather than showing a cryptic error. If the address doesn't point to a Readeck server at all — or the server can't be reached — you'll see a message explaining that instead. Double-check the address and make sure your device has network access to the server.
+
+At the bottom of the welcome screen are three quick-access buttons — **About**, **User Guide**, and **Logs** — so you can read the guide, check app details, or inspect logs before connecting. This is handy when diagnosing a connection problem. Tap the back arrow on any of those screens to return to the welcome screen.
 
 ## Signing In
 

--- a/app/src/main/assets/guide/en/index.md
+++ b/app/src/main/assets/guide/en/index.md
@@ -8,11 +8,11 @@ TOC:
     - getting-started
     - your-bookmarks
     - reading
+    - organizing
+    - offline-reading
     - labels
     - highlights
     - collections
-    - organizing
-    - offline-reading
     - settings
 ---
 
@@ -25,9 +25,9 @@ MyDeck is a mobile reader for [Readeck](https://readeck.org), a self-hosted read
 - [Getting Started](./getting-started.md)
 - [Your Bookmarks](./your-bookmarks.md)
 - [Reading](./reading.md)
+- [Organizing](./organizing.md)
+- [Offline Reading](./offline-reading.md)
 - [Labels](./labels.md)
 - [Highlights](./highlights.md)
 - [Collections](./collections.md)
-- [Organizing](./organizing.md)
-- [Offline Reading](./offline-reading.md)
 - [Settings](./settings.md)

--- a/app/src/main/assets/guide/en/index.md
+++ b/app/src/main/assets/guide/en/index.md
@@ -1,13 +1,18 @@
 ---
 Title: Table of Contents
 # !! IMPORTANT: DO NOT TRANSLATE THE PART BELOW
+# This list mirrors MarkdownAssetLoader.DEFAULT_SECTIONS (the in-app TOC).
+# Keep the two in sync when adding or reordering guide pages.
 TOC:
     - ""
     - getting-started
     - your-bookmarks
     - reading
-    - organizing
+    - labels
     - highlights
+    - collections
+    - organizing
+    - offline-reading
     - settings
 ---
 
@@ -18,8 +23,11 @@ MyDeck is a mobile reader for [Readeck](https://readeck.org), a self-hosted read
 ## Contents
 
 - [Getting Started](./getting-started.md)
-- [Bookmarks](./your-bookmarks.md)
+- [Your Bookmarks](./your-bookmarks.md)
 - [Reading](./reading.md)
-- [Organizing](./organizing.md)
+- [Labels](./labels.md)
 - [Highlights](./highlights.md)
+- [Collections](./collections.md)
+- [Organizing](./organizing.md)
+- [Offline Reading](./offline-reading.md)
 - [Settings](./settings.md)

--- a/app/src/main/assets/guide/en/labels.md
+++ b/app/src/main/assets/guide/en/labels.md
@@ -1,0 +1,45 @@
+# Labels
+
+Labels let you categorize your bookmarks with any words, phrases, or emojis you like. A bookmark can have any number of labels, and labels can be as broad or specific as you want.
+
+## Adding Labels to a Bookmark
+
+You can add labels in four places:
+
+- **From a bookmark card** — tap the **🏷️ Edit labels** icon on any card in a list view to open the label picker for that bookmark, choose its labels, and tap **Done**. This is the quickest way to label a single bookmark without opening it — ideal when tidying My List.
+
+- **When saving a bookmark** — the Add Link sheet (opened from the **+** button or the Android share sheet) shows a **Labels** section with chips for current labels and an **Add labels** / **Edit labels** row. Tap that row to open a label picker, select one or more labels, then tap **Done** to save label changes.
+
+- **From Bookmark Details** — open any bookmark and tap **⋮** → **Details**. The Labels section shows existing labels with **×** buttons to remove them, plus an **Add labels** / **Edit labels** row that opens the same multi-select label picker.
+
+- **For several bookmarks at once** — tap **⋮ → Select bookmarks**, choose the cards you want (or **⋮ → Select all**), then open the **⋮ overflow** and tap **Add labels**. Pick one or more labels (or create a new one) and tap **Done** to add them to every selected bookmark. Existing labels are kept, and any bookmark that already has all the chosen labels is left unchanged. The selection stays active afterward, so you can keep working with it. A snackbar confirms the result (e.g. "Labels added to 3 bookmarks") with an **Undo** that restores the prior labels on the bookmarks that changed. Batch *removing* labels isn't supported yet.
+
+## Browsing by Label
+
+Open the navigation drawer and tap **Labels** to open the label sheet. It lists all your labels (alphabetically by default), each with a count of bookmarks carrying it. Use the **Search labels** field at the top of the sheet to find a specific label quickly if you have many.
+
+## Tuning the Label Search
+
+Every label picker in the app — when browsing, saving, editing, or filtering — has two small toggles in its top bar that control how results are ranked. They're especially helpful when you have hundreds of labels:
+
+- **Matching** — `∗a∗` matches your typed text *anywhere* in a label name; tap to switch to `a∗`, which matches only labels that **start** with your text.
+- **Sort** — `abc` orders results alphabetically; tap to switch to `123`, which orders them by how many bookmarks use each label (most-used first).
+
+Long-press either toggle for a tooltip describing its current mode. Your choices are remembered and apply to every label picker. Tap the sheet's **title** to jump back to the top of the list.
+
+Tap a label to see all bookmarks with that label. The resulting list works like any other bookmark list — you can sort, filter, and use all the same card actions.
+
+You can also tap a label chip directly on any bookmark card in a list view to instantly filter that view to bookmarks with that label.
+
+## Rename or Delete a Label
+
+Because renaming or deleting a label affects every bookmark that carries it, both actions use a confirmation dialog rather than an immediate change.
+
+There are two ways to access these actions:
+
+- **From the label sheet** — long-press a label to open a menu with **Rename label** and **Delete label**
+- **From a label's bookmark list** — tap **⋮** in the top bar and choose **Rename label** or **Delete label**
+
+**Rename label** — opens a dialog with the current name pre-filled. Edit the name and tap **Rename**.
+
+**Delete label** — opens a confirmation dialog. Tap **Delete** to confirm; the label is removed from all bookmarks.

--- a/app/src/main/assets/guide/en/offline-reading.md
+++ b/app/src/main/assets/guide/en/offline-reading.md
@@ -1,0 +1,39 @@
+# Offline Reading
+
+Offline reading lets you read your bookmarks without an internet connection. It is optional and off by default. When you turn it on, MyDeck downloads and keeps eligible bookmarks available so their extracted content is ready even when you're offline.
+
+This page explains how offline content works and how it shows up on your bookmarks. The controls that decide *how much* to keep and *when* to download live in **Settings → Synchronization → Offline Reading** (see [Settings](./settings.md)).
+
+## Automatic and Pinned Content
+
+MyDeck keeps two kinds of offline content:
+
+- **Automatic** — content MyDeck manages for you within your offline limits. This includes any bookmark you simply open while offline reading is on. Automatic content is trimmed as newer bookmarks arrive or limits are reached.
+- **Pinned** — content you deliberately keep. Pinned bookmarks are protected: routine offline maintenance won't remove them. Only unpinning, **Clear All Offline Content**, turning offline reading off, or exceeding the maximum storage cap can remove pinned content.
+
+### Pinning a Bookmark
+
+- **While reading** — tap **⋮ → Pin offline** (it reads **Unpin offline** once pinned). This option appears only while offline reading is enabled.
+- **Several at once** — tap **⋮ → Select bookmarks** in a list, choose the cards you want, then open the **⋮ overflow** and tap **Pin offline**. MyDeck downloads anything not already stored, under your sync settings (Wi‑Fi only, battery saver), and you stay in selection mode so you can keep working. A snackbar summarizes the result, such as "8 pinned offline" or "8 pinned offline · 2 have no offline content" when some selected items (for example, link-only bookmarks or videos with no article) have nothing to store.
+
+Unpinning hands a bookmark back to automatic management — it doesn't delete the content, it's just no longer protected.
+
+## Download Status on Cards
+
+All three card layouts show whether a bookmark's content has been downloaded for offline reading:
+
+- **No indicator** — content not yet downloaded
+- **Outlined download icon** — text has been cached on demand for reading
+- **Filled download icon** — the bookmark is fully available offline, downloaded automatically by your offline settings
+- **Filled download icon in a highlight colour** — the bookmark is pinned: fully available offline because you kept it yourself, and protected from routine offline maintenance
+
+In **Grid** and **Compact** layouts, this icon appears on the site-info row, next to the site name and reading time. In **Mosaic** layout, it appears on the title row near the top-right area of the card.
+
+The same slot also surfaces two status badges, which take priority over the download icon:
+
+- **Error icon** — your Readeck server reported a problem with this bookmark (for example, it couldn't extract the content). These are the same bookmarks matched by the **With errors** filter; open the bookmark to see the details.
+- **Circle-slash icon** — there is no readable content to download; opening the card takes you to the original page.
+
+## Turning Offline Reading Off
+
+If you turn offline reading off, MyDeck removes all stored offline content — both automatic and pinned — immediately, but keeps the lightweight text it cached when you opened bookmarks while browsing. See [Settings](./settings.md) for the storage limits, Wi‑Fi/battery rules, storage stats, and **Clear All Offline Content**.

--- a/app/src/main/assets/guide/en/organizing.md
+++ b/app/src/main/assets/guide/en/organizing.md
@@ -1,52 +1,8 @@
 # Organizing
 
-Labels, favorites, and archive are the tools MyDeck gives you to keep your bookmarks tidy and easy to find.
+Favorites, archive, and deletion are the tools MyDeck gives you to keep your bookmarks tidy and easy to find.
 
-## Labels
-
-Labels let you categorize your bookmarks with any words, phrases, or emojis you like. A bookmark can have any number of labels, and labels can be as broad or specific as you want.
-
-### Adding Labels to a Bookmark
-
-You can add labels in four places:
-
-- **From a bookmark card** — tap the **🏷️ Edit labels** icon on any card in a list view to open the label picker for that bookmark, choose its labels, and tap **Done**. This is the quickest way to label a single bookmark without opening it — ideal when tidying My List.
-
-- **When saving a bookmark** — the Add Link sheet (opened from the **+** button or the Android share sheet) shows a **Labels** section with chips for current labels and an **Add labels** / **Edit labels** row. Tap that row to open a label picker, select one or more labels, then tap **Done** to save label changes.
-
-- **From Bookmark Details** — open any bookmark and tap **⋮** → **Details**. The Labels section shows existing labels with **×** buttons to remove them, plus an **Add labels** / **Edit labels** row that opens the same multi-select label picker.
-
-- **For several bookmarks at once** — tap **⋮ → Select bookmarks**, choose the cards you want (or **⋮ → Select all**), then open the **⋮ overflow** and tap **Add labels**. Pick one or more labels (or create a new one) and tap **Done** to add them to every selected bookmark. Existing labels are kept, and any bookmark that already has all the chosen labels is left unchanged. The selection stays active afterward, so you can keep working with it. A snackbar confirms the result (e.g. "Labels added to 3 bookmarks") with an **Undo** that restores the prior labels on the bookmarks that changed. Batch *removing* labels isn't supported yet.
-
-### Browsing by Label
-
-Open the navigation drawer and tap **Labels** to open the label sheet. It lists all your labels (alphabetically by default), each with a count of bookmarks carrying it. Use the **Search labels** field at the top of the sheet to find a specific label quickly if you have many.
-
-### Tuning the Label Search
-
-Every label picker in the app — when browsing, saving, editing, or filtering — has two small toggles in its top bar that control how results are ranked. They're especially helpful when you have hundreds of labels:
-
-- **Matching** — `∗a∗` matches your typed text *anywhere* in a label name; tap to switch to `a∗`, which matches only labels that **start** with your text.
-- **Sort** — `abc` orders results alphabetically; tap to switch to `123`, which orders them by how many bookmarks use each label (most-used first).
-
-Long-press either toggle for a tooltip describing its current mode. Your choices are remembered and apply to every label picker. Tap the sheet's **title** to jump back to the top of the list.
-
-Tap a label to see all bookmarks with that label. The resulting list works like any other bookmark list — you can sort, filter, and use all the same card actions.
-
-You can also tap a label chip directly on any bookmark card in a list view to instantly filter that view to bookmarks with that label.
-
-### Rename or Delete a Label
-
-Because renaming or deleting a label affects every bookmark that carries it, both actions use a confirmation dialog rather than an immediate change.
-
-There are two ways to access these actions:
-
-- **From the label sheet** — long-press a label to open a menu with **Rename label** and **Delete label**
-- **From a label's bookmark list** — tap **⋮** in the top bar and choose **Rename label** or **Delete label**
-
-**Rename label** — opens a dialog with the current name pre-filled. Edit the name and tap **Rename**.
-
-**Delete label** — opens a confirmation dialog. Tap **Delete** to confirm; the label is removed from all bookmarks.
+Labels have their own page — see the [Labels](./labels.md) guide for adding, browsing, renaming, and deleting labels.
 
 ## Favorites
 

--- a/app/src/main/assets/guide/en/reading.md
+++ b/app/src/main/assets/guide/en/reading.md
@@ -78,13 +78,9 @@ Tap **🔍** to open the in-content search bar. Type to search; matching text in
 
 ### Highlights
 
-Article bookmarks support Readeck highlights directly in the reading view. Video bookmarks also support highlights when Readeck provides text content such as a transcript.
+Article bookmarks — and videos with transcript text — support Readeck highlights directly in the reading view. To create one, select text and tap **Highlight** in the Android text selection menu, then choose a color and optionally add a note. Tap **⋮ → Highlights** to browse the highlights saved in the current bookmark.
 
-To create a highlight, select text in the article or transcript and tap **Highlight** in the Android text selection menu, then choose a color and optionally enter a note. If your selection overlaps one or more existing highlights, **Save** changes the color and note for those highlights and **Delete** removes them immediately.
-
-To edit or delete an existing highlight directly, tap the highlighted text. Clear the note field and save to remove a highlight note. You can also open **⋮ → Highlights** to browse saved highlights and jump to any one in the article or transcript.
-
-The main **Highlights** destination in the navigation drawer opens a global list of all your highlights across all bookmarks. Tap any highlight in that list to open its source bookmark and scroll directly to that highlight. See the [Highlights](./highlights.md) guide for more details.
+See the [Highlights](./highlights.md) guide for editing, deleting, colors and notes, and the global Highlights list across all your bookmarks.
 
 ## End-of-content Actions
 
@@ -101,7 +97,7 @@ Tap **⋮** in the top bar for additional actions:
 - **Add to favorites / Remove favorite** — toggle the favorite status
 - **Archive / Unarchive** — move the bookmark to the archive (or back to My List)
 - **Mark as read / Mark as unread** — toggle whether the bookmark has been read; this is reflected back in the bookmark list
-- **Pin offline / Unpin offline** — keep this bookmark on your device for offline reading (or release it back to automatic management). Pinned bookmarks are protected from the automatic offline limit and show a **pin** icon in the bookmark list. This action appears only while offline reading is enabled
+- **Pin offline / Unpin offline** — keep this bookmark on your device for offline reading (or release it back to automatic management). Appears only while offline reading is enabled; see [Offline Reading](./offline-reading.md)
 - **View web page / View [bookmark type]** — switch between the reading view and the web page in an in-app viewer (see above)
 - **Share link** — open the Android share sheet to share the bookmark using the format selected in **Settings → User Interface**
 - **Details** — open the Bookmark Details screen (see below)

--- a/app/src/main/assets/guide/en/settings.md
+++ b/app/src/main/assets/guide/en/settings.md
@@ -13,9 +13,7 @@ The **Account** option in the drawer shows your username. Tapping it opens the *
 
 ## Server URL Security
 
-The standard MyDeck app accepts HTTPS Readeck server URLs only. If an older install was already signed in to an `http://` server URL, MyDeck shows a startup screen with two choices: switch to an HTTPS URL and sign in again, or install the separate HTTP-enabled APK.
-
-The HTTP-enabled APK is for trusted private-network setups that cannot use HTTPS. It installs beside the standard app and keeps separate credentials and local data.
+The standard MyDeck app accepts HTTPS Readeck server URLs only; a separate HTTP-enabled APK exists for trusted private-network setups that cannot use HTTPS. See [Getting Started](./getting-started.md) for the full explanation, including what happens if an older install was already signed in over `http://`.
 
 ## Synchronization
 
@@ -32,9 +30,7 @@ Above the sync button, the **Bookmarks** counts show how many bookmarks are in y
 
 ### Offline Reading
 
-Offline reading is optional and off by default. When enabled, MyDeck automatically downloads and keeps eligible bookmarks available so you can read them without internet access. A status indicator below the toggle shows whether content is actively syncing, up to date, or waiting on a connection or battery constraint.
-
-MyDeck keeps two kinds of offline content: **automatic** content that it manages for you within the limits below (this includes bookmarks you simply open while offline reading is on), and **pinned** content that you deliberately keep. Pin a bookmark from its reading view (**⋮ → Pin offline**) or pin several at once with **Pin offline** in the bookmark-list selection menu. Pinned bookmarks are protected from automatic trimming — only unpinning them, **Clear All Offline Content**, turning offline reading off, or the maximum storage cap will remove them.
+Offline reading is optional and off by default. The **Enable offline reading** toggle turns it on; a status indicator below shows whether content is actively syncing, up to date, or waiting on a connection or battery constraint. For what offline reading does, how automatic and pinned content differ, and how download status appears on your cards, see the [Offline Reading](./offline-reading.md) guide. The controls below decide *how much* MyDeck keeps and *when* it downloads.
 
 #### What to keep offline
 

--- a/app/src/main/assets/guide/en/your-bookmarks.md
+++ b/app/src/main/assets/guide/en/your-bookmarks.md
@@ -77,19 +77,7 @@ Progress is tracked based on how far you scroll in the article — it reflects t
 
 ## Download Status
 
-All three layouts show whether a bookmark's content has been downloaded for offline reading:
-
-- **No indicator** — content not yet downloaded
-- **Outlined download icon** — text has been cached on demand for reading
-- **Filled download icon** — the bookmark is fully available offline, downloaded automatically by your offline settings
-- **Filled download icon in a highlight colour** — the bookmark is fully available offline because you saved it yourself (by opening it while offline reading is on); these hand-picked items are kept and aren't removed by routine offline maintenance
-
-The same slot also surfaces two status badges, which take priority over the download icon:
-
-- **Error icon** — your Readeck server reported a problem with this bookmark (for example, it couldn't extract the content). These are the same bookmarks matched by the **With errors** filter; open the bookmark to see the details. The badge appears once a metadata sync has run, without needing the content to be downloaded.
-- **Circle-slash icon** — there is no readable content to download; opening the card takes you to the original page.
-
-In **Grid** and **Compact** layouts, this icon appears on the site-info row, next to the site name and reading time. In **Mosaic** layout, it appears on the title row near the top-right area of the card.
+Each card also shows a small icon indicating whether the bookmark's content has been downloaded for offline reading, and two status badges (an **error** badge and a **no-content** badge) that take priority over it. See [Offline Reading](./offline-reading.md) for what each download icon and badge means.
 
 ## Card Actions
 
@@ -200,19 +188,7 @@ Tap **Search** to apply, or **Reset** to clear all filters.
 
 ## Collections
 
-A **collection** is a saved set of filter criteria you can return to with a single tap. Open **Collections** from the navigation drawer (or the navigation rail in wide layouts) to see all your collections, each shown as a card with its name and the date it was created.
-
-To create one, tap the **New Collection** button. A sheet opens with the same filter controls as the filter sheet, plus a **name** field at the top. Set the criteria you want, give the collection a name, and tap **Save** (Save stays disabled until you enter a name). MyDeck opens the new collection right away.
-
-Tap any collection card to open it. The list then shows that collection as its own view: the top bar displays the collection's name with a leading icon, and the collection's own criteria are not shown as filter chips — it reads like an ordinary list. To leave a collection, pick any other view (My List, Archive, a label, etc.) from the navigation drawer.
-
-**Saving the current filter as a collection.** When you've applied a filter to an ordinary list (so chips are showing), open the **⋮ overflow menu** and tap **Save as Collection**. The editor opens pre-filled with your current filter; name it and tap Save to keep it.
-
-**Layering filters on a collection.** While viewing a collection you can still apply additional filters (⋮ → Filter). Those extra criteria appear as chips on top of the collection; the app-bar title stays the collection's name, and the saved collection is unchanged until you explicitly save. Dismiss a chip (or tap **Reset** in the filter sheet) to return to just the collection's own criteria.
-
-**Editing, renaming, and deleting.** While a collection is active, the **⋮ overflow menu** offers **Edit collection** and **Delete collection**. Edit opens the editor pre-filled with the collection's criteria (plus any filter you've layered on) and its current name — change the name to rename it, adjust the criteria, and Save. Delete (from the overflow or the editor's **Delete** button) removes the collection and shows a **"Collection deleted"** snackbar with **Undo** — the same as deleting a bookmark, the removal is held until the snackbar goes away, so tap Undo to keep it.
-
-Note: the **Downloaded** filter and the **Length** (reading time / word count) filters are specific to this device and aren't stored in collections, so they don't appear in the collection editor. They remain available in the normal list filter.
+A **collection** is a saved set of filter criteria you can return to with a single tap. Open **Collections** from the navigation drawer (or the navigation rail in wide layouts), or save your current filter with **⋮ → Save as Collection**. See the [Collections](./collections.md) guide for creating, opening, editing, and deleting collections.
 
 ## Selecting Multiple Bookmarks
 
@@ -229,7 +205,7 @@ Archive and Favorite apply immediately and **keep you in selection mode**, so yo
 
 **Delete** is held until the snackbar goes away: the bookmarks stay greyed out while it's showing, so you can tap **Undo** to keep them, or dismiss the snackbar (or tap elsewhere) to confirm the deletion.
 
-**Pin offline** keeps the selected bookmarks on your device for offline reading. Pinned bookmarks are protected — the automatic offline limit won't remove them (only unpinning, clearing offline content, or turning offline reading off does; see [Settings](./settings.md)). MyDeck downloads anything that isn't already stored in the background under your sync settings (Wi-Fi only, battery saver), and each pinned card shows a **pin** icon. The menu reads **Unpin offline** instead when every selected bookmark is already pinned; unpinning hands those bookmarks back to automatic management (it doesn't delete them — they're just no longer protected). Like Archive and Favorite, pinning **keeps you in selection mode**. A snackbar summarizes the result, such as "8 pinned offline" or "8 pinned offline · 2 have no offline content" when some selected items (for example, link-only bookmarks or videos with no article) have nothing to store. The Pin/Unpin option is hidden while offline reading is turned off. You can also pin or unpin a single article from the **⋮ menu** while reading it.
+**Pin offline / Unpin offline** keeps the selected bookmarks on your device for offline reading (or hands them back to automatic management). Like Archive and Favorite, it keeps you in selection mode and shows a summary snackbar. The option is hidden while offline reading is turned off. See [Offline Reading](./offline-reading.md) for how pinning works.
 
 ## Refreshing
 

--- a/app/src/main/java/com/mydeck/app/domain/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/mydeck/app/domain/UserRepositoryImpl.kt
@@ -1,5 +1,7 @@
 package com.mydeck.app.domain
 
+import android.content.Context
+import com.mydeck.app.R
 import com.mydeck.app.domain.model.AuthenticationDetails
 import com.mydeck.app.domain.model.CachedServerInfo
 import com.mydeck.app.domain.model.User
@@ -10,6 +12,7 @@ import com.mydeck.app.io.rest.ReadeckApi
 import com.mydeck.app.io.rest.ReadeckNetworkPolicy
 import com.mydeck.app.io.rest.isHttpBlockedByBuildPolicy
 import com.mydeck.app.io.rest.model.OAuthRevokeRequestDto
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
@@ -17,12 +20,14 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import timber.log.Timber
 import java.io.IOException
 import javax.inject.Inject
 
 class UserRepositoryImpl @Inject constructor(
+    @ApplicationContext private val context: Context,
     private val settingsDataStore: SettingsDataStore,
     private val readeckApi: ReadeckApi,
     private val json: Json,
@@ -69,7 +74,10 @@ class UserRepositoryImpl @Inject constructor(
                 if (!info.features.contains("oauth")) {
                     settingsDataStore.clearCredentials()
                     return@withContext UserRepository.LoginResult.Error(
-                        "This server does not support OAuth authentication.",
+                        context.getString(
+                            R.string.account_login_server_no_oauth,
+                            info.version.release
+                        ),
                         code = infoResponse.code()
                     )
                 }
@@ -106,6 +114,15 @@ class UserRepositoryImpl @Inject constructor(
                 } else {
                     UserRepository.LoginResult.NetworkError("Network error: ${e.message}")
                 }
+            } catch (e: SerializationException) {
+                // /api/info returned something that is not the expected JSON (e.g. an HTML
+                // page). This happens when the server is older than 0.20 (no /api/info route)
+                // or the URL does not point at a Readeck API endpoint.
+                settingsDataStore.clearCredentials()
+                UserRepository.LoginResult.Error(
+                    context.getString(R.string.account_login_not_readeck_server),
+                    ex = e
+                )
             } catch (e: Exception) {
                 settingsDataStore.clearCredentials()
                 UserRepository.LoginResult.Error(

--- a/app/src/main/java/com/mydeck/app/io/rest/BaseUrlProvider.kt
+++ b/app/src/main/java/com/mydeck/app/io/rest/BaseUrlProvider.kt
@@ -32,5 +32,11 @@ class BaseUrlProvider @Inject constructor(
         }
     }
 
-    fun getBaseUrl(): String = baseUrl ?: throw IllegalStateException("BaseUrl not initialized")
+    /**
+     * The configured server base URL, or null when no server is set yet (e.g. before
+     * sign-in). Callers on the OkHttp chain must treat null as "not configured" and
+     * fail with an IOException so the failure is delivered through normal call
+     * callbacks rather than crashing the dispatcher thread.
+     */
+    fun getBaseUrl(): String? = baseUrl
 }

--- a/app/src/main/java/com/mydeck/app/io/rest/model/ServerInfoDto.kt
+++ b/app/src/main/java/com/mydeck/app/io/rest/model/ServerInfoDto.kt
@@ -7,8 +7,11 @@ import kotlinx.serialization.Serializable
 data class ServerInfoDto(
     @SerialName("version")
     val version: VersionDto,
+    // Servers older than 0.21 (which introduced OAuth) never send this key at all,
+    // rather than sending an empty list — default to empty so parsing succeeds and
+    // the caller's "does not support oauth" check fires instead of a deserialization error.
     @SerialName("features")
-    val features: List<String>
+    val features: List<String> = emptyList()
 )
 
 @Serializable

--- a/app/src/main/java/com/mydeck/app/ui/about/AboutViewModel.kt
+++ b/app/src/main/java/com/mydeck/app/ui/about/AboutViewModel.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -54,8 +55,13 @@ class AboutViewModel @Inject constructor(
                 serverInfoLoading = cachedInfo == null
             )
 
-            // If network is available, fetch fresh info in background
-            if (connectivityMonitor.isNetworkAvailable()) {
+            // Before sign-in there is no server configured, so there is nothing to
+            // fetch — attempting the call would fail (no base URL). Show the
+            // unavailable state instead of firing a doomed request.
+            val hasServer = !settingsDataStore.urlFlow.first().isNullOrBlank()
+
+            // If network is available and a server is configured, fetch fresh info.
+            if (hasServer && connectivityMonitor.isNetworkAvailable()) {
                 try {
                     val response = readeckApi.getInfo()
                     if (response.isSuccessful) {
@@ -103,10 +109,17 @@ class AboutViewModel @Inject constructor(
                     Timber.e(e, "Error fetching server info")
                 }
             } else {
-                // No network - if we have cache, show it; otherwise keep loading=true
+                // No server configured, or no network: if we have cached info, show it;
+                // otherwise there is nothing to show, so surface the unavailable state
+                // rather than spinning forever.
                 if (cachedInfo != null) {
                     _uiState.value = _uiState.value.copy(
                         serverInfoLoading = false
+                    )
+                } else {
+                    _uiState.value = _uiState.value.copy(
+                        serverInfoLoading = false,
+                        serverInfoError = true
                     )
                 }
             }

--- a/app/src/main/java/com/mydeck/app/ui/navigation/Routes.kt
+++ b/app/src/main/java/com/mydeck/app/ui/navigation/Routes.kt
@@ -48,5 +48,11 @@ object UserGuideRoute
 @Serializable
 data class UserGuideSectionRoute(
     val fileName: String,
-    val title: String
+    val title: String,
+    // Optional text to scroll to when the page opens (e.g. a matched heading or
+    // the search query when arriving from guide search). Null for normal navigation.
+    val anchor: String? = null,
+    // Optional search term to highlight throughout the page when arriving from
+    // guide search. Null for normal navigation.
+    val query: String? = null
 )

--- a/app/src/main/java/com/mydeck/app/ui/userguide/MarkdownAssetLoader.kt
+++ b/app/src/main/java/com/mydeck/app/ui/userguide/MarkdownAssetLoader.kt
@@ -36,18 +36,17 @@ class MarkdownAssetLoader @Inject constructor(
     companion object {
         private const val ASSETS_BASE_PATH = "guide"
         private const val DEFAULT_LOCALE = "en"
-        // Single source of truth for the in-app table of contents. Order mirrors
-        // the navigation drawer's Tools group (Labels → Highlights → Collections).
+        // Single source of truth for the in-app table of contents.
         // index.md (used by the website) is kept in sync with this list by hand.
         val DEFAULT_SECTIONS = listOf(
             GuideSection("Getting Started", "getting-started.md", 0),
             GuideSection("Your Bookmarks",  "your-bookmarks.md",  1),
             GuideSection("Reading",         "reading.md",         2),
-            GuideSection("Labels",          "labels.md",          3),
-            GuideSection("Highlights",      "highlights.md",      4),
-            GuideSection("Collections",     "collections.md",     5),
-            GuideSection("Organizing",      "organizing.md",      6),
-            GuideSection("Offline Reading", "offline-reading.md", 7),
+            GuideSection("Organizing",      "organizing.md",      3),
+            GuideSection("Offline Reading", "offline-reading.md", 4),
+            GuideSection("Labels",          "labels.md",          5),
+            GuideSection("Highlights",      "highlights.md",      6),
+            GuideSection("Collections",     "collections.md",     7),
             GuideSection("Settings",        "settings.md",        8)
         )
     }

--- a/app/src/main/java/com/mydeck/app/ui/userguide/MarkdownAssetLoader.kt
+++ b/app/src/main/java/com/mydeck/app/ui/userguide/MarkdownAssetLoader.kt
@@ -13,23 +13,45 @@ data class GuideSection(
     val order: Int
 )
 
+/**
+ * A single guide page parsed for offline search: its section metadata, the list
+ * of headings it contains, and its body as plain (markdown-stripped) text.
+ */
+data class GuideSearchDoc(
+    val section: GuideSection,
+    val headings: List<String>,
+    val body: String
+)
+
 @Singleton
 class MarkdownAssetLoader @Inject constructor(
     @ApplicationContext private val context: Context
 ) {
-    
+
+    // Cached, lazily-built search index (one entry per section). Cleared per
+    // process; guide content is bundled, so it never changes at runtime.
+    @Volatile
+    private var searchDocsCache: List<GuideSearchDoc>? = null
+
     companion object {
         private const val ASSETS_BASE_PATH = "guide"
         private const val DEFAULT_LOCALE = "en"
+        // Single source of truth for the in-app table of contents. Order mirrors
+        // the navigation drawer's Tools group (Labels → Highlights → Collections).
+        // index.md (used by the website) is kept in sync with this list by hand.
         val DEFAULT_SECTIONS = listOf(
             GuideSection("Getting Started", "getting-started.md", 0),
             GuideSection("Your Bookmarks",  "your-bookmarks.md",  1),
             GuideSection("Reading",         "reading.md",         2),
-            GuideSection("Organizing",      "organizing.md",      3),
-            GuideSection("Settings",        "settings.md",        4)
+            GuideSection("Labels",          "labels.md",          3),
+            GuideSection("Highlights",      "highlights.md",      4),
+            GuideSection("Collections",     "collections.md",     5),
+            GuideSection("Organizing",      "organizing.md",      6),
+            GuideSection("Offline Reading", "offline-reading.md", 7),
+            GuideSection("Settings",        "settings.md",        8)
         )
     }
-    
+
     private fun getLocalePath(): String {
         val currentLocale = Locale.getDefault().language
         val supportedLocales = listOf("en", "de", "es", "fr", "gl", "pl", "pt", "ru", "uk", "zh")
@@ -59,6 +81,47 @@ class MarkdownAssetLoader @Inject constructor(
         }
     }
     
+    /**
+     * Build (and cache) a plain-text search index over every section. Headings
+     * are kept separately so callers can rank heading matches above body matches.
+     */
+    fun loadSearchDocs(): List<GuideSearchDoc> {
+        searchDocsCache?.let { return it }
+        val localePath = getLocalePath()
+        val docs = loadSections().map { section ->
+            val raw = try {
+                context.assets.open("$localePath/${section.fileName}").use { input ->
+                    input.bufferedReader().use { it.readText() }
+                }
+            } catch (e: IOException) {
+                ""
+            }
+            val withoutFrontmatter = raw.replace(Regex("^---[\\s\\S]*?---\\n*"), "")
+            val headings = Regex("(?m)^#{1,6}\\s+(.+)$")
+                .findAll(withoutFrontmatter)
+                .map { it.groupValues[1].trim() }
+                .toList()
+            GuideSearchDoc(
+                section = section,
+                headings = headings,
+                body = toPlainText(withoutFrontmatter)
+            )
+        }
+        searchDocsCache = docs
+        return docs
+    }
+
+    /** Strip markdown syntax to plain text suitable for substring search. */
+    private fun toPlainText(markdown: String): String {
+        return markdown
+            .replace(Regex("!\\[[^\\]]*]\\([^)]*\\)"), " ")        // images
+            .replace(Regex("\\[([^\\]]+)]\\([^)]*\\)"), "$1")       // links -> text
+            .replace(Regex("(?m)^#{1,6}\\s+"), "")                    // heading markers
+            .replace(Regex("[*_`>|]"), " ")                          // emphasis/quote/table
+            .replace(Regex("[ \\t]+"), " ")
+            .trim()
+    }
+
     fun loadImage(imagePath: String): ByteArray? {
         val localePath = getLocalePath()
         return try {

--- a/app/src/main/java/com/mydeck/app/ui/userguide/UserGuideIndexScreen.kt
+++ b/app/src/main/java/com/mydeck/app/ui/userguide/UserGuideIndexScreen.kt
@@ -1,7 +1,9 @@
 package com.mydeck.app.ui.userguide
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -11,8 +13,14 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.automirrored.filled.Label
 import androidx.compose.material.icons.filled.Bookmark
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Collections
 import androidx.compose.material.icons.filled.CollectionsBookmark
+import androidx.compose.material.icons.filled.EditNote
 import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.outlined.DownloadForOffline
+import androidx.compose.material.icons.outlined.Inventory2
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -21,6 +29,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -28,6 +37,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import com.mydeck.app.R
@@ -35,12 +46,16 @@ import com.mydeck.app.ui.navigation.UserGuideSectionRoute
 import androidx.compose.foundation.clickable
 
 fun getSectionIcon(fileName: String) = when (fileName) {
-    "getting-started.md" -> Icons.Default.Info
-    "your-bookmarks.md"  -> Icons.Default.CollectionsBookmark
-    "reading.md"         -> Icons.Default.Bookmark
-    "organizing.md"      -> Icons.AutoMirrored.Filled.Label
-    "settings.md"        -> Icons.Outlined.Settings
-    else                 -> Icons.Default.Info
+    "getting-started.md"  -> Icons.Default.Info
+    "your-bookmarks.md"   -> Icons.Default.CollectionsBookmark
+    "reading.md"          -> Icons.Default.Bookmark
+    "labels.md"           -> Icons.AutoMirrored.Filled.Label
+    "highlights.md"       -> Icons.Default.EditNote
+    "collections.md"      -> Icons.Default.Collections
+    "organizing.md"       -> Icons.Outlined.Inventory2
+    "offline-reading.md"  -> Icons.Outlined.DownloadForOffline
+    "settings.md"         -> Icons.Outlined.Settings
+    else                  -> Icons.Default.Info
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -96,40 +111,127 @@ fun UserGuideIndexScreen(
                 }
             }
             else -> {
-                LazyColumn(
-                    state = lazyListState,
+                Column(
                     modifier = Modifier
                         .fillMaxSize()
                         .padding(padding)
                 ) {
-                    items(uiState.sections) { section ->
-                        ListItem(
-                            headlineContent = { Text(section.title) },
-                            leadingContent = {
-                                Icon(
-                                    imageVector = getSectionIcon(section.fileName),
-                                    contentDescription = null
-                                )
-                            },
-                            trailingContent = {
-                                Icon(
-                                    Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                                    contentDescription = null
-                                )
-                            },
-                            modifier = Modifier.clickable {
-                                navHostController.navigate(
-                                    UserGuideSectionRoute(
-                                        fileName = section.fileName,
-                                        title = section.title
+                    OutlinedTextField(
+                        value = uiState.searchQuery,
+                        onValueChange = { viewModel.onSearchQueryChange(it) },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 8.dp),
+                        placeholder = { Text(stringResource(R.string.user_guide_search_hint)) },
+                        leadingIcon = {
+                            Icon(Icons.Default.Search, contentDescription = null)
+                        },
+                        trailingIcon = {
+                            if (uiState.searchQuery.isNotEmpty()) {
+                                IconButton(onClick = { viewModel.clearSearch() }) {
+                                    Icon(
+                                        Icons.Default.Close,
+                                        contentDescription = stringResource(R.string.user_guide_search_clear)
                                     )
-                                ) { launchSingleTop = true }
+                                }
                             }
-                        )
-                        HorizontalDivider()
+                        },
+                        singleLine = true
+                    )
+
+                    when {
+                        uiState.searchQuery.isBlank() -> {
+                            LazyColumn(
+                                state = lazyListState,
+                                modifier = Modifier.fillMaxSize()
+                            ) {
+                                items(uiState.sections) { section ->
+                                    GuideSectionRow(
+                                        title = section.title,
+                                        supporting = null,
+                                        fileName = section.fileName,
+                                        onClick = {
+                                            navHostController.navigate(
+                                                UserGuideSectionRoute(
+                                                    fileName = section.fileName,
+                                                    title = section.title
+                                                )
+                                            ) { launchSingleTop = true }
+                                        }
+                                    )
+                                }
+                            }
+                        }
+                        uiState.searchResults.isEmpty() -> {
+                            Box(
+                                modifier = Modifier.fillMaxSize(),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Text(
+                                    text = stringResource(R.string.user_guide_search_no_results),
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
+                        else -> {
+                            LazyColumn(modifier = Modifier.fillMaxSize()) {
+                                items(uiState.searchResults) { result ->
+                                    GuideSectionRow(
+                                        title = result.section.title,
+                                        supporting = result.matchedHeading ?: result.snippet,
+                                        fileName = result.section.fileName,
+                                        onClick = {
+                                            navHostController.navigate(
+                                                UserGuideSectionRoute(
+                                                    fileName = result.section.fileName,
+                                                    title = result.section.title
+                                                )
+                                            ) { launchSingleTop = true }
+                                        }
+                                    )
+                                }
+                            }
+                        }
                     }
                 }
             }
         }
     }
+}
+
+@Composable
+private fun GuideSectionRow(
+    title: String,
+    supporting: String?,
+    fileName: String,
+    onClick: () -> Unit,
+) {
+    ListItem(
+        headlineContent = { Text(title) },
+        supportingContent = supporting?.let {
+            {
+                Text(
+                    text = it,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    style = MaterialTheme.typography.bodySmall
+                )
+            }
+        },
+        leadingContent = {
+            Icon(
+                imageVector = getSectionIcon(fileName),
+                contentDescription = null
+            )
+        },
+        trailingContent = {
+            Icon(
+                Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = null
+            )
+        },
+        modifier = Modifier.clickable(onClick = onClick)
+    )
+    HorizontalDivider()
 }

--- a/app/src/main/java/com/mydeck/app/ui/userguide/UserGuideIndexScreen.kt
+++ b/app/src/main/java/com/mydeck/app/ui/userguide/UserGuideIndexScreen.kt
@@ -185,7 +185,10 @@ fun UserGuideIndexScreen(
                                             navHostController.navigate(
                                                 UserGuideSectionRoute(
                                                     fileName = result.section.fileName,
-                                                    title = result.section.title
+                                                    title = result.section.title,
+                                                    anchor = result.matchedHeading
+                                                        ?: uiState.searchQuery.trim(),
+                                                    query = uiState.searchQuery.trim()
                                                 )
                                             ) { launchSingleTop = true }
                                         }

--- a/app/src/main/java/com/mydeck/app/ui/userguide/UserGuideSectionScreen.kt
+++ b/app/src/main/java/com/mydeck/app/ui/userguide/UserGuideSectionScreen.kt
@@ -19,12 +19,22 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
+import android.text.Spannable
+import android.text.SpannableString
+import android.text.style.BackgroundColorSpan
+import android.widget.TextView
 import com.mydeck.app.R
 import com.mydeck.app.ui.navigation.UserGuideRoute
 import com.mydeck.app.ui.navigation.UserGuideSectionRoute
@@ -37,6 +47,32 @@ fun UserGuideSectionScreen(
     val viewModel: UserGuideSectionViewModel = hiltViewModel()
     val uiState = viewModel.uiState
     val colorScheme = MaterialTheme.colorScheme
+    // Translucent so the underlying text stays readable in both light and dark themes.
+    val highlightColor = colorScheme.primary.copy(alpha = 0.35f).toArgb()
+
+    val scrollState = rememberScrollState()
+    var contentTextView by remember { mutableStateOf<android.widget.TextView?>(null) }
+    var didScrollToAnchor by remember(uiState.content, uiState.searchAnchor) {
+        mutableStateOf(false)
+    }
+
+    // When arriving from guide search, scroll to the matched heading (or the query).
+    // Keyed on scrollState.maxValue so it re-runs once the rendered content has been
+    // measured — otherwise scrollTo would clamp to a stale (smaller) scroll range.
+    LaunchedEffect(uiState.content, uiState.searchAnchor, contentTextView, scrollState.maxValue) {
+        val anchor = uiState.searchAnchor
+        val textView = contentTextView
+        if (anchor.isNullOrBlank() || didScrollToAnchor || textView == null) return@LaunchedEffect
+        if (uiState.content.isEmpty() || scrollState.maxValue <= 0) return@LaunchedEffect
+        val layout = textView.layout ?: return@LaunchedEffect
+        val index = textView.text?.toString()?.indexOf(anchor, ignoreCase = true) ?: -1
+        if (index >= 0) {
+            val line = layout.getLineForOffset(index)
+            val targetY = layout.getLineTop(line) + textView.paddingTop
+            scrollState.scrollTo(targetY.coerceIn(0, scrollState.maxValue))
+            didScrollToAnchor = true
+        }
+    }
 
     val markwon = rememberMarkwon(
         onSectionNavigate = { fileName ->
@@ -120,20 +156,59 @@ fun UserGuideSectionScreen(
                             }
                         },
                         update = { textView ->
+                            contentTextView = textView
                             applyMarkwonColors(textView, colorScheme)
                             // Only set markdown if the content has actually changed
                             if (textView.tag != uiState.content) {
                                 markwon.setMarkdown(textView, uiState.content)
                                 textView.tag = uiState.content
+                                // Highlight every occurrence of the search term when
+                                // arriving from guide search.
+                                highlightSearchTerm(textView, uiState.searchQuery, highlightColor)
                             }
                         },
                         modifier = Modifier
                             .fillMaxSize()
                             .padding(padding)
-                            .verticalScroll(rememberScrollState())
+                            .verticalScroll(scrollState)
                     )
                 }
             }
         }
+    }
+}
+
+/** Marker subclass so our search highlights can be found and removed on re-apply. */
+private class SearchHighlightSpan(color: Int) : BackgroundColorSpan(color)
+
+/**
+ * Highlight every case-insensitive occurrence of [query] in the rendered text.
+ * Matching against the already-rendered text is more accurate than the raw
+ * markdown (links are flattened to their display text, headings have no `#`).
+ */
+private fun highlightSearchTerm(textView: TextView, query: String?, color: Int) {
+    val term = query?.trim().orEmpty()
+    val current = textView.text
+    val spannable: Spannable = when {
+        term.isEmpty() || current.isEmpty() -> return
+        current is Spannable -> current
+        else -> SpannableString(current).also { textView.setText(it, TextView.BufferType.SPANNABLE) }
+    }
+
+    // Clear any previous highlights before re-applying.
+    spannable.getSpans(0, spannable.length, SearchHighlightSpan::class.java)
+        .forEach { spannable.removeSpan(it) }
+
+    val haystack = spannable.toString().lowercase()
+    val needle = term.lowercase()
+    var index = haystack.indexOf(needle)
+    while (index >= 0) {
+        spannable.setSpan(
+            SearchHighlightSpan(color),
+            index,
+            index + needle.length,
+            Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+        )
+        index = haystack.indexOf(needle, index + needle.length)
     }
 }

--- a/app/src/main/java/com/mydeck/app/ui/userguide/UserGuideViewModel.kt
+++ b/app/src/main/java/com/mydeck/app/ui/userguide/UserGuideViewModel.kt
@@ -20,6 +20,8 @@ class UserGuideIndexViewModel @Inject constructor(
     var uiState by mutableStateOf(UserGuideIndexUiState())
         private set
 
+    private var searchDocs: List<GuideSearchDoc> = emptyList()
+
     init {
         loadSections()
     }
@@ -38,12 +40,60 @@ class UserGuideIndexViewModel @Inject constructor(
             }
         }
     }
+
+    fun onSearchQueryChange(query: String) {
+        uiState = uiState.copy(searchQuery = query, searchResults = search(query))
+    }
+
+    fun clearSearch() {
+        uiState = uiState.copy(searchQuery = "", searchResults = emptyList())
+    }
+
+    private fun search(query: String): List<GuideSearchResult> {
+        val trimmed = query.trim()
+        if (trimmed.isEmpty()) return emptyList()
+        if (searchDocs.isEmpty()) {
+            searchDocs = markdownLoader.loadSearchDocs()
+        }
+        val needle = trimmed.lowercase()
+        val headingMatches = mutableListOf<GuideSearchResult>()
+        val bodyMatches = mutableListOf<GuideSearchResult>()
+        for (doc in searchDocs) {
+            val heading = doc.headings.firstOrNull { it.lowercase().contains(needle) }
+            if (heading != null) {
+                headingMatches += GuideSearchResult(doc.section, heading, heading)
+            } else {
+                val idx = doc.body.lowercase().indexOf(needle)
+                if (idx >= 0) {
+                    bodyMatches += GuideSearchResult(doc.section, null, snippet(doc.body, idx, needle.length))
+                }
+            }
+        }
+        return headingMatches + bodyMatches
+    }
+
+    /** A short window of body text around the match, for display in the result row. */
+    private fun snippet(body: String, matchIndex: Int, matchLength: Int): String {
+        val start = (matchIndex - 40).coerceAtLeast(0)
+        val end = (matchIndex + matchLength + 40).coerceAtMost(body.length)
+        val prefix = if (start > 0) "…" else ""
+        val suffix = if (end < body.length) "…" else ""
+        return prefix + body.substring(start, end).trim() + suffix
+    }
 }
 
 data class UserGuideIndexUiState(
     val isLoading: Boolean = false,
     val sections: List<GuideSection> = emptyList(),
-    val error: String? = null
+    val error: String? = null,
+    val searchQuery: String = "",
+    val searchResults: List<GuideSearchResult> = emptyList()
+)
+
+data class GuideSearchResult(
+    val section: GuideSection,
+    val matchedHeading: String?,
+    val snippet: String
 )
 
 @HiltViewModel

--- a/app/src/main/java/com/mydeck/app/ui/userguide/UserGuideViewModel.kt
+++ b/app/src/main/java/com/mydeck/app/ui/userguide/UserGuideViewModel.kt
@@ -104,7 +104,13 @@ class UserGuideSectionViewModel @Inject constructor(
 
     private val route: UserGuideSectionRoute = savedStateHandle.toRoute()
 
-    var uiState by mutableStateOf(UserGuideSectionUiState(title = route.title))
+    var uiState by mutableStateOf(
+        UserGuideSectionUiState(
+            title = route.title,
+            searchAnchor = route.anchor,
+            searchQuery = route.query
+        )
+    )
         private set
 
     init {
@@ -131,5 +137,7 @@ data class UserGuideSectionUiState(
     val isLoading: Boolean = false,
     val title: String = "",
     val content: String = "",
-    val error: String? = null
+    val error: String? = null,
+    val searchAnchor: String? = null,
+    val searchQuery: String? = null
 )

--- a/app/src/main/java/com/mydeck/app/ui/welcome/WelcomeScreen.kt
+++ b/app/src/main/java/com/mydeck/app/ui/welcome/WelcomeScreen.kt
@@ -3,6 +3,10 @@ package com.mydeck.app.ui.welcome
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.List
+import androidx.compose.material.icons.outlined.HelpOutline
+import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import kotlinx.coroutines.flow.collectLatest
@@ -18,7 +22,10 @@ import androidx.navigation.NavHostController
 import com.mydeck.app.R
 import com.mydeck.app.ui.components.MyDeckBrandHeader
 import com.mydeck.app.ui.login.DeviceAuthorizationScreen
+import com.mydeck.app.ui.navigation.AboutRoute
 import com.mydeck.app.ui.navigation.BookmarkListRoute
+import com.mydeck.app.ui.navigation.LogViewRoute
+import com.mydeck.app.ui.navigation.UserGuideRoute
 import com.mydeck.app.ui.navigation.WelcomeRoute
 import com.mydeck.app.ui.settings.AccountSettingsViewModel
 import com.mydeck.app.ui.settings.HttpUrlWarningText
@@ -141,6 +148,50 @@ fun WelcomeScreen(
                         textAlign = TextAlign.Center,
                         modifier = Modifier.fillMaxWidth()
                     )
+                }
+
+                // Quick-access buttons: reach About, User Guide, and Logs before
+                // signing in (useful when diagnosing a connection problem). Each
+                // destination's back button pops the stack back to this screen.
+                Spacer(modifier = Modifier.weight(1f))
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 16.dp),
+                    horizontalArrangement = Arrangement.SpaceEvenly,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    FilledTonalIconButton(
+                        onClick = {
+                            navHostController.navigate(AboutRoute) { launchSingleTop = true }
+                        }
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.Info,
+                            contentDescription = stringResource(R.string.welcome_about_content_description)
+                        )
+                    }
+                    FilledTonalIconButton(
+                        onClick = {
+                            navHostController.navigate(UserGuideRoute) { launchSingleTop = true }
+                        }
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.HelpOutline,
+                            contentDescription = stringResource(R.string.welcome_user_guide_content_description)
+                        )
+                    }
+                    FilledTonalIconButton(
+                        onClick = {
+                            navHostController.navigate(LogViewRoute) { launchSingleTop = true }
+                        }
+                    ) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Outlined.List,
+                            contentDescription = stringResource(R.string.welcome_logs_content_description)
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -715,4 +715,12 @@ other{}
     <string name="font_source_serif" translatable="false">Source Serif</string>
     <string name="font_noto_sans" translatable="false">Noto Sans</string>
     <string name="font_jetbrains_mono" translatable="false">JetBrains Mono</string>
+    <string name="account_login_server_no_oauth">This Readeck server (version %1$s) does not support the authentication method required by this app. Please update your server to version 0.21 or later.</string>
+    <string name="account_login_not_readeck_server">Could not connect to a Readeck server at this address. If your server is running a version older than 0.21, it is not supported by this app. Please check the URL and ensure your server is reachable and up to date.</string>
+    <string name="welcome_about_content_description">About</string>
+    <string name="welcome_user_guide_content_description">User guide</string>
+    <string name="welcome_logs_content_description">Logs</string>
+    <string name="user_guide_search_hint">Search the guide</string>
+    <string name="user_guide_search_clear">Clear search</string>
+    <string name="user_guide_search_no_results">No results found</string>
 </resources>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -714,4 +714,12 @@ other{}
     <string name="font_source_serif" translatable="false">Source Serif</string>
     <string name="font_noto_sans" translatable="false">Noto Sans</string>
     <string name="font_jetbrains_mono" translatable="false">JetBrains Mono</string>
+    <string name="account_login_server_no_oauth">This Readeck server (version %1$s) does not support the authentication method required by this app. Please update your server to version 0.21 or later.</string>
+    <string name="account_login_not_readeck_server">Could not connect to a Readeck server at this address. If your server is running a version older than 0.21, it is not supported by this app. Please check the URL and ensure your server is reachable and up to date.</string>
+    <string name="welcome_about_content_description">About</string>
+    <string name="welcome_user_guide_content_description">User guide</string>
+    <string name="welcome_logs_content_description">Logs</string>
+    <string name="user_guide_search_hint">Search the guide</string>
+    <string name="user_guide_search_clear">Clear search</string>
+    <string name="user_guide_search_no_results">No results found</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -714,4 +714,12 @@ other{}
     <string name="font_source_serif" translatable="false">Source Serif</string>
     <string name="font_noto_sans" translatable="false">Noto Sans</string>
     <string name="font_jetbrains_mono" translatable="false">JetBrains Mono</string>
+    <string name="account_login_server_no_oauth">This Readeck server (version %1$s) does not support the authentication method required by this app. Please update your server to version 0.21 or later.</string>
+    <string name="account_login_not_readeck_server">Could not connect to a Readeck server at this address. If your server is running a version older than 0.21, it is not supported by this app. Please check the URL and ensure your server is reachable and up to date.</string>
+    <string name="welcome_about_content_description">About</string>
+    <string name="welcome_user_guide_content_description">User guide</string>
+    <string name="welcome_logs_content_description">Logs</string>
+    <string name="user_guide_search_hint">Search the guide</string>
+    <string name="user_guide_search_clear">Clear search</string>
+    <string name="user_guide_search_no_results">No results found</string>
 </resources>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -714,4 +714,12 @@ other{}
     <string name="font_source_serif" translatable="false">Source Serif</string>
     <string name="font_noto_sans" translatable="false">Noto Sans</string>
     <string name="font_jetbrains_mono" translatable="false">JetBrains Mono</string>
+    <string name="account_login_server_no_oauth">This Readeck server (version %1$s) does not support the authentication method required by this app. Please update your server to version 0.21 or later.</string>
+    <string name="account_login_not_readeck_server">Could not connect to a Readeck server at this address. If your server is running a version older than 0.21, it is not supported by this app. Please check the URL and ensure your server is reachable and up to date.</string>
+    <string name="welcome_about_content_description">About</string>
+    <string name="welcome_user_guide_content_description">User guide</string>
+    <string name="welcome_logs_content_description">Logs</string>
+    <string name="user_guide_search_hint">Search the guide</string>
+    <string name="user_guide_search_clear">Clear search</string>
+    <string name="user_guide_search_no_results">No results found</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -714,4 +714,12 @@ other{}
     <string name="font_source_serif" translatable="false">Source Serif</string>
     <string name="font_noto_sans" translatable="false">Noto Sans</string>
     <string name="font_jetbrains_mono" translatable="false">JetBrains Mono</string>
+    <string name="account_login_server_no_oauth">This Readeck server (version %1$s) does not support the authentication method required by this app. Please update your server to version 0.21 or later.</string>
+    <string name="account_login_not_readeck_server">Could not connect to a Readeck server at this address. If your server is running a version older than 0.21, it is not supported by this app. Please check the URL and ensure your server is reachable and up to date.</string>
+    <string name="welcome_about_content_description">About</string>
+    <string name="welcome_user_guide_content_description">User guide</string>
+    <string name="welcome_logs_content_description">Logs</string>
+    <string name="user_guide_search_hint">Search the guide</string>
+    <string name="user_guide_search_clear">Clear search</string>
+    <string name="user_guide_search_no_results">No results found</string>
 </resources>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -714,4 +714,12 @@ other{}
     <string name="font_source_serif" translatable="false">Source Serif</string>
     <string name="font_noto_sans" translatable="false">Noto Sans</string>
     <string name="font_jetbrains_mono" translatable="false">JetBrains Mono</string>
+    <string name="account_login_server_no_oauth">This Readeck server (version %1$s) does not support the authentication method required by this app. Please update your server to version 0.21 or later.</string>
+    <string name="account_login_not_readeck_server">Could not connect to a Readeck server at this address. If your server is running a version older than 0.21, it is not supported by this app. Please check the URL and ensure your server is reachable and up to date.</string>
+    <string name="welcome_about_content_description">About</string>
+    <string name="welcome_user_guide_content_description">User guide</string>
+    <string name="welcome_logs_content_description">Logs</string>
+    <string name="user_guide_search_hint">Search the guide</string>
+    <string name="user_guide_search_clear">Clear search</string>
+    <string name="user_guide_search_no_results">No results found</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -714,4 +714,12 @@ other{}
     <string name="font_source_serif" translatable="false">Source Serif</string>
     <string name="font_noto_sans" translatable="false">Noto Sans</string>
     <string name="font_jetbrains_mono" translatable="false">JetBrains Mono</string>
+    <string name="account_login_server_no_oauth">This Readeck server (version %1$s) does not support the authentication method required by this app. Please update your server to version 0.21 or later.</string>
+    <string name="account_login_not_readeck_server">Could not connect to a Readeck server at this address. If your server is running a version older than 0.21, it is not supported by this app. Please check the URL and ensure your server is reachable and up to date.</string>
+    <string name="welcome_about_content_description">About</string>
+    <string name="welcome_user_guide_content_description">User guide</string>
+    <string name="welcome_logs_content_description">Logs</string>
+    <string name="user_guide_search_hint">Search the guide</string>
+    <string name="user_guide_search_clear">Clear search</string>
+    <string name="user_guide_search_no_results">No results found</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -714,4 +714,12 @@ other{}
     <string name="font_source_serif" translatable="false">Source Serif</string>
     <string name="font_noto_sans" translatable="false">Noto Sans</string>
     <string name="font_jetbrains_mono" translatable="false">JetBrains Mono</string>
+    <string name="account_login_server_no_oauth">This Readeck server (version %1$s) does not support the authentication method required by this app. Please update your server to version 0.21 or later.</string>
+    <string name="account_login_not_readeck_server">Could not connect to a Readeck server at this address. If your server is running a version older than 0.21, it is not supported by this app. Please check the URL and ensure your server is reachable and up to date.</string>
+    <string name="welcome_about_content_description">About</string>
+    <string name="welcome_user_guide_content_description">User guide</string>
+    <string name="welcome_logs_content_description">Logs</string>
+    <string name="user_guide_search_hint">Search the guide</string>
+    <string name="user_guide_search_clear">Clear search</string>
+    <string name="user_guide_search_no_results">No results found</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -706,4 +706,12 @@
     <string name="font_source_serif" translatable="false">Source Serif</string>
     <string name="font_noto_sans" translatable="false">Noto Sans</string>
     <string name="font_jetbrains_mono" translatable="false">JetBrains Mono</string>
+    <string name="account_login_server_no_oauth">This Readeck server (version %1$s) does not support the authentication method required by this app. Please update your server to version 0.21 or later.</string>
+    <string name="account_login_not_readeck_server">Could not connect to a Readeck server at this address. If your server is running a version older than 0.21, it is not supported by this app. Please check the URL and ensure your server is reachable and up to date.</string>
+    <string name="welcome_about_content_description">About</string>
+    <string name="welcome_user_guide_content_description">User guide</string>
+    <string name="welcome_logs_content_description">Logs</string>
+    <string name="user_guide_search_hint">Search the guide</string>
+    <string name="user_guide_search_clear">Clear search</string>
+    <string name="user_guide_search_no_results">No results found</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,6 +17,8 @@
     <string name="account_settings_url_http_warning">This HTTP URL sends OAuth tokens without TLS. You are using the HTTP-enabled MyDeck build; prefer a Tailscale Serve HTTPS URL or a reverse proxy with HTTPS when possible.</string>
     <string name="account_settings_http_blocked_error">HTTP Readeck server URLs are not allowed in this MyDeck build.</string>
     <string name="account_settings_initial_sync_failed">Initial sync failed. Please check your connection and try again.</string>
+    <string name="account_login_server_no_oauth">This Readeck server (version %1$s) does not support the authentication method required by this app. Please update your server to version 0.21 or later.</string>
+    <string name="account_login_not_readeck_server">Could not connect to a Readeck server at this address. If your server is running a version older than 0.21, it is not supported by this app. Please check the URL and ensure your server is reachable and up to date.</string>
     <string name="account_settings_username_error">Email address cannot be empty</string>
     <string name="account_settings_password_error">Password cannot be empty</string>
     <string name="account_settings_allow_unencrypted">Allow unencrypted connections</string>
@@ -52,6 +54,9 @@ other{}
     <string name="settings">Settings</string>
     <string name="user_guide">User Guide</string>
     <string name="user_guide_contents">Contents</string>
+    <string name="user_guide_search_hint">Search the guide</string>
+    <string name="user_guide_search_clear">Clear search</string>
+    <string name="user_guide_search_no_results">No results found</string>
     <string name="an_error_occurred">An error occurred.</string>
     <string name="no_bookmarks_found">No bookmarks found.</string>
     <string name="add_bookmark">Add Bookmark</string>
@@ -585,6 +590,9 @@ other{}
     <string name="welcome_title">Welcome to MyDeck</string>
     <string name="welcome_message">MyDeck is a read-later app for Readeck. Enter your Readeck server address below to get started. You\'ll be guided through a quick authorization process to connect your account.</string>
     <string name="welcome_connect_button">Connect</string>
+    <string name="welcome_about_content_description">About</string>
+    <string name="welcome_user_guide_content_description">User guide</string>
+    <string name="welcome_logs_content_description">Logs</string>
 
     <!-- HTTP URL Migration -->
     <string name="http_migration_title">HTTP server URL blocked</string>

--- a/app/src/test/java/com/mydeck/app/domain/UserRepositoryImplTest.kt
+++ b/app/src/test/java/com/mydeck/app/domain/UserRepositoryImplTest.kt
@@ -69,7 +69,13 @@ class UserRepositoryImplTest {
         every { settingsDataStore.usernameFlow } returns usernameFlow
         every { settingsDataStore.tokenFlow } returns tokenFlow
 
-        userRepository = UserRepositoryImpl(settingsDataStore, readeckApi, json, oauthDeviceAuthUseCase)
+        userRepository = UserRepositoryImpl(
+            mockk<android.content.Context>(relaxed = true),
+            settingsDataStore,
+            readeckApi,
+            json,
+            oauthDeviceAuthUseCase
+        )
     }
 
     @After

--- a/docs/specs/guide-rework-spec.md
+++ b/docs/specs/guide-rework-spec.md
@@ -1,0 +1,205 @@
+# User Guide Rework — Specification (DRAFT, untracked)
+
+**Status:** Draft for review. Not part of the `feat/collections` branch scope — framed now, executed later (target: alongside the final changes for the Readeck release).
+**Author context:** Produced from a top-to-bottom review of the bundled guide (`app/src/main/assets/guide/en/`) and its in-app renderer (`app/src/main/java/com/mydeck/app/ui/userguide/`).
+**Applies to:** MyDeck first; then ported to the Readeck for Android guide with branding differences (see §9).
+
+---
+
+## 1. Purpose & Scope
+
+The guide has grown piecemeal across releases. Symptoms the user identified:
+- Very dense pages with minimal navigation.
+- Feature pages (Highlights, Collections) buried "several layers deep."
+- Long, self-contained topics embedded as sections inside first-level pages.
+- No way to search the guide for a specific feature.
+
+This spec covers: (a) page/section/subsection reorganization, (b) specific passage moves, (c) content to remove, (d) at least a remedial search feature, (e) revalidation of the top-level TOC, and (f) mirroring all of it into the Readeck guide with branding differences.
+
+**Out of scope:** rewriting correct content for its own sake. The goal is structure, findability, and de-duplication — not a prose overhaul.
+
+---
+
+## 2. Current-State Findings
+
+### 2.1 Navigation architecture (the core problem)
+
+| Finding | Evidence | Impact |
+|---|---|---|
+| **In-app TOC is hardcoded**, not data-driven | `MarkdownAssetLoader.DEFAULT_SECTIONS` lists exactly 5: Getting Started, Your Bookmarks, Reading, Organizing, Settings | Highlights & Collections are **absent from the TOC** |
+| **`index.md` is unused by the app** | `UserGuideIndexViewModel` → `loadSections()` returns `DEFAULT_SECTIONS`; `index.md` is never read in-app | `index.md` (edited for the website) has silently diverged from the app's real TOC |
+| **Sub-pages reachable only via inline links** | Markwon `linkResolver` navigates `*.md` links (`MarkdownRenderer.kt`); Highlights/Collections are linked only from body text in organizing.md / reading.md / your-bookmarks.md | "Several layers deep" — no direct path from the TOC |
+| **No in-page navigation** | Each page renders as one long scrolling `TextView` (`UserGuideSectionScreen.kt`) | Long pages (reading.md ~171 lines, your-bookmarks.md ~247 lines) are a single unbroken scroll; no jump-to-section, no anchors |
+| **No search** | No search UI or index anywhere in `ui/userguide/` | Users cannot look up a feature by name |
+| **Linked-page titles derived from filename** | `onSectionNavigate` resolves title from `DEFAULT_SECTIONS`, else derives from filename | Works for now but fragile; another reason to make the section list data-driven |
+
+### 2.2 Content duplication & redundancy
+
+| Topic | Documented in | Problem |
+|---|---|---|
+| **Collections** | your-bookmarks.md §Collections (committed by C3) **and** new collections.md | **Direct duplication** — must dedupe (see §8) |
+| Highlights | reading.md §Highlights (create), organizing.md §Highlights (pointer), highlights.md (full) | Overlap between reading.md create-steps and highlights.md |
+| Offline / Pinned content | settings.md §Offline Reading (detailed), your-bookmarks.md §Download Status + §Selecting Multiple (Pin), reading.md §Overflow (Pin) | Scattered; no single home |
+| Delete / Undo mechanics | your-bookmarks.md (Card Actions, Swipe, Multi-select), organizing.md §Deleting Bookmarks, reading.md §Overflow | Same snackbar/Undo behavior re-explained verbatim 4–5× |
+| HTTP/HTTPS server security | getting-started.md §Connecting, settings.md §Server URL Security | Overlapping explanations |
+| Swipe actions | your-bookmarks.md §Swipe Actions, settings.md §Bookmark List → Swipe | Behavior vs configuration split, with repetition |
+
+### 2.3 Over-long embedded sections (candidates for their own page)
+
+- **your-bookmarks.md §Searching and Filtering** (lines ~155–199) — long, self-contained, applies beyond the basic list.
+- **your-bookmarks.md §Collections** (lines ~201–215) — already half-promoted; finish the job.
+- **your-bookmarks.md §Selecting Multiple Bookmarks** (lines ~217–232) — long; conceptually "acting on many bookmarks."
+- **settings.md §Offline Reading** (lines ~33–64) — a substantial standalone feature living as a Settings subsection.
+
+---
+
+## 3. Target Information Architecture — **AGREED: Option B, adjusted**
+
+We're taking **Option B** — keep the long first-level pages intact (do **not** extract Searching/Filtering into a separate page, and do **not** move Multi-select out of Your Bookmarks) — with two adjustments from review:
+
+- **Promote Labels to a top-level page.** For consistency with Highlights and Collections: all three are major features with their own surfaces, so Labels shouldn't stay buried inside Organizing while the other two are surfaced. Extract the Labels section from organizing.md into its own page; Organizing keeps a one-line pointer.
+- **Split Offline Reading.** A top-level **Offline Reading** page covers the *concept and its interactions with bookmarks and content* — download-status card indicators, pinning, automatic-vs-pinned. The **Settings** page retains the *control-by-control detail* (enable toggle, storage limits, Wi-Fi-only, battery saver, storage stats, Clear All), cross-linked. Boundary: **concept + interactions → Offline Reading page; controls → Settings.** Net win: the download-status and pin explanations are currently duplicated across Your Bookmarks and Reading, so consolidating them here *removes* duplication.
+
+### Target top-level TOC (data-driven; see §7)
+
+1. **Getting Started** — connect, sign in, first load, sign out/switch servers. *Single home for the HTTP/HTTPS story.*
+2. **Your Bookmarks** — list & cards, layouts, reading progress, download status, card actions, swipe, sort, long-press, **filtering** (stays here), **multi-select** (stays here), tablet/landscape.
+3. **Reading** — reading view, bookmark types, view formats, typography, find-in-page, links, lightbox, details. Highlights trimmed to a brief create + pointer.
+4. **Labels** — promoted; extracted from Organizing.
+5. **Highlights** — promoted (already its own file).
+6. **Collections** — promoted; single source (dedupe per §8).
+7. **Organizing** — Favorites, Archive, Delete (Labels removed).
+8. **Offline Reading** — concept + bookmark/content interactions; Settings keeps the controls.
+9. **Settings** — Account, Synchronization (bookmark sync + offline **controls**), User Interface, Sharing, Logs; heavy topics (offline detail, security) reduced to short pointers to their home page.
+
+*(About stays a drawer destination, not a guide page.)*
+
+The **Labels → Highlights → Collections** order mirrors the "Tools" group in the navigation drawer, so the guide's feature pages read in the same order the user sees them in the app.
+
+**Deliberately NOT done under B:** extracting Searching/Filtering into a "Finding Bookmarks" page; moving Multi-select into Organizing. Both stay in Your Bookmarks.
+
+**Naming (resolved):** with Labels gone, "Organizing" holds Favorites/Archive/Delete — **keep the name "Organizing"** (least churn).
+
+---
+
+## 4. Specific Passage Moves
+
+| Passage (current) | From | To | Notes |
+|---|---|---|---|
+| §Labels (whole section) | organizing.md | **Labels** (new page) | Extract; Organizing keeps a one-line pointer |
+| §Collections | your-bookmarks.md | **Collections** page | Delete the embedded section; collections.md is the single source |
+| §Offline Reading concept + download-status indicators + pin mechanics | settings.md, your-bookmarks.md §Download Status, reading.md §Overflow (Pin) | **Offline Reading** (new page) | Consolidate concept + interactions here (also de-dupes existing scatter) |
+| Offline **control** detail (toggles, storage limits, Wi-Fi/battery, Clear All) | settings.md (stays) | Settings §Offline (controls only) | Cross-link to Offline Reading page |
+| HTTP/HTTPS detail | duplicated in getting-started.md & settings.md | **Getting Started** (canonical) | settings.md §Server URL Security → short pointer |
+| Highlights create-steps | reading.md §Highlights | keep brief in Reading; full detail in **highlights.md** | Reduce reading.md to "how to create + link to Highlights" |
+
+*Staying put under B:* §Searching and Filtering and §Selecting Multiple Bookmarks remain in your-bookmarks.md.
+
+---
+
+## 5. Content to Remove / Trim
+
+- **Repeated Undo/snackbar explanations.** Explain the delete→greyed→snackbar→Undo model once (Organizing §Deleting), then reference it. Applies to card delete, swipe delete, multi-select delete, collection delete.
+- **Duplicated Pin-offline paragraphs** across your-bookmarks.md and reading.md — collapse to one home (Offline Reading) + short call-outs.
+- **The Highlights drawer bullet** (already trimmed on `feat/collections`) is the template: drawer/list entries should be one-line "what it is," with mechanics living on the feature page. Apply the same discipline to any bullet that grew a "how it works" tail.
+- **settings.md §Offline Reading "maximum storage cap" paragraph** — dense wall; break into a short rule + example when it moves to the Offline Reading page.
+- **index.md prose Contents list** — once the app TOC is data-driven and index.md's role is settled (§7), remove or regenerate it so it can't drift again.
+
+---
+
+## 6. Search Feature
+
+**Requirement:** "at least a remedial search." All guide content is local markdown assets, so search is fully offline and cheap.
+
+### 6.1 Remedial (minimum viable)
+- Add a **search field** to the User Guide index screen (`UserGuideIndexScreen`), or a search icon in its top bar.
+- On query, load every section's markdown (`MarkdownAssetLoader` gains a `loadAllSections()` that returns `{section, headings[], body}`), strip frontmatter/markdown, and do a case-insensitive substring match over **headings first, then body**.
+- Present results as a list of **(page title → matching heading / snippet)** rows; tapping a row opens that page (existing section route).
+- Build a small in-memory index once (Singleton loader can cache parsed content); no persistence needed.
+
+### 6.2 Enhancement path (optional, later)
+- Scroll-to-match: pass the matched heading anchor into the section route and scroll the `TextView` to it (requires heading-offset tracking; Markwon renders to a single `TextView`, so this needs measuring or switching to a structured renderer).
+- Rank results (heading match > first-paragraph > body).
+- Highlight the matched term in the opened page.
+
+### 6.3 Localization
+- New search UI strings must be added to all 10 locale `strings.xml` files with English placeholders (per project l10n rule). Guide *content* stays English-only for now (translations handled separately).
+
+---
+
+## 7. TOC Mechanism Fix (revalidation)
+
+The TOC must become **data-driven and complete** so features stop being orphaned:
+
+1. **Single source of truth.** Either (a) derive `DEFAULT_SECTIONS` from `index.md`'s `TOC:` frontmatter at load time, or (b) keep a Kotlin list but treat it as the authoritative TOC and regenerate/remove `index.md` accordingly. Pick one so app and website cannot diverge again. *Recommendation: parse `index.md` frontmatter → the website and app share it.*
+2. **Add the missing entries** (in drawer order): Labels, Highlights, Collections, then Offline Reading.
+3. **Order** per §3.
+4. **Icons:** `getSectionIcon()` in `UserGuideIndexScreen` currently hardcodes icons per filename — extend for the new pages, or move icon choice into the section data.
+5. **Consider light grouping** (e.g., a divider between "Using MyDeck" and "Configuration") — optional; the flat list is acceptable if complete.
+
+---
+
+## 8. Immediate Cleanup on `feat/collections` (do before this branch's doc commit)
+
+This branch currently has **two** Collections docs:
+- **your-bookmarks.md §Collections** (committed by C3) — embedded, matches the current flat structure.
+- **collections.md** (new, uncommitted, this session) — standalone page + `index.md`/`organizing.md` pointers.
+
+They must not both ship. **Decision (resolved):** for **this branch**, keep Collections as the **embedded section in your-bookmarks.md** (matches today's flat structure, zero code change). **Drop** the standalone `collections.md` and its `index.md` / organizing.md pointers. The promotion of Collections to a standalone top-level page is deferred to the guide rework (§3), where it lands alongside Labels/Highlights as a proper page with a `DEFAULT_SECTIONS` entry.
+
+Everything else from this session (Highlights bullet trim, the your-bookmarks.md Collections **drawer bullet**, README feature line, highlights.md refresh note) is orthogonal and ships as-is.
+
+---
+
+## 9. Cross-Repo: Readeck Guide
+
+The **same structural rework** applies to the Readeck for Android guide. Follow the port harness (`docs/porting/mydeck-readeck-port.md`) — structure ports; branding does not.
+
+### 9.1 Branding / terminology deltas (do not port verbatim)
+- **App name:** "MyDeck" → "Readeck".
+- **List terminology:** confirm Readeck's naming (e.g. "My List" vs "Deck"/"Unread") and use the target's terms.
+- **HTTP-enabled APK story:** MyDeck-specific packaging; confirm Readeck's equivalent (may differ or not exist).
+- **Tailscale / reverse-proxy example, package ids, store copy, links, icons:** target's own.
+- **Locale set:** confirm Readeck's supported languages before assuming the same 10.
+
+### 9.2 Feature-availability deltas
+- **Collections is not yet ported to Readeck.** The Readeck reorg should **reserve the Collections slot in the TOC structure but not add Collections content** until the feature lands. When Collections ports, drop in the (re-branded) collections.md and flip on its TOC entry — no re-architecting.
+- Any other MyDeck-only feature pages should be gated the same way.
+
+### 9.3 Timing
+- The user will revisit this spec just before finalizing the Readeck release (v1.0.0 per current plan; confirm at execution). Apply the app-side TOC/search code changes and the content reorg together so both repos land structurally aligned.
+
+---
+
+## 10. Future-Proofing
+
+Features are landing around this rework (nav drawer enhancements, offline-content changes, the Collections port). To avoid re-introducing the same mess:
+
+- **Data-driven TOC (§7) is the key enabler** — new feature pages become a one-line addition, not a code+doc archaeology exercise.
+- **One-topic-one-home rule:** each feature has a single canonical page; other pages link to it rather than re-explaining.
+- **Nav-drawer enhancements will change the "Navigating" section** (custom collection-backed views, an Offline view, reorderable entries). The guide's drawer description must be updated when that ships — and because Collections/Offline will then be first-class drawer entries, their guide pages should already exist (this rework creates them).
+- **Bullet discipline:** navigation/list bullets stay one-line; mechanics live on feature pages (the Highlights-bullet fix is the pattern).
+
+---
+
+## 11. Execution Phasing & Validation
+
+**Phase 1 — TOC + search plumbing (code):**
+- Make `DEFAULT_SECTIONS` data-driven / reconcile with `index.md`; add missing pages; extend `getSectionIcon`.
+- Add remedial search (§6.1) + locale strings.
+- Verify: `:app:assembleDebugAll`, `:app:testDebugUnitTestAll`, `:app:lintDebugAll`; device-check the guide TOC, deep links, and search.
+
+**Phase 2 — content reorg (assets):**
+- Create/relocate pages per §3–§4; dedupe per §5; fix the Collections duplication per §8.
+- English `en/` only; translations handled separately.
+
+**Phase 3 — Readeck port:**
+- Apply §9 with branding deltas; reserve/omit not-yet-ported feature pages.
+
+**Validation checklist:**
+- Every TOC entry opens; every inline `.md` link resolves.
+- No topic documented in two places as primary content.
+- Search finds each feature by name and opens the right page.
+- Longest pages have a clear heading structure (even without in-page anchors).
+- `index.md` (website) and the app TOC agree.
+```

--- a/docs/specs/server-version-compat-error.md
+++ b/docs/specs/server-version-compat-error.md
@@ -1,0 +1,115 @@
+# Spec: Server Compatibility Error Messaging
+
+## Background
+
+When a user enters a Readeck server URL and taps Connect, MyDeck already calls
+`GET /api/info` before starting the OAuth device flow. The response includes a
+`features` list; the app already checks for `"oauth"` in that list (see
+`UserRepositoryImpl.initiateLogin`). However, the current error messages in that
+path are generic and developer-facing, not user-friendly. This spec tightens the
+three failure modes into clear, actionable messages.
+
+## Server version reference
+
+| Version | Significance |
+|---------|-------------|
+| **0.20** | First version to include `GET /api/info` |
+| **0.21** | First version to support OAuth — minimum required to use this app |
+| **0.22** | OAuth mandatory; username/password authentication removed |
+| **0.22.3** | Current stable release |
+
+Since `/api/info` (0.20) predates OAuth support (0.21), both failure modes below
+are reachable in practice:
+
+- Servers in the **0.20.x** range have `/api/info` but lack `"oauth"` in
+  `features` → failure mode 2 (clean, JSON-parseable rejection).
+- Servers **older than 0.20** have no `/api/info` route at all → failure mode 3
+  (HTML response, deserialization exception).
+
+## The `/api/info` contract
+
+`GET /api/info` is an unauthenticated public endpoint. Its response includes:
+
+```json
+{
+  "version": {
+    "canonical": "0.23.1-175-g154ad5c1",
+    "release":   "0.23.1",
+    "build":     "175-g154ad5c1"
+  },
+  "features": ["email", "oauth"]
+}
+```
+
+`features` explicitly advertises whether the server supports OAuth. No version
+parsing is required — the presence or absence of `"oauth"` in the list is the
+authoritative signal.
+
+## Failure modes and proposed messages
+
+### 1. `/api/info` call fails (network error, non-200, or empty body)
+
+**Current message:** "Failed to read server capabilities. Please verify the
+server URL and try again."
+
+**Proposed message:** No change needed — this is already clear and actionable.
+
+---
+
+### 2. `/api/info` succeeds but `features` does not contain `"oauth"`
+
+This applies to servers in the **0.20.x** range: they have `/api/info` but
+predate OAuth support (0.21).
+
+**Current message:** "This server does not support OAuth authentication."
+
+**Proposed message:**
+
+> This Readeck server (version **X.Y.Z**) does not support the authentication
+> method required by this app. Please update your server to version **0.21 or
+> later**.
+
+The server's `version.release` is available from the `info` object at the point
+the feature check runs, so it can be interpolated directly into the message.
+
+---
+
+### 3. `/api/info` returns HTML instead of JSON
+
+This is the confirmed error for the user who triggered this spec. It occurs when
+the server is so old it has no `/api/info` route at all, or the URL points to
+something that isn't a Readeck API endpoint. Retrofit attempts to deserialize the
+HTML response as `ServerInfoDto`, throws a `JsonDecodingException`, which falls
+into the outer `catch` block and surfaces as:
+
+> An unexpected error occurred: Unexpected JSON token at offset 0: Expected
+> start of the object '{', but had '<' instead …
+
+This applies to servers **older than 0.20** (no `/api/info` route exists yet).
+
+**Proposed behaviour:** In the outer `catch` of `initiateLogin`, detect this by
+checking for `SerializationException` (or its subtypes
+`JsonDecodingException`/`MissingFieldException`) and return:
+
+> Could not connect to a Readeck server at this address. If your server is
+> running a version older than **0.21**, it is not supported by this app.
+> Please check the URL and ensure your server is reachable and up to date.
+
+---
+
+## Implementation notes
+
+- All three messages map to `LoginResult.Error` with a user-readable `message`
+  string (same type used today).
+- The error display in `AccountSettingsViewModel` already surfaces
+  `LoginResult.Error.errorMessage` — no UI changes needed.
+- For failure mode 2, the server's `version.release` is available from the
+  `info` object before the feature check is made, so it can be interpolated
+  into the message.
+- Messages 2 and 3 are localized string resources resolved in
+  `UserRepositoryImpl`. Because the repository is a domain-layer class with no
+  `Context`, inject `@ApplicationContext Context` (the same pattern already used
+  by `OAuthDeviceAuthorizationUseCase`) so the resource can be resolved to a
+  string before it is placed into `LoginResult.Error`.
+- String resources need entries in all language files (English placeholder for
+  all, per the localization policy in `CLAUDE.md`). Package: `com.mydeck.app`.

--- a/docs/specs/welcome-screen-quick-access.md
+++ b/docs/specs/welcome-screen-quick-access.md
@@ -1,0 +1,115 @@
+# Spec: Welcome Screen Quick-Access Buttons
+
+## Background
+
+The Welcome/server-connection screen (`WelcomeScreen.kt`) is the entry point
+before a user has signed in. Today it offers no way to reach the About page,
+Logs, or User Guide without first connecting — useful information when
+diagnosing a connection problem (e.g. "is my server actually OAuth-capable?")
+or when a user just wants to read the guide before connecting.
+
+## Requirements
+
+Add three round icon buttons to the bottom of the Welcome screen:
+
+| Position | Icon | Destination |
+|----------|------|-------------|
+| Bottom left | Info | About page (variant, see below) |
+| Bottom center | Question mark | User Guide |
+| Bottom right | Logs/list icon | Logs page |
+
+For all three, tapping the back button (top left, on the destination screen)
+returns the user to the Welcome screen.
+
+## Navigation
+
+Confirmed via code inspection (MyDeck, package `com.mydeck.app`):
+
+- All three destination routes (`AboutRoute`, `LogViewRoute`, `UserGuideRoute`)
+  and `WelcomeRoute` already live in the same flat `NavHost` graph in
+  `AppShell.kt`. There is no nesting or auth guard at the route level — the
+  only auth gate in the file is the `startDestination` choice
+  (`WelcomeRoute` vs `BookmarkListRoute()` based on whether a token exists).
+  Navigating to `AboutRoute`/`LogViewRoute`/`UserGuideRoute` directly from
+  `WelcomeScreen` requires no nav-graph restructuring — just wiring
+  `navHostController.navigate(...)` calls from three new buttons.
+- **`AppShell.kt` has two `NavHost` blocks** — the Compact layout's inline
+  `NavHost` (`CompactAppShell`) and the shared `AppShellNavHost` used by the
+  Medium layout (phone vs. tablet/foldable). Both already register the four
+  routes above; `WelcomeScreen(navController)` receives the shared
+  `NavHostController`, so the buttons work from either layout with no
+  block-specific wiring.
+- None of the three destination screens or their ViewModels have any
+  dependency on an authenticated session:
+  - `AboutViewModel` depends only on `SettingsDataStore`, `ConnectivityMonitor`,
+    `ReadeckApi` — no token/session check.
+  - `LogViewViewModel` depends only on `Context` and `SettingsDataStore`,
+    reads local log files from disk — no network call.
+  - `UserGuideIndexViewModel`/`UserGuideSectionViewModel` depend only on
+    `MarkdownAssetLoader` reading bundled `assets/guide/en/*.md` — fully
+    offline.
+  - All three are already safe to open pre-login with **zero code changes**
+    to the screens themselves.
+- Back navigation: each destination screen's back button already calls
+  `navHostController.popBackStack()` (confirmed in `AboutScreen`,
+  `LogViewScreen`, `UserGuideIndexScreen`) — none hardcode a back target such
+  as `BookmarkListRoute`. Entered from `WelcomeRoute`, "back" therefore pops
+  naturally to the Welcome screen. **No changes to the destination screens are
+  required.**
+
+## About page variant — interpretation of "only the server info block"
+
+The request was: *"the one difference than the normal About page is that
+since there's no server connection at this point, only the server info
+block."*
+
+**Resolved interpretation:** this describes the natural state of the
+existing About screen when opened with no server URL saved, not a request to
+hide sections. Code inspection confirms `AboutScreenContent` already
+handles the no-connection case gracefully and without code changes:
+
+- `AboutViewModel` has no auth dependency. With no saved server URL,
+  `serverUrl` is null and the server-info fetch fails or has no cache,
+  setting `serverInfoError = true`.
+- The server-info card already has fallback copy for this
+  (`about_system_info_server_unavailable` / `about_system_info_server_error`
+  strings) and renders an empty detail list rather than crashing.
+- App version/description, Credits, Project Links, and License sections are
+  static (no server dependency) and render normally regardless of connection
+  state.
+
+So **"only the server info block" differs** in the sense that it's the one
+section whose content changes (shows an "unavailable"/"not connected" state
+instead of live server details) — everything else on the page (app info,
+credits, project links, license) is identical to the normal About page.
+
+**Implementation implication:** no new `showOnlyServerInfo`-style parameter
+or conditional section hiding is needed. The Welcome-screen entry point can
+open the existing `AboutScreen` unmodified, with back navigation returning to
+Welcome (per the Navigation section above).
+
+**If this interpretation is wrong** (i.e. the actual intent was to hide
+Credits/Project Links/License and show *only* the server-info card), that
+would require a new boolean parameter threaded through `AboutScreen` →
+`AboutScreenContent`, since those sections currently always render with no
+existing gate. The server-info card is already cleanly isolated as its own
+call to the reusable `CollapsibleInfoCard` composable, so extracting it alone
+would be straightforward if needed — but the simpler, no-code-change reading
+above should be confirmed with the user before implementation.
+
+## Implementation notes
+
+- New buttons: `FilledTonalIconButton` (round Material3 control) at the bottom
+  of the Welcome column, pushed down with a weighted spacer, laid out in a
+  `Row` with `Arrangement.SpaceEvenly`. Icons: `Icons.Outlined.Info` (About),
+  `Icons.Outlined.HelpOutline` (User Guide), `Icons.AutoMirrored.Outlined.List`
+  (Logs) — matching the icons the drawer/rail already use for About and Guide.
+  Each needs a content description (accessibility) added as a new string
+  resource — same localization requirement as any new string (English
+  placeholder in all language files per `CLAUDE.md`).
+- User guide documentation (`app/src/main/assets/guide/en/getting-started.md`)
+  should mention the new quick-access buttons on the connection screen, per
+  the project's documentation policy.
+- Touches both `NavHost` blocks' entry point via the shared `NavHostController`
+  and `WelcomeScreen.kt`.
+- No backend/API changes; purely client-side navigation and layout.


### PR DESCRIPTION
## Summary

Implements three specs (`docs/specs/`), staged for later port to `readeck-android`:

- **Server compatibility error messaging** — `UserRepositoryImpl.initiateLogin` now returns user-friendly, localized, version-aware errors when a Readeck server lacks OAuth support (needs 0.21+) or isn't a Readeck server at all (non-JSON `/api/info` response), instead of generic/developer-facing messages.
- **Welcome-screen quick-access buttons** — About, User Guide, and Logs are now reachable from the welcome screen before signing in, useful when diagnosing a connection problem.
- **User guide rework** — data-driven, complete TOC (adds Labels, Highlights, Collections, Offline Reading pages); remedial offline search over headings + body, with jump-to-match and highlight-all-occurrences on the opened page; content reorganized to remove duplication (new Labels/Collections/Offline Reading pages, source sections trimmed to pointers).

**Follow-up fixes from device testing** (second, third commits):
- Fixed a crash opening About before sign-in (`BaseUrlProvider.getBaseUrl()` threw a non-catchable exception on the OkHttp dispatcher thread when no server was configured).
- Guide search now scrolls to the match and highlights every occurrence of the search term.
- Reordered the guide TOC: Organizing and Offline Reading now precede Labels/Highlights/Collections.
- Fixed a real-server parsing bug found during compatibility testing: Readeck 0.20.x omits the `features` key from `/api/info` entirely (it wasn't added until 0.21), which threw a deserialization error instead of showing the correct "server doesn't support OAuth" message.

New strings added with English placeholders to all locale files. `CHANGELOG.md` `[Unreleased]` updated.

## Test plan

- [x] `./gradlew :app:assembleDebugAll` passes
- [x] `./gradlew :app:testDebugUnitTestAll` passes (one known-flaky, unrelated timing test excluded — passes in isolation)
- [x] `./gradlew :app:lintDebugAll` passes, no new errors
- [x] Device-verified on Pixel 9: welcome quick-access buttons navigate correctly and return to Welcome on back
- [x] Device-verified: About screen shows the unavailable server-info state (no crash) when opened before sign-in
- [x] Device-verified: guide search jumps to the matched section, scrolls to the first match, and highlights every occurrence of the search term
- [x] Device-verified against Readeck server v0.19 (lacks /api/info) and v0.20 (has /api/info but no oauth) to confirm the new compatibility error messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)
