### PR TITLE
chore(release): bump version to 0.14.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.5] - 2026-07-03
+
 ### Added
 
+- Collections: save a set of filter criteria (search, labels, type, date range, and more) as a named, reusable view. Create one from the new Collections screen (navigation drawer/rail) or save your current filter directly from a list via "Save as Collection". Opening a collection shows it as its own list view, and you can layer additional filters on top without changing the saved collection. Rename, edit, or delete collections at any time.
 - Welcome screen quick-access buttons: reach **About**, the **User Guide**, and **Logs** before connecting to a server — handy when diagnosing a connection problem.
 - The in-app User Guide now has a **search field** to look up a feature by name — tapping a result opens the page, jumps to the match, and highlights every occurrence of the term — and **Labels**, **Highlights**, **Collections**, and **Offline Reading** each have their own page in the guide's table of contents.
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,8 +30,8 @@ android {
         applicationId = "com.mydeck.app"
         minSdk = 24
         targetSdk = 35
-        versionCode = 14004
-        versionName = "0.14.4"
+        versionCode = 14005
+        versionName = "0.14.5"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/metadata/en-US/changelogs/14005.txt
+++ b/metadata/en-US/changelogs/14005.txt
@@ -1,0 +1,8 @@
+<b>Added</b>
+- Collections: save filter criteria as a named, reusable view; create from the Collections screen or "Save as Collection"
+- Welcome screen quick-access buttons for About, User Guide, and Logs before connecting
+- User Guide search, plus dedicated Labels, Highlights, Collections, and Offline Reading pages
+
+<b>Changed</b>
+- Clearer sign-in errors for outdated or non-Readeck servers
+- User Guide reorganized to reduce duplication


### PR DESCRIPTION
Moves [Unreleased] into the 0.14.5 release section, including Collections (merged in #215 but never recorded in the changelog) alongside the welcome quick-access, server-compatibility, and user-guide rework features from #219.