### PR TITLE
feat: consistent bottom-sheet dismissal + affordances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Label delete confirmation** now shows how many bookmarks the label will be removed from, so the scope of the action is clear before confirming.
 - **Bulk bookmark delete** now requires an extra confirmation step when 25 or more bookmarks are selected, showing the count before proceeding to the usual undo snackbar flow.
+- **Bottom sheets** now slide closed consistently — closing one with a button (e.g. Done, Save, Search) animates out the same way as swiping it down, instead of vanishing instantly. The label picker also drops its back arrow to match the other sheets.
 
 ## [0.14.5] - 2026-07-03
 

--- a/app/src/main/java/com/mydeck/app/ui/collections/CollectionEditorSheet.kt
+++ b/app/src/main/java/com/mydeck/app/ui/collections/CollectionEditorSheet.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -32,6 +33,7 @@ import androidx.compose.ui.unit.dp
 import com.mydeck.app.R
 import com.mydeck.app.domain.model.FilterFormState
 import com.mydeck.app.ui.components.FilterControls
+import com.mydeck.app.ui.components.dismissSheet
 import com.mydeck.app.ui.components.rememberFilterEditorState
 
 /**
@@ -55,6 +57,7 @@ fun CollectionEditorSheet(
     onDelete: (() -> Unit)? = null,
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val scope = rememberCoroutineScope()
     var name by remember(initialName) { mutableStateOf(initialName) }
     val filterState = rememberFilterEditorState(initialFilter)
 
@@ -103,17 +106,23 @@ fun CollectionEditorSheet(
             ) {
                 if (onDelete != null) {
                     TextButton(
-                        onClick = onDelete,
+                        onClick = { scope.dismissSheet(sheetState) { onDelete() } },
                         colors = ButtonDefaults.textButtonColors(
                             contentColor = MaterialTheme.colorScheme.error
                         ),
                     ) { Text(stringResource(R.string.collection_delete_action)) }
                 }
                 Spacer(Modifier.weight(1f))
-                TextButton(onClick = onDismiss) { Text(stringResource(R.string.cancel)) }
+                TextButton(onClick = { scope.dismissSheet(sheetState) { onDismiss() } }) {
+                    Text(stringResource(R.string.cancel))
+                }
                 Spacer(Modifier.width(8.dp))
                 Button(
-                    onClick = { onSave(name.trim(), filterState.toFilterFormState()) },
+                    onClick = {
+                        scope.dismissSheet(sheetState) {
+                            onSave(name.trim(), filterState.toFilterFormState())
+                        }
+                    },
                     enabled = name.isNotBlank() && !filterState.hasValidationError,
                 ) { Text(stringResource(R.string.collection_editor_save)) }
             }

--- a/app/src/main/java/com/mydeck/app/ui/components/BottomSheetDismiss.kt
+++ b/app/src/main/java/com/mydeck/app/ui/components/BottomSheetDismiss.kt
@@ -1,0 +1,24 @@
+package com.mydeck.app.ui.components
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.SheetState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+/**
+ * Animate a [ModalBottomSheet][androidx.compose.material3.ModalBottomSheet] closed, then run
+ * [onClosed] once it has finished sliding out.
+ *
+ * Swipe/scrim dismissal already animates — the sheet slides out *before* `onDismissRequest`
+ * fires. Buttons and programmatic closes that flip the caller's show-flag directly (e.g. a
+ * Done/Save button that immediately sets `show = false`) skip that motion and make the sheet
+ * vanish instantly. Route those through this helper so every close shares the same MD3
+ * slide-out. [onClosed] is where the show-flag is actually flipped (typically the sheet's
+ * `onDismiss`, or a commit callback that dismisses synchronously).
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+fun CoroutineScope.dismissSheet(sheetState: SheetState, onClosed: () -> Unit) {
+    launch { sheetState.hide() }.invokeOnCompletion {
+        if (!sheetState.isVisible) onClosed()
+    }
+}

--- a/app/src/main/java/com/mydeck/app/ui/components/FilterBottomSheet.kt
+++ b/app/src/main/java/com/mydeck/app/ui/components/FilterBottomSheet.kt
@@ -54,6 +54,7 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -531,11 +532,12 @@ fun FilterBottomSheet(
     onDismiss: () -> Unit,
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false)
+    val scope = rememberCoroutineScope()
     val state = rememberFilterEditorState(currentFilter)
 
     val applyFilter = {
         if (!state.hasValidationError) {
-            onApply(state.toFilterFormState())
+            scope.dismissSheet(sheetState) { onApply(state.toFilterFormState()) }
         }
     }
 
@@ -561,7 +563,9 @@ fun FilterBottomSheet(
             // -- Action buttons
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
                 if (state.hasActiveFilters) {
-                    TextButton(onClick = onReset) { Text(stringResource(R.string.filter_reset)) }
+                    TextButton(onClick = { scope.dismissSheet(sheetState) { onReset() } }) {
+                        Text(stringResource(R.string.filter_reset))
+                    }
                     Spacer(Modifier.width(8.dp))
                 }
                 Button(onClick = { applyFilter() }, enabled = !state.hasValidationError) { Text(stringResource(R.string.search)) }

--- a/app/src/main/java/com/mydeck/app/ui/detail/ReaderSettingsBottomSheet.kt
+++ b/app/src/main/java/com/mydeck/app/ui/detail/ReaderSettingsBottomSheet.kt
@@ -55,6 +55,7 @@ import timber.log.Timber
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.geometry.Offset
@@ -74,6 +75,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.Velocity
 import com.mydeck.app.R
+import com.mydeck.app.ui.components.dismissSheet
 import com.mydeck.app.domain.model.EffectiveAppearance
 import com.mydeck.app.domain.model.ReaderFontFamily
 import com.mydeck.app.domain.model.ReaderAppearanceSelection
@@ -728,6 +730,7 @@ private fun SelectFontSheet(
     onDismiss: () -> Unit,
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val scope = rememberCoroutineScope()
     // Transparent scrim so the reading view behind isn't double-dimmed — the underlying
     // typography sheet's scrim already dims it, and we want the live font preview visible.
     ModalBottomSheet(
@@ -789,7 +792,7 @@ private fun SelectFontSheet(
                     text = stringResource(R.string.select_font_title),
                     style = MaterialTheme.typography.titleMedium,
                 )
-                TextButton(onClick = onDismiss) {
+                TextButton(onClick = { scope.dismissSheet(sheetState) { onDismiss() } }) {
                     Text(stringResource(R.string.select_font_done))
                 }
             }

--- a/app/src/main/java/com/mydeck/app/ui/list/LabelsBottomSheet.kt
+++ b/app/src/main/java/com/mydeck/app/ui/list/LabelsBottomSheet.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.clickable
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.outlined.Label
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Clear
@@ -69,6 +68,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import com.mydeck.app.R
 import com.mydeck.app.ui.components.VerticalScrollbar
+import com.mydeck.app.ui.components.dismissSheet
 import kotlinx.coroutines.launch
 
 sealed interface LabelPickerMode {
@@ -97,6 +97,9 @@ fun LabelPickerBottomSheet(
     // Hoisted so the title-tap affordance can scroll the results list (see the scrollable branch).
     val lazyListState = rememberLazyListState()
     val coroutineScope = rememberCoroutineScope()
+    // Declared here (ahead of commitSearch / the item click handlers) so every dismiss path can
+    // animate the sheet closed via dismissSheet instead of flipping the caller's flag instantly.
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val screenHeight = LocalConfiguration.current.screenHeightDp.dp
     var contextMenuLabel by remember { mutableStateOf<String?>(null) }
     var showRenameDialog by remember { mutableStateOf(false) }
@@ -203,8 +206,10 @@ fun LabelPickerBottomSheet(
                 // Single-select mode is selection-only: only existing labels can be applied.
                 if (exactLabel != null) {
                     searchQuery = ""
-                    mode.onLabelSelected(exactLabel)
-                    onDismiss()
+                    coroutineScope.dismissSheet(sheetState) {
+                        mode.onLabelSelected(exactLabel)
+                        onDismiss()
+                    }
                 }
             }
         }
@@ -220,7 +225,6 @@ fun LabelPickerBottomSheet(
         searchQuery = ""
     }
 
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val showSearchEmptyState = filteredLabels.isEmpty() && !showCreateAction
     val showScrollableResults = showCreateAction || unselectedFilteredLabels.isNotEmpty()
 
@@ -284,8 +288,10 @@ fun LabelPickerBottomSheet(
                         onClick = {
                             when (mode) {
                                 is LabelPickerMode.SingleSelect -> {
-                                    mode.onLabelSelected(label)
-                                    onDismiss()
+                                    coroutineScope.dismissSheet(sheetState) {
+                                        mode.onLabelSelected(label)
+                                        onDismiss()
+                                    }
                                 }
 
                                 is LabelPickerMode.MultiSelect -> {
@@ -344,14 +350,6 @@ fun LabelPickerBottomSheet(
                         }
                     )
                 },
-                navigationIcon = {
-                    IconButton(onClick = onDismiss) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(R.string.back)
-                        )
-                    }
-                },
                 actions = {
                     // Label-search ranking toggles (persisted globally). Placed before Done so they
                     // shift left to make room for it on the multi-select sheet. Each shows the current
@@ -401,8 +399,10 @@ fun LabelPickerBottomSheet(
                     if (mode is LabelPickerMode.MultiSelect) {
                         TextButton(
                             onClick = {
-                                mode.onDone(tempSelection.toSet())
-                                onDismiss()
+                                coroutineScope.dismissSheet(sheetState) {
+                                    mode.onDone(tempSelection.toSet())
+                                    onDismiss()
+                                }
                             }
                         ) {
                             Text(stringResource(R.string.label_picker_done))

--- a/docs/porting/bottom-sheet-consistency-port.md
+++ b/docs/porting/bottom-sheet-consistency-port.md
@@ -1,0 +1,42 @@
+# Port checklist — Bottom-sheet dismissal + affordance consistency
+
+**Source:** Readeck for Android `enhancement/bottom-sheet-consistency` (commit `0000e13` — "feat: consistent bottom-sheet dismissal + affordances")
+**Target:** MyDeck `main`
+**Methodology:** `docs/porting/mydeck-readeck-port.md`
+
+> **Direction note:** this change originated in **Readeck for Android**, so here SOURCE = Readeck, TARGET = MyDeck (the reverse of most earlier port docs). The source package is identical (`com.mydeck.app`), so files still copy verbatim.
+
+## Branding deltas applied (§2)
+
+**None.** The change is pure Compose UI/logic — no `applicationId`/flavor, no `app_name`, no OAuth constants, no brand-prefixed URLs or schemes, and no app name in the CHANGELOG wording. This is a copy-verbatim port with zero §2 edits.
+
+## Files changed
+
+### New files (verbatim)
+- `app/src/main/java/com/mydeck/app/ui/components/BottomSheetDismiss.kt` — shared `CoroutineScope.dismissSheet(sheetState) { … }` helper: runs `sheetState.hide()` then invokes the close in `invokeOnCompletion`, so button/programmatic closes animate out like a swipe/scrim dismiss instead of vanishing instantly.
+
+### Modified files (merged — baselines are byte-identical per §0.2, so the source version applies cleanly)
+- `app/src/main/java/com/mydeck/app/ui/detail/ReaderSettingsBottomSheet.kt` — `SelectFontSheet`: added `rememberCoroutineScope`; route the top-right **Done** through `dismissSheet`. (Adds imports `rememberCoroutineScope`, `com.mydeck.app.ui.components.dismissSheet`.)
+- `app/src/main/java/com/mydeck/app/ui/collections/CollectionEditorSheet.kt` — route **Cancel / Save / Delete** through `dismissSheet` (all close synchronously in the caller). (Adds the same two imports.)
+- `app/src/main/java/com/mydeck/app/ui/components/FilterBottomSheet.kt` — route **Search** (incl. the keyboard IME action, via the `applyFilter` lambda) and **Reset** through `dismissSheet`. Same-package, so only `rememberCoroutineScope` import is added.
+- `app/src/main/java/com/mydeck/app/ui/list/LabelsBottomSheet.kt` — (1) removed the `TopAppBar` back-arrow `navigationIcon` (affordance convention: no back arrow in a modal sheet) and dropped the now-unused `ArrowBack` import; (2) moved the `sheetState` declaration up (ahead of `commitSearch` / the item click handlers) so every dismiss path can reach it; (3) route the **Done** action, single-select label taps (item `onClick` and the search-commit `exactLabel` path) through `dismissSheet`. (Adds `com.mydeck.app.ui.components.dismissSheet` import.)
+- `CHANGELOG.md` — `[Unreleased]` → `### Changed` bullet. Wording is brand-neutral; copy as-is (or reword to taste — MyDeck isn't named).
+
+### Sheets deliberately NOT changed (audit result — port the same decision)
+- **Add bookmark** and **Annotation edit** close via an async loading→success state transition (not an instant flag-flip), and already have no back arrow.
+- **Annotations list** and **Reader settings (main sheet)** close only via drag handle / scrim, which already animates.
+- **ShareActivity**'s inline sheet dismisses via `finish()` (activity teardown), no back arrow.
+
+## §4 data-model check
+No Room schema changes — §4 is a no-op.
+
+## Pre-port sanity (§0.2)
+Before copying, confirm MyDeck's current versions of the four modified sheet files match Readeck's pre-`0000e13` baseline (they should be byte-identical). If MyDeck has independently diverged in any of them (e.g. its own sheet edits), merge the `dismissSheet` routing by hand rather than overwriting, and surface the divergence.
+
+## Verification
+Run after porting:
+```
+./gradlew :app:assembleDebugAll :app:testDebugUnitTestAll :app:lintDebugAll
+./scripts/install-phone.sh
+```
+On-device: open each changed sheet and confirm it **slides** closed (not blinks) when dismissed by its button — Select font (Done), Filter (Search / Reset), Save/Edit Collection (Save / Cancel / Delete), Label picker (pick a label / Done). Confirm the label picker no longer shows a back arrow.

--- a/docs/porting/mydeck-readeck-port.md
+++ b/docs/porting/mydeck-readeck-port.md
@@ -61,6 +61,7 @@ Everything else — logic, DTOs, ViewModels, Compose UI, tests, DAOs, workers, s
 - To cherry-pick or read source commits from the TARGET, add the sibling as a local remote and fetch:
   `git remote add <source> <path-or-url> && git fetch <source>` (a local path like `/Users/nathan/development/MyDeck` works). Then `git cherry-pick <sha>` or `git show <sha>:<path>`.
 - Because the source package is identical (§0), cherry-picks apply with no path/package fixups — only the §2 branding edits and any §4 model regeneration remain.
+- **Remove the remote once done.** A remote added solely to cherry-pick for a port is scratch, not durable repo config — once the port is complete (committed/PR proposed), `git remote remove <source>`. Exception: if another port from the same source is already queued in the same session, leave it until the last queued port from that source completes, then remove it.
 
 ## 4. Data-model / migration reconciliation (the only real gotcha)
 
@@ -86,6 +87,8 @@ If a port has no schema change, this section is a no-op — skip it entirely.
 ## 6. Per-feature port checklists
 
 This methodology is the reusable harness. Each concrete port gets a short checklist (e.g. `docs/porting/<feature>-port.md`) listing that feature's commits, files, and the specific §2 branding values used — finalized against the shipped source code. Seed it from any inline "keep repo-agnostic / flag divergence" notes the source author left.
+
+**Once a port is complete, the checklist doc must exist in BOTH repos** — same rule as this methodology doc (see the note at the top of this file). Copy the finalized checklist into the other repo's `docs/porting/` alongside it. It's fine to leave that copy uncommitted if the other repo has its own pending doc cleanup in flight — just don't skip the copy.
 
 ## 7. Start-of-port checklist (most boxes are pre-answered by §0–§1)
 


### PR DESCRIPTION
## Summary
- Add shared `dismissSheet(sheetState)` helper so button/programmatic sheet closes animate out like a swipe/scrim dismiss instead of vanishing instantly.
- Route Select Font (Done), Collection editor (Cancel/Save/Delete), Filter (Search incl. IME action/Reset), and Label picker (Done, label taps) through it.
- Drop the label picker's back arrow to match the other modal sheets.
- Ported from Readeck for Android (`0000e13`) on Codeberg; see docs/porting/bottom-sheet-consistency-port.md.

## Test plan
- [x] ./gradlew :app:assembleDebugAll :app:testDebugUnitTestAll :app:lintDebugAll
- [x] Verified on-device: each sheet slides closed, label picker has no back arrow