### PR TITLE
Feat/oauth auth code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- OAuth Authorization Code + PKCE sign-in: tapping **Sign In** now opens the Readeck authorization page in your browser, completing sign-in without entering a code. PKCE ensures the flow is secure even with a custom URI scheme redirect.
+- **Sign in with a code instead** fallback: users who cannot use the browser flow (e.g. on constrained devices) can still sign in via the existing OAuth Device Code flow by tapping the new secondary action on the sign-in screen.
+- The sign-in flow now survives process death while the browser is open — if Android reclaims the app, returning from the browser resumes where it left off.
+
 ## [0.14.5] - 2026-07-03
 
 ### Added

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,6 +34,8 @@ android {
         versionName = "0.14.5"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        manifestPlaceholders["oauthCallbackScheme"] = "mydeck"
+        manifestPlaceholders["oauthCallbackHost"] = "oauth-callback"
     }
 
     signingConfigs {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,8 +34,17 @@ android {
         versionName = "0.14.5"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        manifestPlaceholders["oauthCallbackScheme"] = "mydeck"
-        manifestPlaceholders["oauthCallbackHost"] = "oauth-callback"
+
+        // Single source of truth for the OAuth authorization-code redirect URI.
+        // The manifest intent-filter, MainActivity's callback matcher, and the use case's
+        // registered redirect_uri all derive from these — change them here only.
+        // (For the Readeck port, swap these values or move them per-flavor.)
+        val oauthCallbackScheme = "mydeck"
+        val oauthCallbackHost = "oauth-callback"
+        manifestPlaceholders["oauthCallbackScheme"] = oauthCallbackScheme
+        manifestPlaceholders["oauthCallbackHost"] = oauthCallbackHost
+        buildConfigField("String", "OAUTH_CALLBACK_SCHEME", "\"$oauthCallbackScheme\"")
+        buildConfigField("String", "OAUTH_CALLBACK_HOST", "\"$oauthCallbackHost\"")
     }
 
     signingConfigs {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,11 +24,20 @@
             android:configChanges="screenLayout|orientation|screenSize|keyboard|keyboardHidden|smallestScreenSize"
             android:exported="true"
             android:label="${appLabel}"
+            android:launchMode="singleTop"
             android:theme="@style/Theme.MyDeck.Starting">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="${oauthCallbackScheme}"
+                    android:host="${oauthCallbackHost}" />
             </intent-filter>
         </activity>
         <activity

--- a/app/src/main/assets/guide/en/getting-started.md
+++ b/app/src/main/assets/guide/en/getting-started.md
@@ -18,18 +18,24 @@ At the bottom of the welcome screen are three quick-access buttons — **About**
 
 ## Signing In
 
-MyDeck uses the OAuth device authorization flow to sign you in securely without ever handling your password. After tapping **Connect**, the screen shows two things:
+MyDeck uses OAuth to sign you in securely without ever handling your password.
 
-1. **A verification URL** — the address to visit in your browser (for example, `https://readeck.example.com/device`)
+### Browser-based sign-in (default)
+
+After entering your server address and tapping **Sign In**, MyDeck opens the Readeck authorization page in your browser. Log in to Readeck if you are not already logged in, review the permissions, and tap **Authorize**. You are returned to MyDeck automatically and the sign-in is complete.
+
+If you close the browser before completing the authorization, tap **Cancel** in MyDeck and try again.
+
+### Sign in with a code instead
+
+If you cannot use the browser flow — for example, on a TV or e-reader, or if your device browser cannot reach the server — tap **Sign in with a code instead** on the sign-in screen. The screen shows:
+
+1. **A verification URL** — the address to visit in any browser (for example, `https://readeck.example.com/device`)
 2. **Your user code** — a short one-time code to enter on that page
 
-The easiest way to sign in is to tap **Open in Browser**, which opens the Readeck authorization page directly. Log in to Readeck if prompted, review the permissions requested, and tap **Authorize**.
+Tap **Open in Browser** to open the Readeck page directly, or tap **Copy URL** and **Copy Code** to use them manually. Once you authorize in the browser, MyDeck detects the approval automatically.
 
-If you prefer to do it manually, tap **Copy URL** to copy the verification address and open it yourself, then tap **Copy Code** to copy the code and enter it when prompted.
-
-Once you tap Authorize, MyDeck detects the approval automatically and the sign-in is complete. When the Readeck page updates to show a "Return to Readeck" button, close the browser and return to MyDeck.
-
-> **Note:** The user code expires after 5 minutes. If the countdown reaches zero before you finish, go back and start the connection process again.
+> **Note:** The user code expires after 5 minutes. If the countdown reaches zero, go back and start the process again.
 
 ## First Load
 
@@ -39,5 +45,5 @@ After signing in, MyDeck syncs your bookmarks from the server. Depending on how 
 
 To sign out or connect to a different server, open the navigation drawer and tap **Settings**, then tap **Account**.
 
-- To **switch servers**, update the **Readeck URL** field and tap **Login** to re-authenticate.
+- To **switch servers**, update the **Readeck URL** field and tap **Sign In** to re-authenticate.
 - To **sign out**, tap **Sign Out**. This removes all locally stored bookmarks from the device and returns you to the welcome screen.

--- a/app/src/main/java/com/mydeck/app/MainActivity.kt
+++ b/app/src/main/java/com/mydeck/app/MainActivity.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.remember
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.navigation.compose.rememberNavController
 import dagger.hilt.android.AndroidEntryPoint
+import com.mydeck.app.domain.OAuthCallbackRepository
 import com.mydeck.app.domain.model.resolveEffectiveAppearance
 import com.mydeck.app.domain.model.Theme
 import com.mydeck.app.ui.navigation.AccountSettingsRoute
@@ -31,6 +32,9 @@ class MainActivity : ComponentActivity() {
 
     @Inject
     lateinit var settingsDataStore: SettingsDataStore
+
+    @Inject
+    lateinit var oauthCallbackRepository: OAuthCallbackRepository
 
     private lateinit var intentState: MutableState<Intent?>
 
@@ -65,6 +69,7 @@ class MainActivity : ComponentActivity() {
                             navController.navigate(BookmarkDetailRoute(bookmarkId))
                         }
                     }
+                    dispatchOAuthCallbackIfPresent(newIntent)
                     // Consume the intent after processing
                     intentState.value = null
                 }
@@ -90,5 +95,33 @@ class MainActivity : ComponentActivity() {
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         intentState.value = intent
+    }
+
+    private fun dispatchOAuthCallbackIfPresent(intent: Intent) {
+        val data = intent.data ?: return
+        if (data.scheme != "mydeck" || data.host != "oauth-callback") return
+
+        val code = data.getQueryParameter("code")
+        val state = data.getQueryParameter("state")
+        val error = data.getQueryParameter("error")
+
+        when {
+            error != null -> {
+                val errorDescription = data.getQueryParameter("error_description")
+                Timber.w("OAuth callback error: $error — $errorDescription")
+                oauthCallbackRepository.dispatch(
+                    OAuthCallbackRepository.OAuthCallbackEvent.Error(error, errorDescription)
+                )
+            }
+            !code.isNullOrBlank() && !state.isNullOrBlank() -> {
+                Timber.d("OAuth callback received: code present, state=$state")
+                oauthCallbackRepository.dispatch(
+                    OAuthCallbackRepository.OAuthCallbackEvent.Success(code, state)
+                )
+            }
+            else -> {
+                Timber.w("OAuth callback received but missing both error and valid code+state — ignoring")
+            }
+        }
     }
 }

--- a/app/src/main/java/com/mydeck/app/MainActivity.kt
+++ b/app/src/main/java/com/mydeck/app/MainActivity.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.remember
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.navigation.compose.rememberNavController
 import dagger.hilt.android.AndroidEntryPoint
+import com.mydeck.app.BuildConfig
 import com.mydeck.app.domain.OAuthCallbackRepository
 import com.mydeck.app.domain.model.resolveEffectiveAppearance
 import com.mydeck.app.domain.model.Theme
@@ -94,12 +95,21 @@ class MainActivity : ComponentActivity() {
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
-        intentState.value = intent
+        // onNewIntent can arrive during resume — after onCreate returns but before setContent's
+        // composition has initialized `intentState` (e.g. the cold-start OAuth redirect after a
+        // process death). Update the activity intent so the initial composition picks it up, and
+        // only touch the Compose state once it actually exists.
+        setIntent(intent)
+        if (::intentState.isInitialized) {
+            intentState.value = intent
+        }
     }
 
     private fun dispatchOAuthCallbackIfPresent(intent: Intent) {
         val data = intent.data ?: return
-        if (data.scheme != "mydeck" || data.host != "oauth-callback") return
+        if (data.scheme != BuildConfig.OAUTH_CALLBACK_SCHEME ||
+            data.host != BuildConfig.OAUTH_CALLBACK_HOST
+        ) return
 
         val code = data.getQueryParameter("code")
         val state = data.getQueryParameter("state")

--- a/app/src/main/java/com/mydeck/app/domain/OAuthCallbackRepository.kt
+++ b/app/src/main/java/com/mydeck/app/domain/OAuthCallbackRepository.kt
@@ -10,6 +10,14 @@ import javax.inject.Singleton
 /**
  * Application-scoped event bus that bridges OAuth redirect intents (received in MainActivity)
  * to the login ViewModel, surviving process death and ViewModel recreation.
+ *
+ * Uses `replay = 1` deliberately: after a full process death the redirect intent can be dispatched
+ * from `MainActivity.onCreate` *before* the recreated ViewModel re-subscribes. With `replay = 0`
+ * that emission would be dropped and the login would hang on the "waiting" screen. With `replay = 1`
+ * the late subscriber still receives the callback.
+ *
+ * The consumer MUST call [consume] once it has handled (or rejected) an event, so a stale callback
+ * is not replayed into a subsequent, unrelated login attempt.
  */
 @Singleton
 class OAuthCallbackRepository @Inject constructor() {
@@ -20,6 +28,7 @@ class OAuthCallbackRepository @Inject constructor() {
     }
 
     private val _events = MutableSharedFlow<OAuthCallbackEvent>(
+        replay = 1,
         extraBufferCapacity = 1,
         onBufferOverflow = BufferOverflow.DROP_OLDEST
     )
@@ -27,5 +36,10 @@ class OAuthCallbackRepository @Inject constructor() {
 
     fun dispatch(event: OAuthCallbackEvent) {
         _events.tryEmit(event)
+    }
+
+    /** Clears the replayed event after it has been handled, so it is not re-delivered. */
+    fun consume() {
+        _events.resetReplayCache()
     }
 }

--- a/app/src/main/java/com/mydeck/app/domain/OAuthCallbackRepository.kt
+++ b/app/src/main/java/com/mydeck/app/domain/OAuthCallbackRepository.kt
@@ -1,0 +1,31 @@
+package com.mydeck.app.domain
+
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Application-scoped event bus that bridges OAuth redirect intents (received in MainActivity)
+ * to the login ViewModel, surviving process death and ViewModel recreation.
+ */
+@Singleton
+class OAuthCallbackRepository @Inject constructor() {
+
+    sealed class OAuthCallbackEvent {
+        data class Success(val code: String, val state: String) : OAuthCallbackEvent()
+        data class Error(val error: String, val errorDescription: String?) : OAuthCallbackEvent()
+    }
+
+    private val _events = MutableSharedFlow<OAuthCallbackEvent>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
+    val events: SharedFlow<OAuthCallbackEvent> = _events.asSharedFlow()
+
+    fun dispatch(event: OAuthCallbackEvent) {
+        _events.tryEmit(event)
+    }
+}

--- a/app/src/main/java/com/mydeck/app/domain/usecase/OAuthAuthorizationCodeUseCase.kt
+++ b/app/src/main/java/com/mydeck/app/domain/usecase/OAuthAuthorizationCodeUseCase.kt
@@ -2,6 +2,7 @@ package com.mydeck.app.domain.usecase
 
 import android.content.Context
 import android.os.Build
+import com.mydeck.app.BuildConfig
 import com.mydeck.app.io.rest.ReadeckApi
 import com.mydeck.app.io.rest.isHttpBlockedByBuildPolicy
 import com.mydeck.app.io.rest.model.OAuthAuthCodeTokenRequestDto
@@ -27,7 +28,9 @@ class OAuthAuthorizationCodeUseCase @Inject constructor(
         private const val REQUIRED_SCOPES = "bookmarks:read bookmarks:write profile:read"
         private const val CLIENT_URI = "https://github.com/NateEaton/mydeck-android"
         private const val SOFTWARE_ID = "com.mydeck.app"
-        const val REDIRECT_URI = "mydeck://oauth-callback"
+        // Derived from the single build-config source so the manifest intent-filter,
+        // MainActivity's matcher, and this registered redirect_uri can never drift.
+        val REDIRECT_URI = "${BuildConfig.OAUTH_CALLBACK_SCHEME}://${BuildConfig.OAUTH_CALLBACK_HOST}"
         private val CLIENT_NAME get() = "MyDeck Android — ${Build.MANUFACTURER} ${Build.MODEL}"
     }
 

--- a/app/src/main/java/com/mydeck/app/domain/usecase/OAuthAuthorizationCodeUseCase.kt
+++ b/app/src/main/java/com/mydeck/app/domain/usecase/OAuthAuthorizationCodeUseCase.kt
@@ -1,0 +1,187 @@
+package com.mydeck.app.domain.usecase
+
+import android.content.Context
+import android.os.Build
+import com.mydeck.app.io.rest.ReadeckApi
+import com.mydeck.app.io.rest.isHttpBlockedByBuildPolicy
+import com.mydeck.app.io.rest.model.OAuthAuthCodeTokenRequestDto
+import com.mydeck.app.io.rest.model.OAuthClientRegistrationRequestDto
+import com.mydeck.app.io.rest.model.OAuthErrorDto
+import com.mydeck.app.util.AppVersion
+import com.mydeck.app.util.PkceUtil
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import timber.log.Timber
+import java.io.IOException
+import javax.inject.Inject
+
+class OAuthAuthorizationCodeUseCase @Inject constructor(
+    private val readeckApi: ReadeckApi,
+    private val json: Json,
+    @ApplicationContext private val context: Context
+) {
+    companion object {
+        private const val GRANT_TYPE_AUTHORIZATION_CODE = "authorization_code"
+        private const val GRANT_TYPE_DEVICE_CODE = "urn:ietf:params:oauth:grant-type:device_code"
+        private const val REQUIRED_SCOPES = "bookmarks:read bookmarks:write profile:read"
+        private const val CLIENT_URI = "https://github.com/NateEaton/mydeck-android"
+        private const val SOFTWARE_ID = "com.mydeck.app"
+        const val REDIRECT_URI = "mydeck://oauth-callback"
+        private val CLIENT_NAME get() = "MyDeck Android — ${Build.MANUFACTURER} ${Build.MODEL}"
+    }
+
+    data class InitiateResult(
+        val authorizeUrl: String,
+        val codeVerifier: String,
+        val state: String,
+        val clientId: String
+    )
+
+    sealed class AuthCodeInitiateResult {
+        data class Ready(val result: InitiateResult) : AuthCodeInitiateResult()
+        data object HttpBlockedByBuildPolicy : AuthCodeInitiateResult()
+        data class Error(val message: String, val exception: Exception? = null) : AuthCodeInitiateResult()
+    }
+
+    sealed class TokenExchangeResult {
+        data class Success(val accessToken: String) : TokenExchangeResult()
+        data class UserDenied(val message: String) : TokenExchangeResult()
+        data object HttpBlockedByBuildPolicy : TokenExchangeResult()
+        data class Error(val message: String, val exception: Exception? = null) : TokenExchangeResult()
+    }
+
+    /**
+     * Step 1: Register an ephemeral OAuth client with authorization_code grant and redirect_uri,
+     * generate PKCE + state, and build the /authorize URL to open in a Custom Tab.
+     */
+    suspend fun initiateAuthorization(serverUrl: String): AuthCodeInitiateResult {
+        try {
+            Timber.d("Registering OAuth client for authorization_code flow")
+            val clientRegistrationRequest = OAuthClientRegistrationRequestDto(
+                clientName = CLIENT_NAME,
+                clientUri = CLIENT_URI,
+                softwareId = SOFTWARE_ID,
+                softwareVersion = AppVersion.versionName(context),
+                grantTypes = listOf(GRANT_TYPE_AUTHORIZATION_CODE, GRANT_TYPE_DEVICE_CODE),
+                redirectUris = listOf(REDIRECT_URI)
+            )
+
+            val clientResponse = readeckApi.registerOAuthClient(clientRegistrationRequest)
+
+            if (!clientResponse.isSuccessful || clientResponse.body() == null) {
+                val errorMessage = parseOAuthError(clientResponse.errorBody()?.string())
+                Timber.e("Client registration failed: $errorMessage")
+                return AuthCodeInitiateResult.Error("Failed to register with server: $errorMessage")
+            }
+
+            val clientId = clientResponse.body()!!.clientId
+            Timber.d("OAuth client registered: $clientId")
+
+            val verifier = PkceUtil.generateCodeVerifier()
+            val challenge = PkceUtil.codeChallenge(verifier)
+            val state = PkceUtil.generateState()
+
+            val authorizeUrl = PkceUtil.buildAuthorizeUrl(
+                serverUrlWithApi = serverUrl,
+                clientId = clientId,
+                redirectUri = REDIRECT_URI,
+                scope = REQUIRED_SCOPES,
+                challenge = challenge,
+                state = state
+            )
+
+            Timber.d("Authorization URL built; opening Custom Tab")
+            return AuthCodeInitiateResult.Ready(
+                InitiateResult(
+                    authorizeUrl = authorizeUrl,
+                    codeVerifier = verifier,
+                    state = state,
+                    clientId = clientId
+                )
+            )
+
+        } catch (e: IOException) {
+            if (e.isHttpBlockedByBuildPolicy()) {
+                Timber.w(e, "HTTP blocked during authorization initiation")
+                return AuthCodeInitiateResult.HttpBlockedByBuildPolicy
+            }
+            Timber.e(e, "Network error during authorization initiation")
+            return AuthCodeInitiateResult.Error("Network error: ${e.message}", e)
+        } catch (e: SerializationException) {
+            Timber.e(e, "Serialization error during authorization initiation")
+            return AuthCodeInitiateResult.Error("Invalid response from server: ${e.message}", e)
+        } catch (e: Exception) {
+            Timber.e(e, "Unexpected error during authorization initiation")
+            return AuthCodeInitiateResult.Error("Unexpected error: ${e.message}", e)
+        }
+    }
+
+    /**
+     * Step 2: Exchange the authorization code for an access token via POST /api/oauth/token.
+     */
+    suspend fun exchangeCode(code: String, codeVerifier: String): TokenExchangeResult {
+        try {
+            Timber.d("Exchanging authorization code for access token")
+            val tokenRequest = OAuthAuthCodeTokenRequestDto(
+                grantType = GRANT_TYPE_AUTHORIZATION_CODE,
+                code = code,
+                codeVerifier = codeVerifier
+            )
+
+            val tokenResponse = readeckApi.requestTokenWithAuthCode(tokenRequest)
+
+            if (tokenResponse.isSuccessful && tokenResponse.body() != null) {
+                Timber.i("Authorization code exchange succeeded")
+                return TokenExchangeResult.Success(tokenResponse.body()!!.accessToken)
+            }
+
+            val errorBody = tokenResponse.errorBody()?.string()
+            if (errorBody.isNullOrBlank()) {
+                Timber.e("Token exchange failed with no error body: ${tokenResponse.code()}")
+                return TokenExchangeResult.Error("Server error: ${tokenResponse.code()}")
+            }
+
+            val oauthError = try {
+                json.decodeFromString<OAuthErrorDto>(errorBody)
+            } catch (e: SerializationException) {
+                Timber.e(e, "Failed to parse OAuth error response")
+                return TokenExchangeResult.Error("Invalid error response from server")
+            }
+
+            Timber.w("Token exchange OAuth error: ${oauthError.error} — ${oauthError.errorDescription}")
+            return when (oauthError.error) {
+                "access_denied" ->
+                    TokenExchangeResult.UserDenied(oauthError.errorDescription ?: "Authorization was denied")
+                "invalid_grant" ->
+                    TokenExchangeResult.Error(oauthError.errorDescription ?: "Invalid authorization code")
+                else ->
+                    TokenExchangeResult.Error(oauthError.errorDescription ?: "Unknown error: ${oauthError.error}")
+            }
+
+        } catch (e: IOException) {
+            if (e.isHttpBlockedByBuildPolicy()) {
+                Timber.w(e, "HTTP blocked during token exchange")
+                return TokenExchangeResult.HttpBlockedByBuildPolicy
+            }
+            Timber.e(e, "Network error during token exchange")
+            return TokenExchangeResult.Error("Network error: ${e.message}", e)
+        } catch (e: SerializationException) {
+            Timber.e(e, "Serialization error during token exchange")
+            return TokenExchangeResult.Error("Invalid response from server: ${e.message}", e)
+        } catch (e: Exception) {
+            Timber.e(e, "Unexpected error during token exchange")
+            return TokenExchangeResult.Error("Unexpected error: ${e.message}", e)
+        }
+    }
+
+    private fun parseOAuthError(errorBody: String?): String {
+        if (errorBody.isNullOrBlank()) return "Unknown error"
+        return try {
+            val oauthError = json.decodeFromString<OAuthErrorDto>(errorBody)
+            oauthError.errorDescription ?: oauthError.error
+        } catch (e: SerializationException) {
+            "Server error"
+        }
+    }
+}

--- a/app/src/main/java/com/mydeck/app/io/rest/ReadeckApi.kt
+++ b/app/src/main/java/com/mydeck/app/io/rest/ReadeckApi.kt
@@ -14,6 +14,7 @@ import com.mydeck.app.io.rest.model.OAuthClientRegistrationRequestDto
 import com.mydeck.app.io.rest.model.OAuthClientRegistrationResponseDto
 import com.mydeck.app.io.rest.model.OAuthDeviceAuthorizationRequestDto
 import com.mydeck.app.io.rest.model.OAuthDeviceAuthorizationResponseDto
+import com.mydeck.app.io.rest.model.OAuthAuthCodeTokenRequestDto
 import com.mydeck.app.io.rest.model.OAuthRevokeRequestDto
 import com.mydeck.app.io.rest.model.OAuthTokenRequestDto
 import com.mydeck.app.io.rest.model.OAuthTokenResponseDto
@@ -75,6 +76,11 @@ interface ReadeckApi {
     @POST("oauth/token")
     suspend fun requestToken(
         @Body body: OAuthTokenRequestDto
+    ): Response<OAuthTokenResponseDto>
+
+    @POST("oauth/token")
+    suspend fun requestTokenWithAuthCode(
+        @Body body: OAuthAuthCodeTokenRequestDto
     ): Response<OAuthTokenResponseDto>
 
     @POST("oauth/revoke")

--- a/app/src/main/java/com/mydeck/app/io/rest/model/OAuthAuthCodeTokenRequestDto.kt
+++ b/app/src/main/java/com/mydeck/app/io/rest/model/OAuthAuthCodeTokenRequestDto.kt
@@ -1,0 +1,16 @@
+package com.mydeck.app.io.rest.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class OAuthAuthCodeTokenRequestDto(
+    @SerialName("grant_type")
+    val grantType: String,
+
+    @SerialName("code")
+    val code: String,
+
+    @SerialName("code_verifier")
+    val codeVerifier: String
+)

--- a/app/src/main/java/com/mydeck/app/io/rest/model/OAuthClientRegistrationRequestDto.kt
+++ b/app/src/main/java/com/mydeck/app/io/rest/model/OAuthClientRegistrationRequestDto.kt
@@ -18,5 +18,8 @@ data class OAuthClientRegistrationRequestDto(
     val softwareVersion: String,
 
     @SerialName("grant_types")
-    val grantTypes: List<String>
+    val grantTypes: List<String>,
+
+    @SerialName("redirect_uris")
+    val redirectUris: List<String>? = null
 )

--- a/app/src/main/java/com/mydeck/app/ui/settings/AccountSettingsScreen.kt
+++ b/app/src/main/java/com/mydeck/app/ui/settings/AccountSettingsScreen.kt
@@ -22,7 +22,9 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import com.mydeck.app.R
+import com.mydeck.app.ui.components.MyDeckBrandHeader
 import com.mydeck.app.ui.login.DeviceAuthorizationScreen
+import com.mydeck.app.util.openUrlInCustomTab
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -32,6 +34,7 @@ fun AccountSettingsScreen(
 ) {
     val settingsUiState = viewModel.uiState.collectAsState().value
     val keyboardController = LocalSoftwareKeyboardController.current
+    val context = LocalContext.current
     val onUrlChanged: (String) -> Unit = { url -> viewModel.updateUrl(url) }
     val onLoginClicked: () -> Unit = { viewModel.login() }
     val onSignOut: () -> Unit = { viewModel.signOut() }
@@ -52,27 +55,82 @@ fun AccountSettingsScreen(
         }
     ) { scaffoldPadding ->
 
-    // When device authorization is in progress, show the auth screen instead of the form
-    if (settingsUiState.authStatus is AccountSettingsViewModel.AuthStatus.WaitingForAuthorization &&
-        settingsUiState.deviceAuthState != null) {
-        DeviceAuthorizationScreen(
-            userCode = settingsUiState.deviceAuthState!!.userCode,
-            verificationUri = settingsUiState.deviceAuthState!!.verificationUri,
-            verificationUriComplete = settingsUiState.deviceAuthState!!.verificationUriComplete,
-            expiresAt = settingsUiState.deviceAuthState!!.expiresAt,
-            onCancel = { viewModel.cancelAuthorization() },
-            modifier = Modifier.padding(scaffoldPadding)
-        )
-    } else {
+    when {
+        settingsUiState.authStatus is AccountSettingsViewModel.AuthStatus.WaitingForAuthorization &&
+            settingsUiState.deviceAuthState != null -> {
+            DeviceAuthorizationScreen(
+                userCode = settingsUiState.deviceAuthState!!.userCode,
+                verificationUri = settingsUiState.deviceAuthState!!.verificationUri,
+                verificationUriComplete = settingsUiState.deviceAuthState!!.verificationUriComplete,
+                expiresAt = settingsUiState.deviceAuthState!!.expiresAt,
+                onCancel = { viewModel.cancelAuthorization() },
+                modifier = Modifier.padding(scaffoldPadding)
+            )
+        }
+        settingsUiState.authStatus is AccountSettingsViewModel.AuthStatus.BrowserLaunched ||
+            settingsUiState.authStatus is AccountSettingsViewModel.AuthStatus.Exchanging -> {
+            BrowserLoginWaitingScreen(
+                isExchanging = settingsUiState.authStatus is AccountSettingsViewModel.AuthStatus.Exchanging,
+                onCancel = { viewModel.cancelAuthorization() },
+                onUseCodeInstead = { viewModel.switchToDeviceCodeFlow() },
+                modifier = Modifier.padding(scaffoldPadding)
+            )
+        }
+        else -> {
+            LoginFormContent(
+                settingsUiState = settingsUiState,
+                onUrlChanged = onUrlChanged,
+                onLoginClicked = onLoginClicked,
+                onSignInWithCodeClicked = { viewModel.switchToDeviceCodeFlow() },
+                onSignOut = onSignOut,
+                keyboardController = keyboardController,
+                modifier = Modifier.padding(scaffoldPadding)
+            )
+        }
+    }
 
+    } // end Scaffold
+
+    LaunchedEffect(Unit) {
+        viewModel.navigationEvent.collectLatest { event ->
+            when (event) {
+                is AccountSettingsViewModel.NavigationEvent.NavigateBack -> {
+                    navHostController.popBackStack()
+                }
+                is AccountSettingsViewModel.NavigationEvent.NavigateToBookmarkList -> {
+                    navHostController.navigate(com.mydeck.app.ui.navigation.BookmarkListRoute()) {
+                        popUpTo(com.mydeck.app.ui.navigation.AccountSettingsRoute) { inclusive = true }
+                    }
+                }
+            }
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.browserLaunchEvent.collect { url ->
+            openUrlInCustomTab(context, url)
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun LoginFormContent(
+    settingsUiState: AccountSettingsViewModel.AccountSettingsUiState,
+    onUrlChanged: (String) -> Unit,
+    onLoginClicked: () -> Unit,
+    onSignInWithCodeClicked: () -> Unit,
+    onSignOut: () -> Unit,
+    keyboardController: androidx.compose.ui.platform.SoftwareKeyboardController?,
+    modifier: Modifier = Modifier
+) {
     LazyColumn(
-        modifier = Modifier
-            .padding(scaffoldPadding)
+        modifier = modifier
             .padding(16.dp)
             .fillMaxSize(),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(8.dp),
-        contentPadding = androidx.compose.foundation.layout.PaddingValues(bottom = 48.dp)
+        contentPadding = PaddingValues(bottom = 48.dp)
     ) {
         item {
             OutlinedTextField(
@@ -112,7 +170,16 @@ fun AccountSettingsScreen(
             )
         }
 
-        // Error message display
+        item {
+            TextButton(
+                onClick = onSignInWithCodeClicked,
+                enabled = settingsUiState.loginEnabled && settingsUiState.authStatus !is AccountSettingsViewModel.AuthStatus.Loading,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(stringResource(R.string.account_settings_sign_in_with_code))
+            }
+        }
+
         if (settingsUiState.authStatus is AccountSettingsViewModel.AuthStatus.Error) {
             item {
                 Text(
@@ -126,7 +193,6 @@ fun AccountSettingsScreen(
             }
         }
 
-        // Sign-out section (only show when logged in)
         if (settingsUiState.isLoggedIn) {
             item {
                 HorizontalDivider(modifier = Modifier.padding(vertical = 16.dp))
@@ -152,22 +218,62 @@ fun AccountSettingsScreen(
             }
         }
     }
+}
 
-    } // end else (non-auth form)
-    } // end Scaffold
+@Composable
+internal fun BrowserLoginWaitingScreen(
+    isExchanging: Boolean,
+    onCancel: () -> Unit,
+    onUseCodeInstead: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 20.dp, vertical = 24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Spacer(modifier = Modifier.height(24.dp))
 
-    LaunchedEffect(Unit) {
-        viewModel.navigationEvent.collectLatest { event ->
-            when (event) {
-                is AccountSettingsViewModel.NavigationEvent.NavigateBack -> {
-                    navHostController.popBackStack()
-                }
-                is AccountSettingsViewModel.NavigationEvent.NavigateToBookmarkList -> {
-                    navHostController.navigate(com.mydeck.app.ui.navigation.BookmarkListRoute()) {
-                        popUpTo(com.mydeck.app.ui.navigation.AccountSettingsRoute) { inclusive = true }
-                    }
-                }
+        MyDeckBrandHeader()
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        CircularProgressIndicator(modifier = Modifier.size(40.dp), strokeWidth = 3.dp)
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Text(
+            text = if (isExchanging) {
+                stringResource(R.string.oauth_auth_code_exchanging)
+            } else {
+                stringResource(R.string.oauth_auth_code_browser_launched)
+            },
+            style = MaterialTheme.typography.bodyLarge,
+            textAlign = TextAlign.Center
+        )
+
+        if (!isExchanging) {
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = stringResource(R.string.oauth_auth_code_browser_hint),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center
+            )
+        }
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        if (!isExchanging) {
+            TextButton(onClick = onUseCodeInstead) {
+                Text(stringResource(R.string.account_settings_sign_in_with_code))
             }
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+
+        OutlinedButton(onClick = onCancel, modifier = Modifier.fillMaxWidth()) {
+            Text(stringResource(android.R.string.cancel))
         }
     }
 }
@@ -191,7 +297,7 @@ fun LoginButton(
                     strokeWidth = 2.dp
                 )
                 Spacer(modifier = Modifier.width(8.dp))
-                Text("Signing in...")
+                Text(stringResource(R.string.account_settings_signing_in))
             }
             else -> {
                 Text(stringResource(R.string.account_settings_login))

--- a/app/src/main/java/com/mydeck/app/ui/settings/AccountSettingsViewModel.kt
+++ b/app/src/main/java/com/mydeck/app/ui/settings/AccountSettingsViewModel.kt
@@ -129,6 +129,7 @@ class AccountSettingsViewModel @Inject constructor(
     fun login() {
         val url = normalizeApiUrl(_uiState.value.url)
         Timber.d("login() called with normalized URL: $url")
+        pollingJob?.cancel()
         authCodeJob?.cancel()
         authCodeJob = viewModelScope.launch {
             startAuthCodeLogin(url)
@@ -139,6 +140,7 @@ class AccountSettingsViewModel @Inject constructor(
     fun switchToDeviceCodeFlow() {
         authCodeJob?.cancel()
         clearAuthCodePendingState()
+        oauthCallbackRepository.consume()
         if (!isValidUrlForCurrentSettings(_uiState.value.url)) {
             _uiState.update { it.copy(authStatus = AuthStatus.Idle) }
             return
@@ -151,6 +153,8 @@ class AccountSettingsViewModel @Inject constructor(
 
     private suspend fun startAuthCodeLogin(url: String) {
         _uiState.update { it.copy(authStatus = AuthStatus.Loading) }
+        // Drop any stale callback from a prior attempt before we subscribe for this one.
+        oauthCallbackRepository.consume()
         settingsDataStore.saveUrl(url)
 
         when (val result = oauthAuthCodeUseCase.initiateAuthorization(url)) {
@@ -178,56 +182,58 @@ class AccountSettingsViewModel @Inject constructor(
     }
 
     private suspend fun awaitOAuthCallback(serverUrl: String, codeVerifier: String, expectedState: String) {
-        oauthCallbackRepository.events.first { event ->
-            when (event) {
-                is OAuthCallbackRepository.OAuthCallbackEvent.Success -> {
-                    if (event.state != expectedState) {
-                        Timber.e("OAuth state mismatch — possible CSRF. Expected $expectedState, got ${event.state}")
-                        _uiState.update {
-                            it.copy(authStatus = AuthStatus.Error(context.getString(R.string.oauth_auth_code_state_mismatch_error)))
-                        }
-                        clearAuthCodePendingState()
-                        return@first true
-                    }
-                    _uiState.update { it.copy(authStatus = AuthStatus.Exchanging) }
-                    when (val exchangeResult = oauthAuthCodeUseCase.exchangeCode(event.code, codeVerifier)) {
-                        is OAuthAuthorizationCodeUseCase.TokenExchangeResult.Success -> {
-                            clearAuthCodePendingState()
-                            when (val loginResult = userRepository.completeLogin(serverUrl, exchangeResult.accessToken)) {
-                                is UserRepository.LoginResult.Success -> onLoginSuccess()
-                                is UserRepository.LoginResult.Error ->
-                                    _uiState.update { it.copy(authStatus = AuthStatus.Error(loginResult.errorMessage)) }
-                                UserRepository.LoginResult.HttpBlockedByBuildPolicy ->
-                                    _uiState.update { it.copy(authStatus = AuthStatus.Error(context.getString(R.string.account_settings_http_blocked_error))) }
-                                else ->
-                                    _uiState.update { it.copy(authStatus = AuthStatus.Error(context.getString(R.string.oauth_auth_code_exchange_failed))) }
-                            }
-                        }
-                        is OAuthAuthorizationCodeUseCase.TokenExchangeResult.UserDenied -> {
-                            clearAuthCodePendingState()
-                            _uiState.update { it.copy(authStatus = AuthStatus.Error(exchangeResult.message)) }
-                        }
-                        OAuthAuthorizationCodeUseCase.TokenExchangeResult.HttpBlockedByBuildPolicy -> {
-                            clearAuthCodePendingState()
-                            _uiState.update { it.copy(authStatus = AuthStatus.Error(context.getString(R.string.account_settings_http_blocked_error))) }
-                        }
-                        is OAuthAuthorizationCodeUseCase.TokenExchangeResult.Error -> {
-                            clearAuthCodePendingState()
-                            _uiState.update { it.copy(authStatus = AuthStatus.Error(exchangeResult.message)) }
-                        }
-                    }
-                    true
-                }
-                is OAuthCallbackRepository.OAuthCallbackEvent.Error -> {
-                    Timber.w("OAuth callback error: ${event.error} — ${event.errorDescription}")
+        // Suspends until MainActivity dispatches a redirect. `events` has replay=1 so a callback
+        // delivered before this subscription (e.g. after process death) is still received here.
+        val event = oauthCallbackRepository.events.first()
+        // Clear the replay cache immediately so this callback can't be re-delivered to a later flow.
+        oauthCallbackRepository.consume()
+
+        when (event) {
+            is OAuthCallbackRepository.OAuthCallbackEvent.Success -> {
+                if (event.state != expectedState) {
+                    Timber.e("OAuth state mismatch — possible CSRF. Expected $expectedState, got ${event.state}")
                     clearAuthCodePendingState()
-                    val message = when (event.error) {
-                        "access_denied" -> context.getString(R.string.oauth_auth_code_access_denied)
-                        else -> event.errorDescription ?: context.getString(R.string.oauth_auth_code_exchange_failed)
+                    _uiState.update {
+                        it.copy(authStatus = AuthStatus.Error(context.getString(R.string.oauth_auth_code_state_mismatch_error)))
                     }
-                    _uiState.update { it.copy(authStatus = AuthStatus.Error(message)) }
-                    true
+                    return
                 }
+                _uiState.update { it.copy(authStatus = AuthStatus.Exchanging) }
+                when (val exchangeResult = oauthAuthCodeUseCase.exchangeCode(event.code, codeVerifier)) {
+                    is OAuthAuthorizationCodeUseCase.TokenExchangeResult.Success -> {
+                        clearAuthCodePendingState()
+                        when (val loginResult = userRepository.completeLogin(serverUrl, exchangeResult.accessToken)) {
+                            is UserRepository.LoginResult.Success -> onLoginSuccess()
+                            is UserRepository.LoginResult.Error ->
+                                _uiState.update { it.copy(authStatus = AuthStatus.Error(loginResult.errorMessage)) }
+                            UserRepository.LoginResult.HttpBlockedByBuildPolicy ->
+                                _uiState.update { it.copy(authStatus = AuthStatus.Error(context.getString(R.string.account_settings_http_blocked_error))) }
+                            else ->
+                                _uiState.update { it.copy(authStatus = AuthStatus.Error(context.getString(R.string.oauth_auth_code_exchange_failed))) }
+                        }
+                    }
+                    is OAuthAuthorizationCodeUseCase.TokenExchangeResult.UserDenied -> {
+                        clearAuthCodePendingState()
+                        _uiState.update { it.copy(authStatus = AuthStatus.Error(exchangeResult.message)) }
+                    }
+                    OAuthAuthorizationCodeUseCase.TokenExchangeResult.HttpBlockedByBuildPolicy -> {
+                        clearAuthCodePendingState()
+                        _uiState.update { it.copy(authStatus = AuthStatus.Error(context.getString(R.string.account_settings_http_blocked_error))) }
+                    }
+                    is OAuthAuthorizationCodeUseCase.TokenExchangeResult.Error -> {
+                        clearAuthCodePendingState()
+                        _uiState.update { it.copy(authStatus = AuthStatus.Error(exchangeResult.message)) }
+                    }
+                }
+            }
+            is OAuthCallbackRepository.OAuthCallbackEvent.Error -> {
+                Timber.w("OAuth callback error: ${event.error} — ${event.errorDescription}")
+                clearAuthCodePendingState()
+                val message = when (event.error) {
+                    "access_denied" -> context.getString(R.string.oauth_auth_code_access_denied)
+                    else -> event.errorDescription ?: context.getString(R.string.oauth_auth_code_exchange_failed)
+                }
+                _uiState.update { it.copy(authStatus = AuthStatus.Error(message)) }
             }
         }
     }
@@ -372,32 +378,33 @@ class AccountSettingsViewModel @Inject constructor(
      * on constrained ENQUEUED/BLOCKED states.
      */
     private suspend fun onLoginSuccess() {
-        try {
-            prepareForInitialSync()
-            val initialSyncWorkId = LoadBookmarksWorker.enqueue(context, isInitialLoad = true)
-
-            if (waitForInitialSyncToStart(initialSyncWorkId) == InitialSyncStartResult.TIMED_OUT) {
-                Timber.w("Initial sync did not start within timeout; cancelling work.")
-                workManager.cancelWorkById(initialSyncWorkId)
-            }
-
-            _uiState.update {
-                it.copy(
-                    authStatus = AuthStatus.Success,
-                    isLoggedIn = true,
-                    deviceAuthState = null
-                )
-            }
-            _navigationEvent.trySend(NavigationEvent.NavigateToBookmarkList)
-        } catch (e: Exception) {
-            Timber.e(e, "Failed to prepare initial sync after login")
-            _uiState.update {
-                it.copy(
-                    authStatus = AuthStatus.Error(context.getString(R.string.account_settings_initial_sync_failed)),
-                    deviceAuthState = null
-                )
+        // Run the post-login initial sync on the application scope so navigation or this
+        // ViewModel being cleared — e.g. while the process-death OAuth restore settles — cannot
+        // cancel it mid-flight and leave the bookmark list unpopulated. Mirrors the device-code
+        // polling job, which runs on applicationScope for the same reason.
+        val syncJob = applicationScope.launch {
+            try {
+                prepareForInitialSync()
+                val initialSyncWorkId = LoadBookmarksWorker.enqueue(context, isInitialLoad = true)
+                if (waitForInitialSyncToStart(initialSyncWorkId) == InitialSyncStartResult.TIMED_OUT) {
+                    Timber.w("Initial sync did not start within timeout; cancelling work.")
+                    workManager.cancelWorkById(initialSyncWorkId)
+                }
+            } catch (e: Exception) {
+                // A failed initial sync must not block login — the list recovers on next refresh.
+                Timber.e(e, "Initial sync after login failed to start")
             }
         }
+        syncJob.join()
+
+        _uiState.update {
+            it.copy(
+                authStatus = AuthStatus.Success,
+                isLoggedIn = true,
+                deviceAuthState = null
+            )
+        }
+        _navigationEvent.trySend(NavigationEvent.NavigateToBookmarkList)
     }
 
     private suspend fun prepareForInitialSync() {
@@ -433,6 +440,7 @@ class AccountSettingsViewModel @Inject constructor(
         pollingJob?.cancel()
         authCodeJob?.cancel()
         clearAuthCodePendingState()
+        oauthCallbackRepository.consume()
         _uiState.update {
             it.copy(authStatus = AuthStatus.Idle, deviceAuthState = null)
         }

--- a/app/src/main/java/com/mydeck/app/ui/settings/AccountSettingsViewModel.kt
+++ b/app/src/main/java/com/mydeck/app/ui/settings/AccountSettingsViewModel.kt
@@ -1,16 +1,20 @@
 package com.mydeck.app.ui.settings
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import android.content.Context
 import com.mydeck.app.BuildConfig
 import com.mydeck.app.R
 import com.mydeck.app.domain.BookmarkRepository
+import com.mydeck.app.domain.OAuthCallbackRepository
 import com.mydeck.app.domain.UserRepository
 import com.mydeck.app.domain.model.OAuthDeviceAuthorizationState
+import com.mydeck.app.domain.usecase.OAuthAuthorizationCodeUseCase
 import com.mydeck.app.domain.usecase.OAuthDeviceAuthorizationUseCase
 import com.mydeck.app.io.prefs.SettingsDataStore
 import com.mydeck.app.ui.migration.HttpUrlMigrationLoginCoordinator
+import com.mydeck.app.util.openUrlInCustomTab
 import com.mydeck.app.worker.LoadBookmarksWorker
 import com.mydeck.app.util.isValidUrl
 import com.mydeck.app.coroutine.ApplicationScope
@@ -40,10 +44,13 @@ import java.util.UUID
 
 @HiltViewModel
 class AccountSettingsViewModel @Inject constructor(
+    private val savedStateHandle: SavedStateHandle,
     private val settingsDataStore: SettingsDataStore,
     private val bookmarkRepository: BookmarkRepository,
     private val userRepository: UserRepository,
     private val oauthDeviceAuthUseCase: OAuthDeviceAuthorizationUseCase,
+    private val oauthAuthCodeUseCase: OAuthAuthorizationCodeUseCase,
+    private val oauthCallbackRepository: OAuthCallbackRepository,
     private val workManager: WorkManager,
     @ApplicationContext private val context: Context,
     @ApplicationScope private val applicationScope: CoroutineScope,
@@ -64,6 +71,8 @@ class AccountSettingsViewModel @Inject constructor(
         data object Idle : AuthStatus()
         data object Loading : AuthStatus()
         data object WaitingForAuthorization : AuthStatus()
+        data object BrowserLaunched : AuthStatus()
+        data object Exchanging : AuthStatus()
         data object Success : AuthStatus()
         data class Error(val message: String) : AuthStatus()
     }
@@ -74,7 +83,11 @@ class AccountSettingsViewModel @Inject constructor(
     private val _navigationEvent = Channel<NavigationEvent>(Channel.BUFFERED)
     val navigationEvent: Flow<NavigationEvent> = _navigationEvent.receiveAsFlow()
 
+    private val _browserLaunchEvent = Channel<String>(Channel.BUFFERED)
+    val browserLaunchEvent: Flow<String> = _browserLaunchEvent.receiveAsFlow()
+
     private var pollingJob: Job? = null
+    private var authCodeJob: Job? = null
 
     sealed class NavigationEvent {
         data object NavigateToBookmarkList : NavigationEvent()
@@ -93,7 +106,17 @@ class AccountSettingsViewModel @Inject constructor(
                 )
             }
             if (pendingMigrationLoginUrl != null) {
-                startLogin(pendingMigrationLoginUrl)
+                startDeviceCodeLogin(pendingMigrationLoginUrl)
+            } else {
+                // Restore BrowserLaunched state after process death during Custom Tab
+                val pendingVerifier = savedStateHandle.get<String>(KEY_CODE_VERIFIER)
+                val pendingState = savedStateHandle.get<String>(KEY_AUTH_STATE)
+                val pendingServerUrl = savedStateHandle.get<String>(KEY_SERVER_URL)
+                if (pendingVerifier != null && pendingState != null && pendingServerUrl != null) {
+                    Timber.d("Restoring BrowserLaunched state after process death")
+                    _uiState.update { it.copy(authStatus = AuthStatus.BrowserLaunched) }
+                    awaitOAuthCallback(pendingServerUrl, pendingVerifier, pendingState)
+                }
             }
         }
     }
@@ -102,16 +125,120 @@ class AccountSettingsViewModel @Inject constructor(
         validateUrl(url)
     }
 
+    /** Primary sign-in action — launches browser-based OAuth Authorization Code + PKCE flow. */
     fun login() {
         val url = normalizeApiUrl(_uiState.value.url)
         Timber.d("login() called with normalized URL: $url")
-
-        viewModelScope.launch {
-            startLogin(url)
+        authCodeJob?.cancel()
+        authCodeJob = viewModelScope.launch {
+            startAuthCodeLogin(url)
         }
     }
 
-    private suspend fun startLogin(url: String) {
+    /** Switches to the Device Code flow, cancelling any in-progress auth-code flow. */
+    fun switchToDeviceCodeFlow() {
+        authCodeJob?.cancel()
+        clearAuthCodePendingState()
+        if (!isValidUrlForCurrentSettings(_uiState.value.url)) {
+            _uiState.update { it.copy(authStatus = AuthStatus.Idle) }
+            return
+        }
+        val url = normalizeApiUrl(_uiState.value.url)
+        viewModelScope.launch {
+            startDeviceCodeLogin(url)
+        }
+    }
+
+    private suspend fun startAuthCodeLogin(url: String) {
+        _uiState.update { it.copy(authStatus = AuthStatus.Loading) }
+        settingsDataStore.saveUrl(url)
+
+        when (val result = oauthAuthCodeUseCase.initiateAuthorization(url)) {
+            is OAuthAuthorizationCodeUseCase.AuthCodeInitiateResult.Ready -> {
+                val initResult = result.result
+                // Persist PKCE state for process-death survival
+                savedStateHandle[KEY_CODE_VERIFIER] = initResult.codeVerifier
+                savedStateHandle[KEY_AUTH_STATE] = initResult.state
+                savedStateHandle[KEY_SERVER_URL] = url
+
+                _uiState.update { it.copy(authStatus = AuthStatus.BrowserLaunched) }
+                _browserLaunchEvent.trySend(initResult.authorizeUrl)
+                awaitOAuthCallback(url, initResult.codeVerifier, initResult.state)
+            }
+
+            OAuthAuthorizationCodeUseCase.AuthCodeInitiateResult.HttpBlockedByBuildPolicy -> {
+                _uiState.update { it.copy(authStatus = AuthStatus.Error(context.getString(R.string.account_settings_http_blocked_error))) }
+            }
+
+            is OAuthAuthorizationCodeUseCase.AuthCodeInitiateResult.Error -> {
+                Timber.e("Auth code initiation error: ${result.message}")
+                _uiState.update { it.copy(authStatus = AuthStatus.Error(result.message)) }
+            }
+        }
+    }
+
+    private suspend fun awaitOAuthCallback(serverUrl: String, codeVerifier: String, expectedState: String) {
+        oauthCallbackRepository.events.first { event ->
+            when (event) {
+                is OAuthCallbackRepository.OAuthCallbackEvent.Success -> {
+                    if (event.state != expectedState) {
+                        Timber.e("OAuth state mismatch — possible CSRF. Expected $expectedState, got ${event.state}")
+                        _uiState.update {
+                            it.copy(authStatus = AuthStatus.Error(context.getString(R.string.oauth_auth_code_state_mismatch_error)))
+                        }
+                        clearAuthCodePendingState()
+                        return@first true
+                    }
+                    _uiState.update { it.copy(authStatus = AuthStatus.Exchanging) }
+                    when (val exchangeResult = oauthAuthCodeUseCase.exchangeCode(event.code, codeVerifier)) {
+                        is OAuthAuthorizationCodeUseCase.TokenExchangeResult.Success -> {
+                            clearAuthCodePendingState()
+                            when (val loginResult = userRepository.completeLogin(serverUrl, exchangeResult.accessToken)) {
+                                is UserRepository.LoginResult.Success -> onLoginSuccess()
+                                is UserRepository.LoginResult.Error ->
+                                    _uiState.update { it.copy(authStatus = AuthStatus.Error(loginResult.errorMessage)) }
+                                UserRepository.LoginResult.HttpBlockedByBuildPolicy ->
+                                    _uiState.update { it.copy(authStatus = AuthStatus.Error(context.getString(R.string.account_settings_http_blocked_error))) }
+                                else ->
+                                    _uiState.update { it.copy(authStatus = AuthStatus.Error(context.getString(R.string.oauth_auth_code_exchange_failed))) }
+                            }
+                        }
+                        is OAuthAuthorizationCodeUseCase.TokenExchangeResult.UserDenied -> {
+                            clearAuthCodePendingState()
+                            _uiState.update { it.copy(authStatus = AuthStatus.Error(exchangeResult.message)) }
+                        }
+                        OAuthAuthorizationCodeUseCase.TokenExchangeResult.HttpBlockedByBuildPolicy -> {
+                            clearAuthCodePendingState()
+                            _uiState.update { it.copy(authStatus = AuthStatus.Error(context.getString(R.string.account_settings_http_blocked_error))) }
+                        }
+                        is OAuthAuthorizationCodeUseCase.TokenExchangeResult.Error -> {
+                            clearAuthCodePendingState()
+                            _uiState.update { it.copy(authStatus = AuthStatus.Error(exchangeResult.message)) }
+                        }
+                    }
+                    true
+                }
+                is OAuthCallbackRepository.OAuthCallbackEvent.Error -> {
+                    Timber.w("OAuth callback error: ${event.error} — ${event.errorDescription}")
+                    clearAuthCodePendingState()
+                    val message = when (event.error) {
+                        "access_denied" -> context.getString(R.string.oauth_auth_code_access_denied)
+                        else -> event.errorDescription ?: context.getString(R.string.oauth_auth_code_exchange_failed)
+                    }
+                    _uiState.update { it.copy(authStatus = AuthStatus.Error(message)) }
+                    true
+                }
+            }
+        }
+    }
+
+    private fun clearAuthCodePendingState() {
+        savedStateHandle.remove<String>(KEY_CODE_VERIFIER)
+        savedStateHandle.remove<String>(KEY_AUTH_STATE)
+        savedStateHandle.remove<String>(KEY_SERVER_URL)
+    }
+
+    private suspend fun startDeviceCodeLogin(url: String) {
         _uiState.update { it.copy(authStatus = AuthStatus.Loading) }
 
         val result = userRepository.initiateLogin(url)
@@ -129,7 +256,6 @@ class AccountSettingsViewModel @Inject constructor(
             }
 
             is UserRepository.LoginResult.Success -> {
-                // Shouldn't happen from initiateLogin, but handle it
                 onLoginSuccess()
             }
 
@@ -180,7 +306,6 @@ class AccountSettingsViewModel @Inject constructor(
                     is OAuthDeviceAuthorizationUseCase.TokenPollResult.Success -> {
                         Timber.i("Token received, completing login")
 
-                        // Complete login: save token, fetch profile
                         when (val loginResult = userRepository.completeLogin(url, result.accessToken)) {
                             is UserRepository.LoginResult.Success -> onLoginSuccess()
                             is UserRepository.LoginResult.Error -> {
@@ -221,7 +346,6 @@ class AccountSettingsViewModel @Inject constructor(
 
                     is OAuthDeviceAuthorizationUseCase.TokenPollResult.NetworkError -> {
                         Timber.w("Network error during polling, will retry: ${result.message}")
-                        // Don't break — transient network errors are retryable
                     }
 
                     OAuthDeviceAuthorizationUseCase.TokenPollResult.HttpBlockedByBuildPolicy -> {
@@ -304,8 +428,11 @@ class AccountSettingsViewModel @Inject constructor(
         }
     }
 
+    /** Cancels any in-progress auth flow (device-code polling or auth-code await) and resets state. */
     fun cancelAuthorization() {
         pollingJob?.cancel()
+        authCodeJob?.cancel()
+        clearAuthCodePendingState()
         _uiState.update {
             it.copy(authStatus = AuthStatus.Idle, deviceAuthState = null)
         }
@@ -317,7 +444,7 @@ class AccountSettingsViewModel @Inject constructor(
             val logoutResult = userRepository.logout()
             Timber.d("logout result: $logoutResult")
             _uiState.update {
-                AccountSettingsUiState(url = it.url) // Reset to logged-out state
+                AccountSettingsUiState(url = it.url)
             }
         }
     }
@@ -388,5 +515,8 @@ class AccountSettingsViewModel @Inject constructor(
 
     private companion object {
         val INITIAL_SYNC_START_TIMEOUT = 20.seconds
+        const val KEY_CODE_VERIFIER = "oauth_code_verifier"
+        const val KEY_AUTH_STATE = "oauth_auth_state"
+        const val KEY_SERVER_URL = "oauth_server_url"
     }
 }

--- a/app/src/main/java/com/mydeck/app/ui/welcome/WelcomeScreen.kt
+++ b/app/src/main/java/com/mydeck/app/ui/welcome/WelcomeScreen.kt
@@ -19,10 +19,13 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
+import androidx.compose.ui.platform.LocalContext
 import com.mydeck.app.R
 import com.mydeck.app.ui.components.MyDeckBrandHeader
 import com.mydeck.app.ui.login.DeviceAuthorizationScreen
 import com.mydeck.app.ui.navigation.AboutRoute
+import com.mydeck.app.ui.settings.BrowserLoginWaitingScreen
+import com.mydeck.app.util.openUrlInCustomTab
 import com.mydeck.app.ui.navigation.BookmarkListRoute
 import com.mydeck.app.ui.navigation.LogViewRoute
 import com.mydeck.app.ui.navigation.UserGuideRoute
@@ -38,6 +41,13 @@ fun WelcomeScreen(
 ) {
     val settingsUiState = viewModel.uiState.collectAsState().value
     val keyboardController = LocalSoftwareKeyboardController.current
+    val context = LocalContext.current
+
+    LaunchedEffect(Unit) {
+        viewModel.browserLaunchEvent.collect { url ->
+            openUrlInCustomTab(context, url)
+        }
+    }
 
     LaunchedEffect(Unit) {
         viewModel.navigationEvent.collectLatest { event ->
@@ -55,17 +65,28 @@ fun WelcomeScreen(
     }
 
     Scaffold { scaffoldPadding ->
-        if (settingsUiState.authStatus is AccountSettingsViewModel.AuthStatus.WaitingForAuthorization &&
-            settingsUiState.deviceAuthState != null) {
-            DeviceAuthorizationScreen(
-                userCode = settingsUiState.deviceAuthState!!.userCode,
-                verificationUri = settingsUiState.deviceAuthState!!.verificationUri,
-                verificationUriComplete = settingsUiState.deviceAuthState!!.verificationUriComplete,
-                expiresAt = settingsUiState.deviceAuthState!!.expiresAt,
-                onCancel = { viewModel.cancelAuthorization() },
-                modifier = Modifier.padding(scaffoldPadding)
-            )
-        } else {
+        when {
+            settingsUiState.authStatus is AccountSettingsViewModel.AuthStatus.WaitingForAuthorization &&
+                settingsUiState.deviceAuthState != null -> {
+                DeviceAuthorizationScreen(
+                    userCode = settingsUiState.deviceAuthState!!.userCode,
+                    verificationUri = settingsUiState.deviceAuthState!!.verificationUri,
+                    verificationUriComplete = settingsUiState.deviceAuthState!!.verificationUriComplete,
+                    expiresAt = settingsUiState.deviceAuthState!!.expiresAt,
+                    onCancel = { viewModel.cancelAuthorization() },
+                    modifier = Modifier.padding(scaffoldPadding)
+                )
+            }
+            settingsUiState.authStatus is AccountSettingsViewModel.AuthStatus.BrowserLaunched ||
+                settingsUiState.authStatus is AccountSettingsViewModel.AuthStatus.Exchanging -> {
+                BrowserLoginWaitingScreen(
+                    isExchanging = settingsUiState.authStatus is AccountSettingsViewModel.AuthStatus.Exchanging,
+                    onCancel = { viewModel.cancelAuthorization() },
+                    onUseCodeInstead = { viewModel.switchToDeviceCodeFlow() },
+                    modifier = Modifier.padding(scaffoldPadding)
+                )
+            }
+            else -> {
             Column(
                 modifier = Modifier
                     .padding(scaffoldPadding)
@@ -131,12 +152,21 @@ fun WelcomeScreen(
                                 strokeWidth = 2.dp
                             )
                             Spacer(modifier = Modifier.width(8.dp))
-                            Text("Connecting...")
+                            Text(stringResource(R.string.account_settings_signing_in))
                         }
                         else -> {
-                            Text(stringResource(R.string.welcome_connect_button))
+                            Text(stringResource(R.string.account_settings_login))
                         }
                     }
+                }
+
+                TextButton(
+                    onClick = { viewModel.switchToDeviceCodeFlow() },
+                    enabled = settingsUiState.loginEnabled &&
+                            settingsUiState.authStatus !is AccountSettingsViewModel.AuthStatus.Loading,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(stringResource(R.string.account_settings_sign_in_with_code))
                 }
 
                 if (settingsUiState.authStatus is AccountSettingsViewModel.AuthStatus.Error) {
@@ -194,6 +224,7 @@ fun WelcomeScreen(
                     }
                 }
             }
+        }
         }
     }
 }

--- a/app/src/main/java/com/mydeck/app/util/PkceUtil.kt
+++ b/app/src/main/java/com/mydeck/app/util/PkceUtil.kt
@@ -1,0 +1,54 @@
+package com.mydeck.app.util
+
+import java.net.URLEncoder
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.util.Base64
+
+object PkceUtil {
+
+    private const val VERIFIER_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+    private const val VERIFIER_LENGTH = 64
+
+    fun generateCodeVerifier(): String {
+        val random = SecureRandom()
+        return (1..VERIFIER_LENGTH)
+            .map { VERIFIER_CHARS[random.nextInt(VERIFIER_CHARS.length)] }
+            .joinToString("")
+    }
+
+    fun codeChallenge(verifier: String): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        val hash = digest.digest(verifier.toByteArray(Charsets.US_ASCII))
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(hash)
+    }
+
+    fun generateState(): String {
+        val bytes = ByteArray(16)
+        SecureRandom().nextBytes(bytes)
+        return bytes.joinToString("") { "%02x".format(it) }
+    }
+
+    fun buildAuthorizeUrl(
+        serverUrlWithApi: String,
+        clientId: String,
+        redirectUri: String,
+        scope: String,
+        challenge: String,
+        state: String
+    ): String {
+        val baseUrl = serverUrlWithApi.removeSuffix("/api")
+        val params = linkedMapOf(
+            "client_id" to clientId,
+            "redirect_uri" to redirectUri,
+            "scope" to scope,
+            "code_challenge" to challenge,
+            "code_challenge_method" to "S256",
+            "state" to state
+        )
+        val query = params.entries.joinToString("&") { (k, v) ->
+            "${URLEncoder.encode(k, "UTF-8")}=${URLEncoder.encode(v, "UTF-8")}"
+        }
+        return "$baseUrl/authorize?$query"
+    }
+}

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -16,6 +16,8 @@
     <string name="account_settings_password_label">Passwort</string>
     <string name="account_settings_password_placeholder">Passwort</string>
     <string name="account_settings_login">Einloggen</string>
+    <string name="account_settings_signing_in">Signing in…</string>
+    <string name="account_settings_sign_in_with_code">Sign in with a code instead</string>
     <string name="account_settings_url_error">Ungültige URL</string>
     <string name="account_settings_url_http_warning">This HTTP URL sends OAuth tokens without TLS. You are using the HTTP-enabled MyDeck build; prefer a Tailscale Serve HTTPS URL or a reverse proxy with HTTPS when possible.</string>
     <string name="account_settings_http_blocked_error">HTTP Readeck server URLs are not allowed in this MyDeck build.</string>
@@ -391,6 +393,14 @@ other{}
     <string name="oauth_device_auth_denied">Die Autorisierung wurde verweigert.</string>
     <string name="oauth_device_auth_success">Erfolgreich autorisiert!</string>
     <string name="oauth_error_network">Netzwerkfehler. Bitte überprüfen Sie Ihre Verbindung.</string>
+
+    <!-- OAuth Authorization Code + PKCE -->
+    <string name="oauth_auth_code_browser_launched">Waiting for browser authorization…</string>
+    <string name="oauth_auth_code_browser_hint">Complete sign-in in your browser. You will be returned here automatically.</string>
+    <string name="oauth_auth_code_exchanging">Completing sign-in…</string>
+    <string name="oauth_auth_code_access_denied">Authorization was denied in the browser.</string>
+    <string name="oauth_auth_code_state_mismatch_error">Sign-in failed: security state mismatch. Please try again.</string>
+    <string name="oauth_auth_code_exchange_failed">Sign-in failed. Please try again.</string>
     <string name="logout_confirm_title">Abmelden</string>
     <string name="logout_confirm_message">Sind Sie sicher, dass Sie sich abmelden möchten?</string>
 

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -16,6 +16,8 @@
     <string name="account_settings_password_label">Contraseña</string>
     <string name="account_settings_password_placeholder">contraseña</string>
     <string name="account_settings_login">Iniciar sesión</string>
+    <string name="account_settings_signing_in">Signing in…</string>
+    <string name="account_settings_sign_in_with_code">Sign in with a code instead</string>
     <string name="account_settings_url_error">URL no válida</string>
     <string name="account_settings_url_http_warning">This HTTP URL sends OAuth tokens without TLS. You are using the HTTP-enabled MyDeck build; prefer a Tailscale Serve HTTPS URL or a reverse proxy with HTTPS when possible.</string>
     <string name="account_settings_http_blocked_error">HTTP Readeck server URLs are not allowed in this MyDeck build.</string>
@@ -373,6 +375,14 @@ other{}
     <string name="oauth_device_auth_denied">La autorización fue denegada.</string>
     <string name="oauth_device_auth_success">Autorización exitosa!</string>
     <string name="oauth_error_network">Error de red. Por favor, verifica tu conexión.</string>
+
+    <!-- OAuth Authorization Code + PKCE -->
+    <string name="oauth_auth_code_browser_launched">Waiting for browser authorization…</string>
+    <string name="oauth_auth_code_browser_hint">Complete sign-in in your browser. You will be returned here automatically.</string>
+    <string name="oauth_auth_code_exchanging">Completing sign-in…</string>
+    <string name="oauth_auth_code_access_denied">Authorization was denied in the browser.</string>
+    <string name="oauth_auth_code_state_mismatch_error">Sign-in failed: security state mismatch. Please try again.</string>
+    <string name="oauth_auth_code_exchange_failed">Sign-in failed. Please try again.</string>
     <string name="logout_confirm_title">Cerrar sesión</string>
     <string name="logout_confirm_message">¿Estás seguro de que deseas cerrar sesión?</string>
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -190,6 +190,14 @@
     <string name="oauth_device_auth_denied">L\'autorisation a été refusée.</string>
     <string name="oauth_device_auth_success">Autorisé avec succès !</string>
     <string name="oauth_error_network">Erreur réseau. Veuillez vérifier votre connexion.</string>
+
+    <!-- OAuth Authorization Code + PKCE -->
+    <string name="oauth_auth_code_browser_launched">Waiting for browser authorization…</string>
+    <string name="oauth_auth_code_browser_hint">Complete sign-in in your browser. You will be returned here automatically.</string>
+    <string name="oauth_auth_code_exchanging">Completing sign-in…</string>
+    <string name="oauth_auth_code_access_denied">Authorization was denied in the browser.</string>
+    <string name="oauth_auth_code_state_mismatch_error">Sign-in failed: security state mismatch. Please try again.</string>
+    <string name="oauth_auth_code_exchange_failed">Sign-in failed. Please try again.</string>
     <string name="logout_confirm_title">Se déconnecter</string>
     <string name="logout_confirm_message">Êtes-vous sûr de vouloir vous déconnecter ?</string>
 
@@ -567,6 +575,8 @@
     <string name="account_settings_password_label">Password</string>
     <string name="account_settings_password_placeholder">password</string>
     <string name="account_settings_login">Login</string>
+    <string name="account_settings_signing_in">Signing in…</string>
+    <string name="account_settings_sign_in_with_code">Sign in with a code instead</string>
     <string name="account_settings_url_error">Invalid URL</string>
     <string name="account_settings_username_error">Email address cannot be empty</string>
     <string name="account_settings_password_error">Password cannot be empty</string>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -15,6 +15,8 @@
     <string name="account_settings_password_label">Contrasinal</string>
     <string name="account_settings_password_placeholder">contrasinal</string>
     <string name="account_settings_login">Acceder</string>
+    <string name="account_settings_signing_in">Signing in…</string>
+    <string name="account_settings_sign_in_with_code">Sign in with a code instead</string>
     <string name="account_settings_url_error">URL non válido</string>
     <string name="account_settings_url_http_warning">This HTTP URL sends OAuth tokens without TLS. You are using the HTTP-enabled MyDeck build; prefer a Tailscale Serve HTTPS URL or a reverse proxy with HTTPS when possible.</string>
     <string name="account_settings_http_blocked_error">HTTP Readeck server URLs are not allowed in this MyDeck build.</string>
@@ -296,6 +298,14 @@ other{}
     <string name="oauth_device_auth_denied">Authorization was denied.</string>
     <string name="oauth_device_auth_success">Successfully authorized!</string>
     <string name="oauth_error_network">Network error. Please check your connection.</string>
+
+    <!-- OAuth Authorization Code + PKCE -->
+    <string name="oauth_auth_code_browser_launched">Waiting for browser authorization…</string>
+    <string name="oauth_auth_code_browser_hint">Complete sign-in in your browser. You will be returned here automatically.</string>
+    <string name="oauth_auth_code_exchanging">Completing sign-in…</string>
+    <string name="oauth_auth_code_access_denied">Authorization was denied in the browser.</string>
+    <string name="oauth_auth_code_state_mismatch_error">Sign-in failed: security state mismatch. Please try again.</string>
+    <string name="oauth_auth_code_exchange_failed">Sign-in failed. Please try again.</string>
     <string name="logout_confirm_title">Sign Out</string>
     <string name="logout_confirm_message">Are you sure you want to sign out?</string>
     <string name="more_options">Máis opcións</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -190,6 +190,14 @@
     <string name="oauth_device_auth_denied">Authorization was denied.</string>
     <string name="oauth_device_auth_success">Successfully authorized!</string>
     <string name="oauth_error_network">Network error. Please check your connection.</string>
+
+    <!-- OAuth Authorization Code + PKCE -->
+    <string name="oauth_auth_code_browser_launched">Waiting for browser authorization…</string>
+    <string name="oauth_auth_code_browser_hint">Complete sign-in in your browser. You will be returned here automatically.</string>
+    <string name="oauth_auth_code_exchanging">Completing sign-in…</string>
+    <string name="oauth_auth_code_access_denied">Authorization was denied in the browser.</string>
+    <string name="oauth_auth_code_state_mismatch_error">Sign-in failed: security state mismatch. Please try again.</string>
+    <string name="oauth_auth_code_exchange_failed">Sign-in failed. Please try again.</string>
     <string name="logout_confirm_title">Sign Out</string>
     <string name="logout_confirm_message">Are you sure you want to sign out?</string>
 
@@ -567,6 +575,8 @@
     <string name="account_settings_password_label">Password</string>
     <string name="account_settings_password_placeholder">password</string>
     <string name="account_settings_login">Login</string>
+    <string name="account_settings_signing_in">Signing in…</string>
+    <string name="account_settings_sign_in_with_code">Sign in with a code instead</string>
     <string name="account_settings_url_error">Invalid URL</string>
     <string name="account_settings_username_error">Email address cannot be empty</string>
     <string name="account_settings_password_error">Password cannot be empty</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -190,6 +190,14 @@
     <string name="oauth_device_auth_denied">Authorization was denied.</string>
     <string name="oauth_device_auth_success">Successfully authorized!</string>
     <string name="oauth_error_network">Network error. Please check your connection.</string>
+
+    <!-- OAuth Authorization Code + PKCE -->
+    <string name="oauth_auth_code_browser_launched">Waiting for browser authorization…</string>
+    <string name="oauth_auth_code_browser_hint">Complete sign-in in your browser. You will be returned here automatically.</string>
+    <string name="oauth_auth_code_exchanging">Completing sign-in…</string>
+    <string name="oauth_auth_code_access_denied">Authorization was denied in the browser.</string>
+    <string name="oauth_auth_code_state_mismatch_error">Sign-in failed: security state mismatch. Please try again.</string>
+    <string name="oauth_auth_code_exchange_failed">Sign-in failed. Please try again.</string>
     <string name="logout_confirm_title">Sign Out</string>
     <string name="logout_confirm_message">Are you sure you want to sign out?</string>
 
@@ -567,6 +575,8 @@
     <string name="account_settings_password_label">Password</string>
     <string name="account_settings_password_placeholder">password</string>
     <string name="account_settings_login">Login</string>
+    <string name="account_settings_signing_in">Signing in…</string>
+    <string name="account_settings_sign_in_with_code">Sign in with a code instead</string>
     <string name="account_settings_url_error">Invalid URL</string>
     <string name="account_settings_username_error">Email address cannot be empty</string>
     <string name="account_settings_password_error">Password cannot be empty</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -190,6 +190,14 @@
     <string name="oauth_device_auth_denied">Authorization was denied.</string>
     <string name="oauth_device_auth_success">Successfully authorized!</string>
     <string name="oauth_error_network">Network error. Please check your connection.</string>
+
+    <!-- OAuth Authorization Code + PKCE -->
+    <string name="oauth_auth_code_browser_launched">Waiting for browser authorization…</string>
+    <string name="oauth_auth_code_browser_hint">Complete sign-in in your browser. You will be returned here automatically.</string>
+    <string name="oauth_auth_code_exchanging">Completing sign-in…</string>
+    <string name="oauth_auth_code_access_denied">Authorization was denied in the browser.</string>
+    <string name="oauth_auth_code_state_mismatch_error">Sign-in failed: security state mismatch. Please try again.</string>
+    <string name="oauth_auth_code_exchange_failed">Sign-in failed. Please try again.</string>
     <string name="logout_confirm_title">Sign Out</string>
     <string name="logout_confirm_message">Are you sure you want to sign out?</string>
 
@@ -567,6 +575,8 @@
     <string name="account_settings_password_label">Password</string>
     <string name="account_settings_password_placeholder">password</string>
     <string name="account_settings_login">Login</string>
+    <string name="account_settings_signing_in">Signing in…</string>
+    <string name="account_settings_sign_in_with_code">Sign in with a code instead</string>
     <string name="account_settings_url_error">Invalid URL</string>
     <string name="account_settings_username_error">Email address cannot be empty</string>
     <string name="account_settings_password_error">Password cannot be empty</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -190,6 +190,14 @@
     <string name="oauth_device_auth_denied">Authorization was denied.</string>
     <string name="oauth_device_auth_success">Successfully authorized!</string>
     <string name="oauth_error_network">Network error. Please check your connection.</string>
+
+    <!-- OAuth Authorization Code + PKCE -->
+    <string name="oauth_auth_code_browser_launched">Waiting for browser authorization…</string>
+    <string name="oauth_auth_code_browser_hint">Complete sign-in in your browser. You will be returned here automatically.</string>
+    <string name="oauth_auth_code_exchanging">Completing sign-in…</string>
+    <string name="oauth_auth_code_access_denied">Authorization was denied in the browser.</string>
+    <string name="oauth_auth_code_state_mismatch_error">Sign-in failed: security state mismatch. Please try again.</string>
+    <string name="oauth_auth_code_exchange_failed">Sign-in failed. Please try again.</string>
     <string name="logout_confirm_title">Sign Out</string>
     <string name="logout_confirm_message">Are you sure you want to sign out?</string>
 
@@ -567,6 +575,8 @@
     <string name="account_settings_password_label">Password</string>
     <string name="account_settings_password_placeholder">password</string>
     <string name="account_settings_login">Login</string>
+    <string name="account_settings_signing_in">Signing in…</string>
+    <string name="account_settings_sign_in_with_code">Sign in with a code instead</string>
     <string name="account_settings_url_error">Invalid URL</string>
     <string name="account_settings_username_error">Email address cannot be empty</string>
     <string name="account_settings_password_error">Password cannot be empty</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -5,6 +5,8 @@
     <string name="account_settings_password_label">密码</string>
     <string name="account_settings_password_placeholder">密码</string>
     <string name="account_settings_login">登录</string>
+    <string name="account_settings_signing_in">Signing in…</string>
+    <string name="account_settings_sign_in_with_code">Sign in with a code instead</string>
     <string name="account_settings_url_error">无效的 URL</string>
     <string name="account_settings_url_http_warning">This HTTP URL sends OAuth tokens without TLS. You are using the HTTP-enabled MyDeck build; prefer a Tailscale Serve HTTPS URL or a reverse proxy with HTTPS when possible.</string>
     <string name="account_settings_http_blocked_error">HTTP Readeck server URLs are not allowed in this MyDeck build.</string>
@@ -366,6 +368,14 @@
     <string name="oauth_device_auth_denied">Authorization was denied.</string>
     <string name="oauth_device_auth_success">Successfully authorized!</string>
     <string name="oauth_error_network">Network error. Please check your connection.</string>
+
+    <!-- OAuth Authorization Code + PKCE -->
+    <string name="oauth_auth_code_browser_launched">Waiting for browser authorization…</string>
+    <string name="oauth_auth_code_browser_hint">Complete sign-in in your browser. You will be returned here automatically.</string>
+    <string name="oauth_auth_code_exchanging">Completing sign-in…</string>
+    <string name="oauth_auth_code_access_denied">Authorization was denied in the browser.</string>
+    <string name="oauth_auth_code_state_mismatch_error">Sign-in failed: security state mismatch. Please try again.</string>
+    <string name="oauth_auth_code_exchange_failed">Sign-in failed. Please try again.</string>
     <string name="logout_confirm_title">Sign Out</string>
     <string name="logout_confirm_message">Are you sure you want to sign out?</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,7 +12,9 @@
     <string name="account_settings_username_label">Email Address</string>
     <string name="account_settings_password_label">Password</string>
     <string name="account_settings_password_placeholder">password</string>
-    <string name="account_settings_login">Login</string>
+    <string name="account_settings_login">Sign In</string>
+    <string name="account_settings_signing_in">Signing in…</string>
+    <string name="account_settings_sign_in_with_code">Sign in with a code instead</string>
     <string name="account_settings_url_error">Invalid URL</string>
     <string name="account_settings_url_http_warning">This HTTP URL sends OAuth tokens without TLS. You are using the HTTP-enabled MyDeck build; prefer a Tailscale Serve HTTPS URL or a reverse proxy with HTTPS when possible.</string>
     <string name="account_settings_http_blocked_error">HTTP Readeck server URLs are not allowed in this MyDeck build.</string>
@@ -621,6 +623,15 @@ other{}
     <string name="oauth_device_auth_denied">Authorization was denied.</string>
     <string name="oauth_device_auth_success">Successfully authorized!</string>
     <string name="oauth_error_network">Network error. Please check your connection.</string>
+
+    <!-- OAuth Authorization Code + PKCE -->
+    <string name="oauth_auth_code_browser_launched">Waiting for browser authorization…</string>
+    <string name="oauth_auth_code_browser_hint">Complete sign-in in your browser. You will be returned here automatically.</string>
+    <string name="oauth_auth_code_exchanging">Completing sign-in…</string>
+    <string name="oauth_auth_code_access_denied">Authorization was denied in the browser.</string>
+    <string name="oauth_auth_code_state_mismatch_error">Sign-in failed: security state mismatch. Please try again.</string>
+    <string name="oauth_auth_code_exchange_failed">Sign-in failed. Please try again.</string>
+
     <string name="logout_confirm_title">Sign Out</string>
     <string name="logout_confirm_message">Are you sure you want to sign out?</string>
 

--- a/app/src/test/java/com/mydeck/app/domain/OAuthCallbackRepositoryTest.kt
+++ b/app/src/test/java/com/mydeck/app/domain/OAuthCallbackRepositoryTest.kt
@@ -1,0 +1,38 @@
+package com.mydeck.app.domain
+
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class OAuthCallbackRepositoryTest {
+
+    @Test
+    fun `event dispatched before subscription is still delivered via replay`() = runTest {
+        val repo = OAuthCallbackRepository()
+
+        // Dispatch first — no collector yet (simulates MainActivity onCreate after process death).
+        repo.dispatch(OAuthCallbackRepository.OAuthCallbackEvent.Success("code-1", "state-1"))
+
+        // A late subscriber must still receive it.
+        val event = repo.events.first()
+        assertTrue(event is OAuthCallbackRepository.OAuthCallbackEvent.Success)
+        assertEquals("code-1", (event as OAuthCallbackRepository.OAuthCallbackEvent.Success).code)
+    }
+
+    @Test
+    fun `consume clears the replay cache so a stale event is not re-delivered`() = runTest {
+        val repo = OAuthCallbackRepository()
+
+        repo.dispatch(OAuthCallbackRepository.OAuthCallbackEvent.Success("code-1", "state-1"))
+        // Handle and consume.
+        repo.events.first()
+        repo.consume()
+
+        // A fresh event dispatched after consume is the only one seen.
+        repo.dispatch(OAuthCallbackRepository.OAuthCallbackEvent.Error("access_denied", null))
+        val next = repo.events.first()
+        assertTrue(next is OAuthCallbackRepository.OAuthCallbackEvent.Error)
+    }
+}

--- a/app/src/test/java/com/mydeck/app/domain/usecase/OAuthAuthorizationCodeUseCaseTest.kt
+++ b/app/src/test/java/com/mydeck/app/domain/usecase/OAuthAuthorizationCodeUseCaseTest.kt
@@ -1,0 +1,191 @@
+package com.mydeck.app.domain.usecase
+
+import android.content.Context
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import com.mydeck.app.io.rest.ReadeckApi
+import com.mydeck.app.io.rest.model.OAuthAuthCodeTokenRequestDto
+import com.mydeck.app.io.rest.model.OAuthClientRegistrationRequestDto
+import com.mydeck.app.io.rest.model.OAuthClientRegistrationResponseDto
+import com.mydeck.app.io.rest.model.OAuthTokenResponseDto
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Response
+import java.io.IOException
+
+class OAuthAuthorizationCodeUseCaseTest {
+
+    private lateinit var readeckApi: ReadeckApi
+    private lateinit var json: Json
+    private lateinit var useCase: OAuthAuthorizationCodeUseCase
+
+    private val registrationResponse = OAuthClientRegistrationResponseDto(
+        clientId = "test-client-id",
+        clientName = "MyDeck Android",
+        clientUri = "https://github.com/NateEaton/mydeck-android",
+        grantTypes = listOf("authorization_code"),
+        softwareId = "com.mydeck.app",
+        softwareVersion = "1.0.0"
+    )
+
+    @Before
+    fun setup() {
+        readeckApi = mockk()
+        json = Json { ignoreUnknownKeys = true }
+
+        val packageInfo = PackageInfo().apply { versionName = "test-version" }
+        val packageManager = mockk<PackageManager> {
+            every { getPackageInfo(any<String>(), 0) } returns packageInfo
+        }
+        val context = mockk<Context> {
+            every { this@mockk.packageManager } returns packageManager
+            every { packageName } returns "com.mydeck.app.test"
+        }
+        useCase = OAuthAuthorizationCodeUseCase(readeckApi, json, context)
+    }
+
+    // --- initiateAuthorization ---
+
+    @Test
+    fun `initiateAuthorization returns Ready with authorize URL on success`() = runTest {
+        coEvery { readeckApi.registerOAuthClient(any()) } returns Response.success(registrationResponse)
+
+        val result = useCase.initiateAuthorization("https://readeck.example.com/api")
+
+        assertTrue(result is OAuthAuthorizationCodeUseCase.AuthCodeInitiateResult.Ready)
+        val ready = result as OAuthAuthorizationCodeUseCase.AuthCodeInitiateResult.Ready
+        assertTrue(ready.result.authorizeUrl.contains("readeck.example.com/authorize"))
+        assertTrue(ready.result.authorizeUrl.contains("client_id=test-client-id"))
+        assertTrue(ready.result.authorizeUrl.contains("code_challenge_method=S256"))
+        assertNotNull(ready.result.codeVerifier)
+        assertNotNull(ready.result.state)
+        assertEquals("test-client-id", ready.result.clientId)
+    }
+
+    @Test
+    fun `initiateAuthorization includes redirect_uri and authorization_code in registration`() = runTest {
+        val registrationSlot = slot<OAuthClientRegistrationRequestDto>()
+        coEvery { readeckApi.registerOAuthClient(capture(registrationSlot)) } returns Response.success(registrationResponse)
+
+        useCase.initiateAuthorization("https://readeck.example.com/api")
+
+        val captured = registrationSlot.captured
+        assertTrue(captured.grantTypes.contains("authorization_code"))
+        assertNotNull(captured.redirectUris)
+        assertTrue(captured.redirectUris!!.contains("mydeck://oauth-callback"))
+    }
+
+    @Test
+    fun `initiateAuthorization returns Error on registration failure`() = runTest {
+        val errorResponse = Response.error<OAuthClientRegistrationResponseDto>(
+            400,
+            """{"error": "invalid_client_metadata", "error_description": "Bad metadata"}""".toResponseBody(null)
+        )
+        coEvery { readeckApi.registerOAuthClient(any()) } returns errorResponse
+
+        val result = useCase.initiateAuthorization("https://readeck.example.com/api")
+
+        assertTrue(result is OAuthAuthorizationCodeUseCase.AuthCodeInitiateResult.Error)
+        assertTrue((result as OAuthAuthorizationCodeUseCase.AuthCodeInitiateResult.Error).message.contains("Failed to register"))
+    }
+
+    @Test
+    fun `initiateAuthorization returns Error on network error`() = runTest {
+        coEvery { readeckApi.registerOAuthClient(any()) } throws IOException("No route to host")
+
+        val result = useCase.initiateAuthorization("https://readeck.example.com/api")
+
+        assertTrue(result is OAuthAuthorizationCodeUseCase.AuthCodeInitiateResult.Error)
+        assertTrue((result as OAuthAuthorizationCodeUseCase.AuthCodeInitiateResult.Error).message.contains("Network error"))
+    }
+
+    // --- exchangeCode ---
+
+    @Test
+    fun `exchangeCode returns Success on valid token response`() = runTest {
+        val tokenResponse = OAuthTokenResponseDto(
+            accessToken = "my-access-token",
+            tokenType = "Bearer",
+            scope = "bookmarks:read bookmarks:write profile:read"
+        )
+        coEvery { readeckApi.requestTokenWithAuthCode(any()) } returns Response.success(tokenResponse)
+
+        val result = useCase.exchangeCode("auth-code-123", "verifier-abc")
+
+        assertTrue(result is OAuthAuthorizationCodeUseCase.TokenExchangeResult.Success)
+        assertEquals("my-access-token", (result as OAuthAuthorizationCodeUseCase.TokenExchangeResult.Success).accessToken)
+    }
+
+    @Test
+    fun `exchangeCode sends correct grant_type code and code_verifier`() = runTest {
+        val requestSlot = slot<OAuthAuthCodeTokenRequestDto>()
+        val tokenResponse = OAuthTokenResponseDto(accessToken = "token", tokenType = "Bearer")
+        coEvery { readeckApi.requestTokenWithAuthCode(capture(requestSlot)) } returns Response.success(tokenResponse)
+
+        useCase.exchangeCode("the-code", "the-verifier")
+
+        val captured = requestSlot.captured
+        assertEquals("authorization_code", captured.grantType)
+        assertEquals("the-code", captured.code)
+        assertEquals("the-verifier", captured.codeVerifier)
+    }
+
+    @Test
+    fun `exchangeCode returns UserDenied on access_denied error`() = runTest {
+        val errorResponse = Response.error<OAuthTokenResponseDto>(
+            400,
+            """{"error": "access_denied", "error_description": "User denied access"}""".toResponseBody(null)
+        )
+        coEvery { readeckApi.requestTokenWithAuthCode(any()) } returns errorResponse
+
+        val result = useCase.exchangeCode("code", "verifier")
+
+        assertTrue(result is OAuthAuthorizationCodeUseCase.TokenExchangeResult.UserDenied)
+        assertEquals("User denied access", (result as OAuthAuthorizationCodeUseCase.TokenExchangeResult.UserDenied).message)
+    }
+
+    @Test
+    fun `exchangeCode returns Error on invalid_grant`() = runTest {
+        val errorResponse = Response.error<OAuthTokenResponseDto>(
+            400,
+            """{"error": "invalid_grant", "error_description": "Code expired or invalid"}""".toResponseBody(null)
+        )
+        coEvery { readeckApi.requestTokenWithAuthCode(any()) } returns errorResponse
+
+        val result = useCase.exchangeCode("code", "verifier")
+
+        assertTrue(result is OAuthAuthorizationCodeUseCase.TokenExchangeResult.Error)
+        assertTrue((result as OAuthAuthorizationCodeUseCase.TokenExchangeResult.Error).message.contains("Code expired or invalid"))
+    }
+
+    @Test
+    fun `exchangeCode returns Error on network failure`() = runTest {
+        coEvery { readeckApi.requestTokenWithAuthCode(any()) } throws IOException("Connection refused")
+
+        val result = useCase.exchangeCode("code", "verifier")
+
+        assertTrue(result is OAuthAuthorizationCodeUseCase.TokenExchangeResult.Error)
+        assertTrue((result as OAuthAuthorizationCodeUseCase.TokenExchangeResult.Error).message.contains("Network error"))
+    }
+
+    @Test
+    fun `exchangeCode returns Error when server returns empty body`() = runTest {
+        val errorResponse = Response.error<OAuthTokenResponseDto>(400, "".toResponseBody(null))
+        coEvery { readeckApi.requestTokenWithAuthCode(any()) } returns errorResponse
+
+        val result = useCase.exchangeCode("code", "verifier")
+
+        assertTrue(result is OAuthAuthorizationCodeUseCase.TokenExchangeResult.Error)
+        assertTrue((result as OAuthAuthorizationCodeUseCase.TokenExchangeResult.Error).message.contains("Server error"))
+    }
+}

--- a/app/src/test/java/com/mydeck/app/ui/settings/AccountSettingsViewModelTest.kt
+++ b/app/src/test/java/com/mydeck/app/ui/settings/AccountSettingsViewModelTest.kt
@@ -88,6 +88,7 @@ class AccountSettingsViewModelTest {
         
         every { settingsDataStore.urlFlow } returns MutableStateFlow("")
         every { settingsDataStore.tokenFlow } returns MutableStateFlow(null)
+        every { settingsDataStore.saveUrl(any()) } returns Unit
         every { workManager.getWorkInfosForUniqueWorkFlow(any()) } returns flowOf(emptyList())
         every { LoadBookmarksWorker.enqueue(any(), any<Boolean>()) } returns UUID.randomUUID()
         every { context.getString(R.string.account_settings_initial_sync_failed) } returns
@@ -271,6 +272,150 @@ class AccountSettingsViewModelTest {
         viewModel.cancelAuthorization()
         runCurrent()
         unmockkStatic("com.mydeck.app.util.UtilsKt")
+    }
+
+    private fun stubAuthCodeInitiate(
+        url: String = "https://example.com/api",
+        state: String = "test-state",
+        verifier: String = "test-verifier"
+    ) {
+        coEvery { oauthAuthCodeUseCase.initiateAuthorization(url) } returns
+            OAuthAuthorizationCodeUseCase.AuthCodeInitiateResult.Ready(
+                OAuthAuthorizationCodeUseCase.InitiateResult(
+                    authorizeUrl = "https://example.com/authorize?test=1",
+                    codeVerifier = verifier,
+                    state = state,
+                    clientId = "test-client"
+                )
+            )
+    }
+
+    private fun stubInitialSyncSuccess(): UUID {
+        val workId = UUID.randomUUID()
+        val succeededWorkInfo = mockk<WorkInfo> {
+            every { id } returns workId
+            every { state } returns WorkInfo.State.SUCCEEDED
+        }
+        every { LoadBookmarksWorker.enqueue(any(), true) } returns workId
+        every { workManager.getWorkInfosForUniqueWorkFlow(LoadBookmarksWorker.UNIQUE_WORK_NAME) } returns
+            flowOf(listOf(succeededWorkInfo))
+        return workId
+    }
+
+    @Test
+    fun `auth-code callback with matching state exchanges code and completes login`() = runTest {
+        mockkStatic("com.mydeck.app.util.UtilsKt")
+        every { openUrlInCustomTab(any(), any()) } just Runs
+        stubAuthCodeInitiate()
+        coEvery { oauthAuthCodeUseCase.exchangeCode("auth-code-123", "test-verifier") } returns
+            OAuthAuthorizationCodeUseCase.TokenExchangeResult.Success("token-123")
+        coEvery { userRepository.completeLogin("https://example.com/api", "token-123") } returns
+            UserRepository.LoginResult.Success
+        stubInitialSyncSuccess()
+
+        viewModel.updateUrl("https://example.com")
+        viewModel.login()
+        runCurrent()
+        assertEquals(AccountSettingsViewModel.AuthStatus.BrowserLaunched, viewModel.uiState.value.authStatus)
+
+        oauthCallbackRepository.dispatch(
+            OAuthCallbackRepository.OAuthCallbackEvent.Success("auth-code-123", "test-state")
+        )
+        advanceUntilIdle()
+
+        assertEquals(AccountSettingsViewModel.AuthStatus.Success, viewModel.uiState.value.authStatus)
+        coVerify { oauthAuthCodeUseCase.exchangeCode("auth-code-123", "test-verifier") }
+        coVerify { userRepository.completeLogin("https://example.com/api", "token-123") }
+        unmockkStatic("com.mydeck.app.util.UtilsKt")
+    }
+
+    @Test
+    fun `auth-code callback with mismatched state shows error and never exchanges`() = runTest {
+        mockkStatic("com.mydeck.app.util.UtilsKt")
+        every { openUrlInCustomTab(any(), any()) } just Runs
+        every { context.getString(R.string.oauth_auth_code_state_mismatch_error) } returns "state mismatch"
+        stubAuthCodeInitiate()
+
+        viewModel.updateUrl("https://example.com")
+        viewModel.login()
+        runCurrent()
+
+        oauthCallbackRepository.dispatch(
+            OAuthCallbackRepository.OAuthCallbackEvent.Success("auth-code-123", "WRONG-STATE")
+        )
+        advanceUntilIdle()
+
+        assertEquals(
+            AccountSettingsViewModel.AuthStatus.Error("state mismatch"),
+            viewModel.uiState.value.authStatus
+        )
+        coVerify(exactly = 0) { oauthAuthCodeUseCase.exchangeCode(any(), any()) }
+        coVerify(exactly = 0) { userRepository.completeLogin(any(), any()) }
+        unmockkStatic("com.mydeck.app.util.UtilsKt")
+    }
+
+    @Test
+    fun `auth-code callback error access_denied surfaces denied message`() = runTest {
+        mockkStatic("com.mydeck.app.util.UtilsKt")
+        every { openUrlInCustomTab(any(), any()) } just Runs
+        every { context.getString(R.string.oauth_auth_code_access_denied) } returns "denied in browser"
+        stubAuthCodeInitiate()
+
+        viewModel.updateUrl("https://example.com")
+        viewModel.login()
+        runCurrent()
+
+        oauthCallbackRepository.dispatch(
+            OAuthCallbackRepository.OAuthCallbackEvent.Error("access_denied", "User denied")
+        )
+        advanceUntilIdle()
+
+        assertEquals(
+            AccountSettingsViewModel.AuthStatus.Error("denied in browser"),
+            viewModel.uiState.value.authStatus
+        )
+        coVerify(exactly = 0) { oauthAuthCodeUseCase.exchangeCode(any(), any()) }
+        unmockkStatic("com.mydeck.app.util.UtilsKt")
+    }
+
+    @Test
+    fun `restores auth-code flow after process death and completes on replayed callback`() = runTest {
+        // Simulate the callback being dispatched (from MainActivity onCreate) BEFORE the recreated
+        // ViewModel re-subscribes. replay=1 must still deliver it to the restored flow.
+        oauthCallbackRepository.dispatch(
+            OAuthCallbackRepository.OAuthCallbackEvent.Success("restored-code", "restored-state")
+        )
+        coEvery { oauthAuthCodeUseCase.exchangeCode("restored-code", "restored-verifier") } returns
+            OAuthAuthorizationCodeUseCase.TokenExchangeResult.Success("token-restored")
+        coEvery { userRepository.completeLogin("https://example.com/api", "token-restored") } returns
+            UserRepository.LoginResult.Success
+        stubInitialSyncSuccess()
+
+        val restoredHandle = SavedStateHandle(
+            mapOf(
+                "oauth_code_verifier" to "restored-verifier",
+                "oauth_auth_state" to "restored-state",
+                "oauth_server_url" to "https://example.com/api"
+            )
+        )
+        viewModel = AccountSettingsViewModel(
+            savedStateHandle = restoredHandle,
+            settingsDataStore = settingsDataStore,
+            bookmarkRepository = bookmarkRepository,
+            userRepository = userRepository,
+            oauthDeviceAuthUseCase = oauthDeviceAuthUseCase,
+            oauthAuthCodeUseCase = oauthAuthCodeUseCase,
+            oauthCallbackRepository = oauthCallbackRepository,
+            workManager = workManager,
+            context = context,
+            applicationScope = applicationScope,
+            httpUrlMigrationLoginCoordinator = httpUrlMigrationLoginCoordinator
+        )
+        advanceUntilIdle()
+
+        assertEquals(AccountSettingsViewModel.AuthStatus.Success, viewModel.uiState.value.authStatus)
+        coVerify { oauthAuthCodeUseCase.exchangeCode("restored-code", "restored-verifier") }
+        coVerify { userRepository.completeLogin("https://example.com/api", "token-restored") }
     }
 
     @Test

--- a/app/src/test/java/com/mydeck/app/ui/settings/AccountSettingsViewModelTest.kt
+++ b/app/src/test/java/com/mydeck/app/ui/settings/AccountSettingsViewModelTest.kt
@@ -3,22 +3,30 @@ package com.mydeck.app.ui.settings
 import com.mydeck.app.R
 import com.mydeck.app.BuildConfig
 import com.mydeck.app.domain.BookmarkRepository
+import com.mydeck.app.domain.OAuthCallbackRepository
 import com.mydeck.app.domain.UserRepository
 import com.mydeck.app.domain.model.OAuthDeviceAuthorizationState
+import com.mydeck.app.domain.usecase.OAuthAuthorizationCodeUseCase
 import com.mydeck.app.domain.usecase.OAuthDeviceAuthorizationUseCase
 import com.mydeck.app.io.prefs.SettingsDataStore
 import com.mydeck.app.ui.migration.HttpUrlMigrationLoginCoordinator
 import com.mydeck.app.worker.LoadBookmarksWorker
 import android.content.Context
+import androidx.lifecycle.SavedStateHandle
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
+import com.mydeck.app.util.openUrlInCustomTab
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockkObject
+import io.mockk.mockkStatic
 import io.mockk.mockk
 import io.mockk.unmockkObject
+import io.mockk.unmockkStatic
 import io.mockk.verify
+import io.mockk.just
+import io.mockk.Runs
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -48,10 +56,13 @@ import java.util.UUID
 class AccountSettingsViewModelTest {
 
     private val testDispatcher = StandardTestDispatcher()
+    private lateinit var savedStateHandle: SavedStateHandle
     private lateinit var settingsDataStore: SettingsDataStore
     private lateinit var bookmarkRepository: BookmarkRepository
     private lateinit var userRepository: UserRepository
     private lateinit var oauthDeviceAuthUseCase: OAuthDeviceAuthorizationUseCase
+    private lateinit var oauthAuthCodeUseCase: OAuthAuthorizationCodeUseCase
+    private lateinit var oauthCallbackRepository: OAuthCallbackRepository
     private lateinit var workManager: WorkManager
     private lateinit var context: Context
     private lateinit var applicationScope: CoroutineScope
@@ -62,10 +73,13 @@ class AccountSettingsViewModelTest {
     fun setUp() {
         val testDispatcher = StandardTestDispatcher()
         Dispatchers.setMain(testDispatcher)
+        savedStateHandle = SavedStateHandle()
         settingsDataStore = mockk()
         bookmarkRepository = mockk(relaxed = true)
         userRepository = mockk(relaxed = true)
         oauthDeviceAuthUseCase = mockk()
+        oauthAuthCodeUseCase = mockk()
+        oauthCallbackRepository = OAuthCallbackRepository()
         workManager = mockk()
         context = mockk()
         applicationScope = TestScope(testDispatcher)
@@ -85,10 +99,13 @@ class AccountSettingsViewModelTest {
         coEvery { userRepository.logout() } returns UserRepository.LogoutResult.Success
         
         viewModel = AccountSettingsViewModel(
+            savedStateHandle = savedStateHandle,
             settingsDataStore = settingsDataStore,
             bookmarkRepository = bookmarkRepository,
             userRepository = userRepository,
             oauthDeviceAuthUseCase = oauthDeviceAuthUseCase,
+            oauthAuthCodeUseCase = oauthAuthCodeUseCase,
+            oauthCallbackRepository = oauthCallbackRepository,
             workManager = workManager,
             context = context,
             applicationScope = applicationScope,
@@ -107,10 +124,13 @@ class AccountSettingsViewModelTest {
         every { settingsDataStore.urlFlow } returns MutableStateFlow("https://example.com")
         every { settingsDataStore.tokenFlow } returns MutableStateFlow("valid-token") // Non-empty token to set isLoggedIn=true
         viewModel = AccountSettingsViewModel(
+            savedStateHandle = savedStateHandle,
             settingsDataStore = settingsDataStore,
             bookmarkRepository = bookmarkRepository,
             userRepository = userRepository,
             oauthDeviceAuthUseCase = oauthDeviceAuthUseCase,
+            oauthAuthCodeUseCase = oauthAuthCodeUseCase,
+            oauthCallbackRepository = oauthCallbackRepository,
             workManager = workManager,
             context = context,
             applicationScope = applicationScope,
@@ -131,10 +151,13 @@ class AccountSettingsViewModelTest {
         every { settingsDataStore.urlFlow } returns MutableStateFlow("https://example.com/api")
         every { settingsDataStore.tokenFlow } returns MutableStateFlow("valid-token")
         viewModel = AccountSettingsViewModel(
+            savedStateHandle = savedStateHandle,
             settingsDataStore = settingsDataStore,
             bookmarkRepository = bookmarkRepository,
             userRepository = userRepository,
             oauthDeviceAuthUseCase = oauthDeviceAuthUseCase,
+            oauthAuthCodeUseCase = oauthAuthCodeUseCase,
+            oauthCallbackRepository = oauthCallbackRepository,
             workManager = workManager,
             context = context,
             applicationScope = applicationScope,
@@ -170,10 +193,13 @@ class AccountSettingsViewModelTest {
         } returns OAuthDeviceAuthorizationUseCase.TokenPollResult.StillPending
 
         viewModel = AccountSettingsViewModel(
+            savedStateHandle = savedStateHandle,
             settingsDataStore = settingsDataStore,
             bookmarkRepository = bookmarkRepository,
             userRepository = userRepository,
             oauthDeviceAuthUseCase = oauthDeviceAuthUseCase,
+            oauthAuthCodeUseCase = oauthAuthCodeUseCase,
+            oauthCallbackRepository = oauthCallbackRepository,
             workManager = workManager,
             context = context,
             applicationScope = applicationScope,
@@ -221,42 +247,30 @@ class AccountSettingsViewModelTest {
     }
 
     @Test
-    fun `login should trigger OAuth flow`() = runTest {
-        // Mock successful OAuth initiation
-        coEvery { userRepository.initiateLogin("https://example.com/api") } returns UserRepository.LoginResult.DeviceAuthorizationRequired(
-            OAuthDeviceAuthorizationState(
-                clientId = "test-client",
-                deviceCode = "TEST-CODE",
-                userCode = "TEST-USER-CODE",
-                verificationUri = "https://example.com/auth",
-                verificationUriComplete = "https://example.com/auth?code=TEST-USER-CODE",
-                expiresAt = System.currentTimeMillis() + 1800_000,
-                pollingInterval = 5
+    fun `login should trigger auth-code browser flow`() = runTest {
+        mockkStatic("com.mydeck.app.util.UtilsKt")
+        every { openUrlInCustomTab(any(), any()) } just Runs
+
+        coEvery {
+            oauthAuthCodeUseCase.initiateAuthorization("https://example.com/api")
+        } returns OAuthAuthorizationCodeUseCase.AuthCodeInitiateResult.Ready(
+            OAuthAuthorizationCodeUseCase.InitiateResult(
+                authorizeUrl = "https://example.com/authorize?test=1",
+                codeVerifier = "test-verifier",
+                state = "test-state",
+                clientId = "test-client"
             )
         )
 
-        // Polling runs in a background coroutine; provide a stub so it can't throw MockKException
-        // if the test scheduler advances time.
-        coEvery {
-            oauthDeviceAuthUseCase.pollForToken(
-                clientId = any(),
-                deviceCode = any(),
-                currentInterval = any()
-            )
-        } returns OAuthDeviceAuthorizationUseCase.TokenPollResult.StillPending
-        
         viewModel.updateUrl("https://example.com")
         viewModel.login()
-        // Only run immediate tasks; don't advance time into the polling loop delay.
         runCurrent()
-        
-        val uiState = viewModel.uiState.first()
-        assertEquals(AccountSettingsViewModel.AuthStatus.WaitingForAuthorization, uiState.authStatus)
-        assertNotNull(uiState.deviceAuthState)
 
-        // Stop the polling job so the test can complete deterministically.
+        assertEquals(AccountSettingsViewModel.AuthStatus.BrowserLaunched, viewModel.uiState.value.authStatus)
+
         viewModel.cancelAuthorization()
         runCurrent()
+        unmockkStatic("com.mydeck.app.util.UtilsKt")
     }
 
     @Test
@@ -296,7 +310,7 @@ class AccountSettingsViewModelTest {
         val navJob = launch { viewModel.navigationEvent.collect { navEvents.add(it) } }
 
         viewModel.updateUrl("https://example.com")
-        viewModel.login()
+        viewModel.switchToDeviceCodeFlow()
         advanceUntilIdle()
         navJob.cancel()
 
@@ -344,7 +358,7 @@ class AccountSettingsViewModelTest {
         val navJob = launch { viewModel.navigationEvent.collect { navEvents.add(it) } }
 
         viewModel.updateUrl("https://example.com")
-        viewModel.login()
+        viewModel.switchToDeviceCodeFlow()
         advanceUntilIdle()
         navJob.cancel()
 
@@ -392,7 +406,7 @@ class AccountSettingsViewModelTest {
         val navJob = launch { viewModel.navigationEvent.collect { navEvents.add(it) } }
 
         viewModel.updateUrl("https://example.com")
-        viewModel.login()
+        viewModel.switchToDeviceCodeFlow()
         runCurrent()
         advanceTimeBy(20_000)
         advanceUntilIdle()

--- a/app/src/test/java/com/mydeck/app/util/PkceUtilTest.kt
+++ b/app/src/test/java/com/mydeck/app/util/PkceUtilTest.kt
@@ -1,0 +1,85 @@
+package com.mydeck.app.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PkceUtilTest {
+
+    @Test
+    fun `generateCodeVerifier produces 64-char alphanumeric string`() {
+        val verifier = PkceUtil.generateCodeVerifier()
+        assertEquals(64, verifier.length)
+        assertTrue(verifier.all { it.isLetterOrDigit() })
+    }
+
+    @Test
+    fun `generateCodeVerifier produces unique values`() {
+        val v1 = PkceUtil.generateCodeVerifier()
+        val v2 = PkceUtil.generateCodeVerifier()
+        assertNotEquals(v1, v2)
+    }
+
+    @Test
+    fun `codeChallenge matches RFC 7636 known vector`() {
+        // https://www.rfc-editor.org/rfc/rfc7636#appendix-B
+        val verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+        val expected = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+        assertEquals(expected, PkceUtil.codeChallenge(verifier))
+    }
+
+    @Test
+    fun `codeChallenge output is URL-safe base64 without padding`() {
+        val verifier = PkceUtil.generateCodeVerifier()
+        val challenge = PkceUtil.codeChallenge(verifier)
+        assertFalse("challenge must not contain '+'", challenge.contains('+'))
+        assertFalse("challenge must not contain '/'", challenge.contains('/'))
+        assertFalse("challenge must not contain '='", challenge.contains('='))
+    }
+
+    @Test
+    fun `generateState produces 32-char hex string`() {
+        val state = PkceUtil.generateState()
+        assertEquals(32, state.length)
+        assertTrue(state.all { it.isDigit() || it in 'a'..'f' })
+    }
+
+    @Test
+    fun `generateState produces unique values`() {
+        val s1 = PkceUtil.generateState()
+        val s2 = PkceUtil.generateState()
+        assertNotEquals(s1, s2)
+    }
+
+    @Test
+    fun `buildAuthorizeUrl strips api suffix and appends correct params`() {
+        val url = PkceUtil.buildAuthorizeUrl(
+            serverUrlWithApi = "https://readeck.example.com/api",
+            clientId = "my-client",
+            redirectUri = "mydeck://oauth-callback",
+            scope = "bookmarks:read",
+            challenge = "abc123",
+            state = "xyz789"
+        )
+        assertTrue(url.startsWith("https://readeck.example.com/authorize"))
+        assertTrue(url.contains("client_id=my-client"))
+        assertTrue(url.contains("code_challenge_method=S256"))
+        assertTrue(url.contains("state=xyz789"))
+        assertFalse("URL must not contain raw /api path", url.contains("/api/authorize"))
+    }
+
+    @Test
+    fun `buildAuthorizeUrl works when serverUrl has no trailing api`() {
+        val url = PkceUtil.buildAuthorizeUrl(
+            serverUrlWithApi = "https://readeck.example.com",
+            clientId = "c",
+            redirectUri = "mydeck://oauth-callback",
+            scope = "s",
+            challenge = "ch",
+            state = "st"
+        )
+        assertTrue(url.startsWith("https://readeck.example.com/authorize"))
+    }
+}

--- a/docs/porting/mydeck-readeck-port.md
+++ b/docs/porting/mydeck-readeck-port.md
@@ -1,95 +1,96 @@
 # Cross-repo port methodology — MyDeck ⇄ Readeck for Android
 
 **Status:** Durable, reusable process doc. Not tied to any one feature.
-**Scope:** MyDeck (`com.mydeck.app`) and Readeck for Android (`org.readeck.apps.android`) are sibling apps that share most of their offline/sync/create/reader code. A fix or feature landed in one frequently needs to be ported to the other. This doc is the **direction-agnostic** harness for doing that; per-feature port checklists are separate, short docs that this harness produces.
+**Scope:** MyDeck and Readeck for Android are **sibling apps built from the same codebase**. Readeck for Android was forked from MyDeck at a known commit (see §0.2 for the anchor), and — deliberately — **they still share the exact same Kotlin source package (`com.mydeck.app`)**. This was done partly as an homage to MyDeck's heritage, but mostly to make porting between them trivial. A fix or feature landed in one frequently needs porting to the other; this doc is the direction-agnostic harness for doing that.
 
-> **Keep this doc mirrored in BOTH repos.** Either repo can be the source of a change, so whichever one you're working in should carry an up-to-date copy. When you edit this methodology, copy it to the other repo.
+> **Keep this doc mirrored in BOTH repos.** Either repo can be the source of a change. When you edit this methodology, copy it to the other repo.
 
 ---
 
-## 1. Roles (not fixed repos)
+## 0. Fixed facts — the ground truth (DO NOT re-derive these)
 
-A port has two roles. **Neither is permanently MyDeck or Readeck** — assign them per port:
-- **SOURCE** — the repo where the change already landed (the commits/PR you are porting *from*).
-- **TARGET** — the repo you are modifying (porting *into*).
+The two apps are the same codebase with a thin branding skin. Internalize this before porting; it means **the default outcome of a port is "the files are byte-identical except a small, closed set of branding differences."**
 
-The first port of the offline-content rework was SOURCE = MyDeck, TARGET = Readeck (the issues surfaced in MyDeck). Future ports will often be the reverse (SOURCE = Readeck). Do not hard-code a direction.
+1. **Same source package: `com.mydeck.app` in BOTH repos, on purpose.** The `namespace`, the `com/mydeck/app/...` directory tree, and every `package`/`import` are identical across the two apps. **There is never a package/import rewrite.** (`applicationId` differs — see §1 — but that is build config, not source.)
+2. **Shared git history — the fork point is a known commit (the anchor).** Readeck for Android was forked from MyDeck at the last common ancestor, **MyDeck commit `2923470`** ("Archived specs for features and fixes in v0.14.0", 2026-06-05). Readeck's own history begins one commit later at **`a570865`** ("Rebrand as Readeck for Android", 2026-06-08), which only skins branding on top. Use `2923470` as the common-ancestor anchor. Because the rebrand touched only branding, files untouched by it remain **byte-identical** in both repos to this day — so a source diff applies cleanly and unchanged files copy verbatim.
+3. **The default port is: copy byte-identical, then patch the branding.** Assume every changed/new source file copies as-is. The only edits are the enumerated branding points in §2. Do not go re-confirming package roots, channel ids, task names, or locale sets — they are fixed (§1) and identical.
+4. **The ONE thing that needs real work: data-model / Room changes.** These are NEVER copied. Regenerate the model/migration in the TARGET at its own DB version and regenerate its schema JSON (§4). Everything else is copy-plus-branding.
+5. **Cross-repo git is available.** The repos are local siblings; add the other as a remote to cherry-pick across them (§3). Do not conclude "no shared history" just because `git merge-base` fails across two separate checkouts — fetch first.
 
-## 2. Setup assumption (the assisting agent)
+If a port ever turns out NOT to match these facts (e.g. a source file is unexpectedly different from the target baseline), that is a signal worth surfacing — not something to silently work around.
 
-You (the assisting model) are running **in the TARGET repo** — that is the working copy you edit, build, and verify. You have **read access to the SOURCE repo** (a sibling checkout, or via `gh`/`git` against its remote). You read the source change there; you never edit it.
+---
 
-**Confirm before touching code:**
-1. Which repo am I in? → that is the **TARGET**.
-2. Where is the **SOURCE** repo, and what is the exact change set? (branch, PR number, or commit range.)
-3. Is the port a **cherry-pick** or a **manual re-apply**? (§4.)
-4. Fill the **divergence map** (§3) with the *actual* values read from each repo — do not assume.
+## 1. Repo reference table (filled — look up, don't discover)
 
-If any of these is unclear, ask before proceeding.
-
-## 3. Divergence map (the transform points)
-
-These differ between the repos and must be transformed when code crosses either direction. **Read the real values from each repo at port time — the table below names the *axes*, with known MyDeck values; confirm the counterpart in the other repo rather than guessing.**
+Assign roles per port (§ Roles below). To port, read the **TARGET's** column. These values are stable; update this table only if a repo actually changes one.
 
 | Axis | MyDeck | Readeck for Android |
 |---|---|---|
+| Source package (`namespace`, dirs, `package`/`import`) | `com.mydeck.app` | `com.mydeck.app` **(same — never rewrite)** |
 | `applicationId` | `com.mydeck.app` | `org.readeck.apps.android` |
-| Source package root (`com/.../...` dirs + `package`/`import`) | `com.mydeck.app` | *(confirm in repo)* |
-| Build flavors / variant task names | `githubSnapshot`, `githubSnapshotHttp` (e.g. `assembleGithubSnapshotDebug`) | *(confirm — do NOT copy MyDeck flavor names)* |
-| Aggregate verify tasks | `:app:assembleDebugAll`, `:app:testDebugUnitTestAll`, `:app:lintDebugAll` | *(confirm — these "All" tasks may be MyDeck-only)* |
-| Notification channel ids | e.g. `SYNC_NOTIFICATION_CHANNEL_ID = "FullSyncNotificationChannelId"` | *(confirm)* |
-| Branding strings/assets (`app_name`, icons, store copy) | "MyDeck" + icons | "Readeck" + upstream branding — **never port verbatim** |
-| Localized string sets | `values/` + the project's locale folders | *(confirm the locale set matches; it may differ)* |
-| Install/run on device | `scripts/install-phone.sh` (+ project's device setup) | *(confirm the target's run path)* |
-| Remotes | `origin NateEaton/mydeck-android` (+ upstream) | *(confirm)* |
+| Build flavors | `githubSnapshot`, `githubSnapshotHttp`, `githubRelease`, `githubReleaseHttp` | `snapshot`, `stable` |
+| Aggregate verify tasks | `:app:assembleDebugAll`, `:app:testDebugUnitTestAll`, `:app:lintDebugAll` | **same names** |
+| Install on device | `scripts/install-phone.sh` | `scripts/install-phone.sh` **(same)** |
+| Notification channel ids / internal constants | `FullSyncNotificationChannelId` etc. | **identical (same codebase)** |
+| Locale folders | `values/` + `-de-rDE, -es-rES, -fr, -gl-rES, -pl, -pt-rPT, -ru, -uk, -zh-rCN` | **same set** |
+| `app_name` / `appLabel` | "MyDeck" | "Readeck" |
+| OAuth client constants (`OAuth*UseCase`: `CLIENT_URI`, `SOFTWARE_ID`, `CLIENT_NAME`) | `https://github.com/NateEaton/mydeck-android`, `com.mydeck.app`, `"MyDeck Android — …"` | `https://codeberg.org/readeck/readeck-android`, `org.readeck.apps.android`, `"Readeck for Android — …"` |
+| OAuth redirect scheme (custom-scheme features) | `mydeck://…` | `readeck://…` |
+| Host / `origin` remote | **GitHub** — `git@github.com:NateEaton/mydeck-android.git` (+ `upstream` jensomato/ReadeckApp, `readeck-local`, `codeberg`) | **Codeberg** — `git@codeberg.org:readeck/readeck-android.git` |
+| CI / release automation | **GitHub Actions** — `.github/workflows/{checks,release,snapshot}.yml`; snapshot builds dispatched from the Actions tab | **Local** — no GitHub Actions; verification + builds run via `scripts/{ci-verify,build-snapshot,build-release,verify-release}.sh` (Codeberg host) |
+| Fork anchor (common ancestor) | `2923470` "Archived specs … v0.14.0" (2026-06-05) | first rebrand commit `a570865` "Rebrand as Readeck for Android" (2026-06-08) |
 
-## 4. Cherry-pick vs manual re-apply
+## 2. Branding transform points — the ONLY things that ever change
 
-Decide once per port:
-- **Cherry-pick** — viable only if the repos share enough git history that the source commits apply with mostly path/package fixups. Faster. After applying, you still run the §6 transforms (package rewrite, channel ids, flavors, strings, branding) and reconcile migrations (§5).
-- **Manual re-apply** — when histories have diverged: re-implement the change file-by-file in the target, using the source diff as the spec. Slower but unavoidable when cherry-pick produces noise.
+This is a **closed list**. If a diff touches something not on it, it is repo-agnostic logic and copies verbatim.
 
-Determine viability by checking shared history between SOURCE and TARGET (`git log`/merge-base if both are reachable). When in doubt, manual re-apply of the *logic* + transforms is the safe default.
+- `applicationId` and the **flavor block** (names/suffixes) in `app/build.gradle.kts`.
+- `app_name` / `appLabel` / launcher icons / store copy / colors.
+- **OAuth client-registration constants** (`CLIENT_URI`, `SOFTWARE_ID`, `CLIENT_NAME`) — use the TARGET's values from §1.
+- Any **brand-prefixed URL or custom URI scheme** (e.g. `mydeck://` ⇄ `readeck://`). Prefer sourcing these from `BuildConfig`/`manifestPlaceholders` so the port changes one place.
+- **User-guide + CHANGELOG wording** (the app is named in prose) — adapt to the target's name.
 
-## 5. Schema / migration reconciliation (highest-risk gotcha)
+Everything else — logic, DTOs, ViewModels, Compose UI, tests, DAOs, workers, string *keys* — is identical and copies byte-for-byte.
 
-Room DB versions and migration registration are **repo-specific**:
-- A migration added in SOURCE as `vN → vN+1` almost certainly maps to a **different version number** in TARGET (its current DB version differs). Renumber it.
-- Regenerate the TARGET's exported schema JSON for its new version (don't copy SOURCE's `N.json`).
-- Register the migration in the TARGET's database module and add/port its migration test.
-- Verify the column/table additions don't already exist under a different name in TARGET.
+**Never ports across repos** (per-repo infra, not branding): CI config (MyDeck's `.github/workflows/*` has no Readeck counterpart — Readeck verifies via local `scripts/*.sh`), Room schema versions + migrations (§4), signing/keystore config. A source change that only touches these does not port at all; a change that touches them *and* logic ports only the logic.
 
-## 6. Port procedure (direction-agnostic)
+## 3. Roles + cross-repo git
 
-1. **Enumerate** the SOURCE change set (commits/files). Use any inline "keep repo-agnostic / flag divergence" notes the source author left (they mark exactly the transform points).
-2. **Classify each change:** *repo-agnostic logic* (applies verbatim) · *divergence-touching* (package refs, channel ids, flavors, manifest, branding, strings — transform via §3) · *target-specific* (UI/branding that legitimately differs — adapt, don't copy).
-3. **Apply** the logic (cherry-pick or manual), then run the §3 transforms.
-4. **Reconcile migrations** (§5) if any schema changed.
-5. **Re-localize:** add the new strings to the TARGET's string set, in *its* locale folders. **Do not** `git checkout <ref> -- strings.xml` wholesale — that restores the entire file from the source tree and silently drops strings the target added independently. Insert the specific new keys surgically.
-6. **Docs:** port user-guide updates into the TARGET's guide (its wording/branding).
-7. **Verify:** the TARGET's build/test/lint (its task names, not MyDeck's) green; on-device check the ported behavior where feasible (especially anything touching workers/scheduler/migrations).
-8. **Commit/PR** in the TARGET per its conventions. Per repo rules, propose state-changing git/PR commands for the maintainer rather than running them.
+- **SOURCE** = repo the change landed in (read-only; never edit). **TARGET** = repo you're porting into (the one you're working in). Neither is permanently MyDeck or Readeck.
+- To cherry-pick or read source commits from the TARGET, add the sibling as a local remote and fetch:
+  `git remote add <source> <path-or-url> && git fetch <source>` (a local path like `/Users/nathan/development/MyDeck` works). Then `git cherry-pick <sha>` or `git show <sha>:<path>`.
+- Because the source package is identical (§0), cherry-picks apply with no path/package fixups — only the §2 branding edits and any §4 model regeneration remain.
 
-## 7. Recurring gotchas (the durable lessons)
+## 4. Data-model / migration reconciliation (the only real gotcha)
 
-- **Renumber + regenerate migrations** (§5) — never copy a version number across repos.
-- **Channel ids and flavor/variant task names differ** — don't copy `githubSnapshotDebug` or a MyDeck channel constant verbatim.
-- **Branding strings/assets** (`app_name`, store copy, icons) are *intentional* divergences — never port.
-- **Package/import rewrite** across the whole moved set (`com.mydeck.app.*` ⇄ the target root).
-- **Manifest divergence** — permissions and foreground-service types may already differ; merge, don't overwrite.
-- **Surgical string inserts**, never whole-file restores from another tree (clobbers independently-added keys).
-- **Locale set may differ** — confirm the target's languages before assuming the same N files.
+Room DB versions and migration registration are **repo-specific and never copied**:
+- A migration added in SOURCE as `vN → vN+1` maps to a **different version number** in TARGET — renumber it to TARGET's next version.
+- **Regenerate** the TARGET's exported schema JSON for its new version (don't copy SOURCE's `N.json`).
+- Register the migration in TARGET's database module; add/port its migration test.
+- Confirm the added columns/tables don't already exist under a different name in TARGET.
 
-## 8. Per-feature port checklists
+If a port has no schema change, this section is a no-op — skip it entirely.
 
-This methodology is the reusable harness. Each concrete port gets its own short checklist (e.g. `docs/porting/offline-content-rework-port.md`) listing that feature's commits, files, and specific divergences — **finalized against the shipped code** (after the source PR merges), and seeded from the inline divergence flags the source author left while the work was fresh.
+## 5. Port procedure
 
-## 9. Start-of-port checklist (copy/run this each time)
+1. **Identify** SOURCE change set (branch/PR/commit range) and read its diff.
+2. **Copy** the changed/new files (verbatim — cherry-pick per §3, or copy the source-branch version of each file since baselines are identical per §0.2). New files drop in as-is; modified files' baselines match, so the source version is a clean superset.
+3. **Apply the §2 branding edits** — the only edits. For `build.gradle.kts` and `AndroidManifest.xml`, do NOT copy wholesale (flavors/applicationId/manifest entries differ); merge the added blocks.
+4. **Regenerate models** (§4) if any schema changed.
+5. **Localize:** insert the new string *keys* into the TARGET's `values/` + locale files surgically. Never `git checkout <ref> -- strings.xml` (clobbers independently-added keys). Keys and English values port as-is.
+6. **Docs:** port guide + CHANGELOG additions in the target's wording.
+7. **Verify:** `:app:assembleDebugAll`, `:app:testDebugUnitTestAll`, `:app:lintDebugAll` green (same names in both). On-device check via `scripts/install-phone.sh`, especially anything touching workers/scheduler/migrations.
+8. **Commit/PR** per the target's conventions. Per repo rules, **propose** state-changing git/PR commands for the maintainer rather than running them.
 
-- [ ] Confirm TARGET = the repo I'm in; SOURCE located and read-accessible.
+## 6. Per-feature port checklists
+
+This methodology is the reusable harness. Each concrete port gets a short checklist (e.g. `docs/porting/<feature>-port.md`) listing that feature's commits, files, and the specific §2 branding values used — finalized against the shipped source code. Seed it from any inline "keep repo-agnostic / flag divergence" notes the source author left.
+
+## 7. Start-of-port checklist (most boxes are pre-answered by §0–§1)
+
+- [ ] TARGET = the repo I'm in; SOURCE located and read-accessible (add as remote if cherry-picking, §3).
 - [ ] Source change set identified (branch/PR/commit range).
-- [ ] Cherry-pick vs manual re-apply decided (§4).
-- [ ] Divergence map (§3) filled with real values from both repos.
-- [ ] TARGET current DB version + migration registration point identified (§5).
-- [ ] TARGET build/test/lint task names + on-device run path identified.
-- [ ] Localization locale set in TARGET confirmed.
+- [ ] Confirmed the changed source files match §0.2 (source base == target current) — if not, surface it.
+- [ ] Does the change touch the data model? If yes → §4 (regenerate). If no → skip §4.
+- [ ] Branding values for the TARGET pulled from §1.

--- a/docs/specs/oauth-authorization-code-flow-spec.md
+++ b/docs/specs/oauth-authorization-code-flow-spec.md
@@ -1,0 +1,190 @@
+# OAuth Authorization Code Flow — Technical Spec
+
+Status: Proposed (targeting next release; portable to Readeck Android rc6 / v1.0.0)
+Related archives: `docs/archive/TECH_SPEC_OAuth_Device_Code_Authentication.md`, `docs/archive/IMPLEMENTATION_CODE_OAuth_Device_Code.md`
+Authoritative server contract: `docs/openapi-spec.json`
+
+## 1. Goal
+
+Add OAuth 2.0 **Authorization Code + PKCE** as the primary, browser-based sign-in path,
+while keeping the existing **Device Code** flow in the tree as a user-selectable fallback
+("sign in with a code instead") for browserless / input-constrained devices (e-readers, etc.).
+
+The token we ultimately obtain and everything downstream of it is unchanged — this feature
+only replaces *how the access token is acquired* in the common case.
+
+## 2. Server support is already present
+
+The bundled `docs/openapi-spec.json` confirms the Readeck server already implements the full
+authorization-code + PKCE flow. **This feature is not blocked on CIDM or any server change.**
+CIDM (Olivier's interest) is a separate future concern.
+
+Confirmed contract details (source of truth — supersedes the independent assessment where they differ):
+
+- **Authorization endpoint lives at the server ROOT: `GET /authorize`** — *not* under `/api`.
+  The app stores the server URL with a `/api` suffix, so the browser URL is built as
+  `storedUrl.removeSuffix("/api") + "/authorize"`. (Same `removeSuffix("/api")` pattern already
+  used in `AccountSettingsViewModel`.)
+- **Authorize query params:** `client_id`, `redirect_uri`, `scope`, `code_challenge`,
+  `code_challenge_method=S256`, `state`.
+- **Redirect result (success):** `code`, `state`. **(error):** `error` (`invalid_request` or
+  `access_denied`), `error_description`, `state`.
+- **Custom schemes are explicitly allowed as redirect URIs.** Spec: redirect URIs must be
+  "any https URI, http loopback, *or any other app link scheme (ie `my-app.org:/callback`)*."
+  So `mydeck://oauth-callback` is sanctioned.
+- **`redirect_uris` is REQUIRED at client registration when `grant_types` contains
+  `authorization_code`**, and the `redirect_uri` sent to `/authorize` must match a registered one
+  exactly.
+- **Token endpoint stays `POST /api/oauth/token`.** Request body is a `oneOf`. The
+  `authorization_code` branch requires exactly `grant_type` + `code` + `code_verifier` and takes
+  **no `client_id`** (the device-code branch does take `client_id`). `code` maxLength 2048,
+  `code_verifier` maxLength 256. Response DTO unchanged (`access_token`, `token_type`, `scope`).
+- **PKCE:** S256 only ("plain" rejected). Verifier is a random string; challenge is
+  base64url(SHA-256(verifier)) **with URL encoding, without padding**. Server's own example uses a
+  64-char alphanumeric verifier.
+- Clients are ephemeral (valid 10 minutes) — register a fresh client for each flow, exactly as the
+  device-code path already does.
+
+## 3. Redirect mechanism (decision recorded)
+
+- **MyDeck: always custom scheme** — `mydeck://oauth-callback`. We do not control users'
+  self-hosted Readeck domains, so verified https App Links are not an option for MyDeck.
+  PKCE + `state` make the custom scheme acceptable per RFC 8252 (an interceptor would get the code
+  but not the verifier).
+- **Readeck Android (port): pluggable.** Eventually the Readeck platform may host
+  `/.well-known/assetlinks.json`, enabling verified https App Links against the Readeck domain.
+  Design the redirect handling so the redirect URI + intent-filter are driven by `BuildConfig`
+  / `manifestPlaceholders`, not hardcoded, so the port can swap custom scheme → App Links without
+  touching flow logic.
+
+**Scheme form:** a single literal `mydeck://oauth-callback` is simplest. Because client
+registration is ephemeral and per-device, each installed build registers only *its own*
+`redirect_uri`, so a per-flavor scheme (via `manifestPlaceholders`) is also viable and avoids two
+side-by-side installs (e.g. snapshot + release) both claiming the same scheme and triggering
+Android's disambiguation dialog. Default to the single literal unless side-by-side installs prove
+annoying in practice.
+
+## 4. Architecture / changes
+
+### 4.1 Data layer (`io/rest/model`, `io/rest/ReadeckApi`)
+
+- **`OAuthClientRegistrationRequestDto`** — add `redirect_uris: List<String>` and include
+  `"authorization_code"` in `grant_types` (alongside device_code) when registering for the
+  auth-code flow.
+- **New `OAuthAuthCodeTokenRequestDto`** — `grant_type` (`"authorization_code"`), `code`,
+  `code_verifier`. Do **not** reshape the existing `OAuthTokenRequestDto` to nullable fields —
+  a dedicated DTO keeps the device-code path clean and avoids interaction with the global
+  `Json(explicitNulls=false)` config.
+- **`ReadeckApi`** — add a second token method, e.g.
+  `suspend fun requestTokenWithAuthCode(@Body body: OAuthAuthCodeTokenRequestDto): Response<OAuthTokenResponseDto>`
+  (Retrofit can't overload on `@Body` type alone; use a distinct method name). Response type is the
+  unchanged `OAuthTokenResponseDto`.
+- **`OAuthTokenResponseDto` / `OAuthErrorDto`** — unchanged.
+
+### 4.2 PKCE + URL utilities (new)
+
+- `PkceUtil` (or add to `util/`): `generateCodeVerifier()` using `SecureRandom` (43–128 char
+  unreserved charset; 64-char alphanumeric is fine), `codeChallenge(verifier)` =
+  base64url-no-pad SHA-256.
+- `generateState()` — random CSRF token.
+- Authorize-URL builder: `buildAuthorizeUrl(serverUrlWithApi, clientId, redirectUri, scope, challenge, state)`
+  → strips `/api`, appends `/authorize`, URL-encodes params.
+
+### 4.3 Redirect plumbing (`AndroidManifest.xml`, `MainActivity`)
+
+- Add an `<intent-filter>` (BROWSABLE/DEFAULT + `<data android:scheme="..." android:host="..."/>`)
+  driven by a manifest placeholder for the scheme/host — mirror the existing `ShareActivity`
+  filter pattern. Attach it to `MainActivity` (or a thin routing activity).
+- Set `MainActivity` `launchMode="singleTop"`; handle the redirect in `onNewIntent`.
+- Parse `code` / `state` / `error` / `error_description` and emit to the VM via an event channel
+  (SharedFlow / Channel), so the redirect result reaches the in-progress login.
+
+### 4.4 Use case (new: `OAuthAuthorizationCodeUseCase`)
+
+Mirror the structure of `OAuthDeviceAuthorizationUseCase`:
+
+- `initiateAuthorization(serverUrl): Result` — register client (with `redirect_uris` +
+  `authorization_code`), generate verifier/challenge/state, build authorize URL, return the URL to
+  launch plus the values to persist.
+- `exchangeCode(code, verifier): TokenResult` — `POST /api/oauth/token` via
+  `requestTokenWithAuthCode`, map success → access token, map `invalid_grant` / other errors.
+- Reuse the existing `parseOAuthError`, `isHttpBlockedByBuildPolicy`, and error taxonomy.
+
+### 4.5 Process-death persistence
+
+Android may kill the app while the Custom Tab is foregrounded. Persist `code_verifier`, `state`,
+`client_id`, and the target `serverUrl` in **`SavedStateHandle`** (not plain in-memory VM state, which
+the device-code path relied on). On redirect, restore, validate `state` matches, then exchange.
+
+### 4.6 ViewModel / UI (`AccountSettingsViewModel`, login UI)
+
+- Replace the `startLogin()` → `startPolling()` while-loop with a one-shot flow:
+  initiate → launch Custom Tab (reuse `openUrlInCustomTab` in `util/Utils.kt`) → await redirect
+  event → validate `state` → `exchangeCode` → `completeLogin(url, token)` (unchanged).
+- New UI states: browser launched / awaiting redirect / user denied or cancelled in browser /
+  redirect never arrived (timeout).
+- **Fallback affordance:** add a visible secondary action on the login screen — "Sign in with a code
+  instead" — that routes to the existing `DeviceAuthorizationDialog` / device-code path (kept
+  in-tree, not deleted).
+
+### 4.7 Unchanged (confirmed)
+
+`SettingsDataStore` token storage, `AuthInterceptor`, `completeLogin`, logout / `POST /oauth/revoke`
+— all grant-type agnostic.
+
+## 5. Flow (happy path)
+
+1. User enters instance URL, taps Sign in.
+2. App registers ephemeral client (authorization_code + device_code grants, redirect_uris=[our URI]).
+3. App generates verifier/challenge/state, persists them (SavedStateHandle), builds `/authorize` URL.
+4. App opens the authorize URL in a Custom Tab.
+5. User authenticates + approves in the browser; server redirects to `mydeck://oauth-callback?code=...&state=...`.
+6. `MainActivity.onNewIntent` parses params → VM validates `state` → `POST /api/oauth/token`
+   (grant_type=authorization_code, code, code_verifier).
+7. Server returns `access_token` → `completeLogin(url, token)` → profile fetch → done.
+
+Error branches: user denies (`access_denied`), `state` mismatch (abort, show error), redirect never
+arrives (timeout → allow retry or fall back to code entry), network / HTTP-blocked-by-build-policy
+(reuse existing handling).
+
+## 6. Compliance with project requirements
+
+- **Strings:** any new UI strings added to `values/strings.xml` AND all 9 language files as English
+  placeholders (see root `CLAUDE.md`).
+- **User guide:** update `app/src/main/assets/guide/en/getting-started.md` to describe the new
+  browser-based sign-in, and mention the "sign in with a code instead" fallback.
+- **Changelog:** update `## [Unreleased]` in `CHANGELOG.md`.
+- **Verification:** `./gradlew :app:assembleDebugAll :app:testDebugUnitTestAll :app:lintDebugAll`,
+  plus device verification via `./scripts/install-phone.sh`.
+
+## 7. Phased plan
+
+- **Phase 0 — Live-server verification (de-risk first).** Manually register a throwaway client with
+  `authorization_code` + a redirect_uri, open `/authorize` in a browser against the real instance,
+  confirm redirect + token exchange. Validates the root-vs-`/api` path and scheme handling before
+  building UI.
+- **Phase 1 — Data/API.** Registration DTO change; `OAuthAuthCodeTokenRequestDto` + Retrofit method;
+  PKCE util; authorize-URL builder. Unit tests.
+- **Phase 2 — Redirect plumbing.** Manifest intent-filter (placeholder-driven); MainActivity
+  singleTop + onNewIntent; event channel.
+- **Phase 3 — Use case.** `OAuthAuthorizationCodeUseCase`; SavedStateHandle persistence;
+  state/error validation. Unit tests (hand-written fake repo — MockK can't mock suspend funs
+  returning Kotlin `Result`).
+- **Phase 4 — VM/UI.** One-shot login flow; new states; "sign in with a code instead" fallback entry.
+- **Phase 5 — Strings (10 files) / guide / changelog.**
+- **Phase 6 — Verify** (assembleDebugAll / testDebugUnitTestAll / lintDebugAll) + device test.
+
+## 8. Port to Readeck Android (rc6 / v1.0.0)
+
+Self-contained; ports via `docs/porting/mydeck-readeck-port.md`. Deltas: redirect scheme/host,
+`client_uri` / `client_name` / `software_id`, string keys. Server contract is identical, so flow
+logic ports 1:1. Keep the redirect URI + intent-filter `BuildConfig`/placeholder-driven so Readeck
+can later switch custom scheme → server-hosted verified App Links without touching flow logic.
+
+## 9. Open items / to verify in Phase 0
+
+- Exact behavior of `/authorize` when the user is not yet logged into the web session (login then
+  consent) inside a Custom Tab, and that it redirects cleanly to the custom scheme.
+- Whether any deployed server versions we support lack the authorize endpoint (gate on the existing
+  server OAuth-capability check if needed).
+- Final decision on single-literal vs per-flavor scheme.


### PR DESCRIPTION
## OAuth Authorization Code + PKCE sign-in

Adds browser-based OAuth **Authorization Code + PKCE** as the primary sign-in method, alongside the existing Device Code flow (kept as a user-selectable fallback). Tapping **Sign In** now opens the Readeck authorization page in a Custom Tab and completes sign-in on redirect — no code entry needed. Everything downstream of the access token (storage, `AuthInterceptor`, refresh, logout/revoke) is unchanged, since it was already grant-type agnostic.

Server support for this flow already exists in Readeck (confirmed against the bundled `docs/openapi-spec.json`); this is a pure client addition and is not blocked on any server change.

Design doc: [`docs/specs/oauth-authorization-code-flow-spec.md`](docs/specs/oauth-authorization-code-flow-spec.md).

### Flow
1. Register an ephemeral client (`authorization_code` + `device_code` grants, with `redirect_uris`).
2. Generate PKCE verifier/challenge (S256) + a CSRF `state`; persist verifier/state/client_id/serverURL in `SavedStateHandle`.
3. Open the root `/authorize` URL in a Custom Tab.
4. Redirect returns to `mydeck://oauth-callback`; `MainActivity` parses it and hands the code/state to the ViewModel via an app-scoped event bus.
5. Validate `state`, exchange the code for a token (`grant_type=authorization_code`, `code`, `code_verifier`), then complete login.

### Added
- **OAuth Authorization Code + PKCE sign-in** as the primary browser-based flow.
- **"Sign in with a code instead"** — visible fallback to the existing Device Code flow for constrained/browserless devices (dormant, not deleted).
- Sign-in **survives process death** while the browser is open — returning from the browser resumes and completes.

### Implementation notes
- New `OAuthAuthorizationCodeUseCase`, `PkceUtil`, `OAuthAuthCodeTokenRequestDto`, and a dedicated `ReadeckApi.requestTokenWithAuthCode` (the existing device-code token DTO is left untouched).
- Authorize URL is built from the stored API URL with `/api` stripped (the endpoint is at the server root `/authorize`, **not** under `/api`).
- Redirect scheme/host are single-sourced from `BuildConfig.OAUTH_CALLBACK_SCHEME/HOST` (driven by `manifestPlaceholders`), so the manifest filter, `MainActivity` matcher, and registered `redirect_uri` cannot drift — and the Readeck port can swap them in one place.

### Hardening (from review + on-device testing)
The process-death path (app killed while the Custom Tab is foregrounded) exposed several bugs, now fixed:
- **Callback drop** — the callback event bus used `replay=0`, losing a redirect dispatched before the recreated ViewModel re-subscribed. Now `replay=1` + `consume()`, with stale-event clearing on start/cancel/switch.
- **`onNewIntent` crash** — `lateinit intentState` was accessed during resume before composition initialized it (`UninitializedPropertyAccessException`). Fixed via `setIntent()` + `isInitialized` guard.
- **Initial sync cancelled on restore** — `onLoginSuccess` ran the post-login sync on `viewModelScope`, which navigation/VM-clearing cancelled, leaving the list unpopulated. Moved to `applicationScope` (mirrors the device-code polling job).

### Testing
- Unit: `PkceUtilTest` (incl. RFC 7636 known vector), `OAuthAuthorizationCodeUseCaseTest`, `OAuthCallbackRepositoryTest`, and new `AccountSettingsViewModelTest` cases (matching-state exchange, state mismatch, `access_denied`, process-death replay restore). Also fixed a pre-existing VM test that wasn't actually passing (unstubbed `saveUrl`).
- Aggregates green: `:app:assembleDebugAll`, `:app:testDebugUnitTestAll`, `:app:lintDebugAll`.
- **Device:** full happy path (Welcome + Account screens), deny, cancel, code-fallback, and process-death restore (simulated via `adb shell am kill` while the Custom Tab is foreground) all verified on a Pixel 9 — restore completes and populates the list.

### Known minor edge (intentionally left as-is)
On a *re-login* process-death restore, an app-open bookmark sync can race ~150ms ahead of the token, producing a single transient `401` and a brief auth-failure notification before login completes. It self-clears and does not affect the list.


🤖 Generated with [Claude Code](https://claude.com/claude-code)