### PR TITLE
feat: What's New Page and Release History

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The app's icon is now sent as `logo_uri` during OAuth client registration, so the Readeck authorization page can display it in the Application information section.
 - **Sign in with a code instead** fallback: users who cannot use the browser flow (e.g. on constrained devices) can still sign in via the existing OAuth Device Code flow by tapping the new secondary action on the sign-in screen.
 - The sign-in flow now survives process death while the browser is open — if Android reclaims the app, returning from the browser resumes where it left off.
+- **What's New**: after updating, a short sheet highlights what changed in the new version. First-time installs don't see it — instead they get a one-time, dismissible nudge to check out the User Guide. Past releases' notes are reachable any time from **About → What's New**.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The app's icon is now sent as `logo_uri` during OAuth client registration, so the Readeck authorization page can display it in the Application information section.
 - **Sign in with a code instead** fallback: users who cannot use the browser flow (e.g. on constrained devices) can still sign in via the existing OAuth Device Code flow by tapping the new secondary action on the sign-in screen.
 - The sign-in flow now survives process death while the browser is open — if Android reclaims the app, returning from the browser resumes where it left off.
-- **What's New**: after updating, a short sheet highlights what changed in the new version. First-time installs don't see it — instead they get a one-time, dismissible nudge to check out the User Guide. Past releases' notes are reachable any time from **About → What's New**.
+- **What's New**: after updating, a short sheet highlights what changed in the new version. First-time installs don't see it — instead they get a one-time, dismissible nudge to check out the User Guide. **About → What's New** lists every past release's notes, newest first.
 
 ### Changed
 

--- a/app/src/main/assets/guide/en/settings.md
+++ b/app/src/main/assets/guide/en/settings.md
@@ -106,4 +106,4 @@ The **Logs** screen shows the app's log output, which can be useful for troubles
 
 ---
 
-The navigation drawer also has an **About** entry, which shows the current app version, build details, and links to the MyDeck and Readeck project pages.
+The navigation drawer also has an **About** entry, which shows the current app version, build details, and links to the MyDeck and Readeck project pages. After an update, a **What's New** sheet highlights what changed in the new version; you can reopen it any time from **About → What's New**.

--- a/app/src/main/assets/whatsnew/de/0.10.0.md
+++ b/app/src/main/assets/whatsnew/de/0.10.0.md
@@ -1,0 +1,10 @@
+---
+date: 2026-02-26
+---
+# What's New in 0.10.0
+
+**Refined sign-in screen:** Cleaner branding and layout on the sign-in and authorization screens.
+
+**Simpler account settings:** Account settings now show the server's base URL instead of the full API path.
+
+**Better filtering:** Improved keyboard actions and preset reset handling in the filter UI.

--- a/app/src/main/assets/whatsnew/de/0.11.0.md
+++ b/app/src/main/assets/whatsnew/de/0.11.0.md
@@ -1,0 +1,18 @@
+---
+date: 2026-03-14
+---
+# What's New in 0.11.0
+
+**Image gallery:** Tap any article image to open a full-screen gallery with swipe navigation, pinch-to-zoom, double-tap to zoom, and a thumbnail strip.
+
+**Highlights and annotations:** View, create, and edit Readeck highlights directly in the reading view.
+
+**Reader appearance settings:** Curated themes, font size, line spacing, content width, and a fullscreen reading mode that hides the top bar until you swipe up.
+
+**Long-press menus:** Quick actions for images and links, in both the reader and the bookmark list.
+
+**Keep screen on:** A new toggle to stop the screen dimming while you read, plus an About screen showing app and server info in collapsible cards.
+
+**More for media bookmarks:** Typography and Find in Page now work for Video and Picture bookmarks too.
+
+**Reorganized reading actions:** Favorite and Archive moved to the overflow menu and inline buttons at the end of the article, and deleted bookmarks are detected immediately on pull-to-refresh.

--- a/app/src/main/assets/whatsnew/de/0.11.1.md
+++ b/app/src/main/assets/whatsnew/de/0.11.1.md
@@ -1,0 +1,10 @@
+---
+date: 2026-03-19
+---
+# What's New in 0.11.1
+
+**Smarter filter chips:** Dismissing a suggested chip now restores the preset default instead of clearing everything.
+
+**Faster app open:** Cached bookmarks show immediately on open instead of a blocking spinner while syncing in the background.
+
+**Fixes:** Corrected the "With errors" filter after a refresh, a text-size jump when switching reader width, missing "Copy to clipboard" translations, and a rare race condition on rapid successive deletes.

--- a/app/src/main/assets/whatsnew/de/0.12.0.md
+++ b/app/src/main/assets/whatsnew/de/0.12.0.md
@@ -1,0 +1,14 @@
+---
+date: 2026-04-11
+---
+# What's New in 0.12.0
+
+**In-article anchor links:** Table-of-contents and fragment links now navigate correctly within articles, with a long-press menu to open or copy the target.
+
+**Download status at a glance:** A content download-status icon now appears on reading-view bookmark cards, plus a reading-progress icon in Compact view.
+
+**Sync overhauled:** More reliable multipart sync for bookmark and content updates, plus new automatic offline-content sync policies based on volume, item count, or date range.
+
+**HTTP servers supported:** Server URLs can now use http:// for self-hosted or local setups, not just https://.
+
+**Reflow fix:** Corrected a bug where article text could disappear after a layout or font change.

--- a/app/src/main/assets/whatsnew/de/0.12.6.md
+++ b/app/src/main/assets/whatsnew/de/0.12.6.md
@@ -1,0 +1,6 @@
+---
+date: 2026-05-05
+---
+# What's New in 0.12.6
+
+**Crash fix:** Resolved an out-of-memory crash that could occur during offline content synchronization.

--- a/app/src/main/assets/whatsnew/de/0.13.0.md
+++ b/app/src/main/assets/whatsnew/de/0.13.0.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-18
+---
+# What's New in 0.13.0
+
+**Highlights:** Select and save text highlights while reading an article, with support for adding notes to each one.
+
+**Highlights list:** Browse, search, filter, and sort every highlight across all your bookmarks from the navigation drawer.
+
+**Swipe actions:** Swipe a bookmark card for quick favorite, archive, and delete.
+
+**Smoother reading:** More reliable article scrolling, a fix for a crash on Android 14+ devices, and improved sync resilience.

--- a/app/src/main/assets/whatsnew/de/0.13.1.md
+++ b/app/src/main/assets/whatsnew/de/0.13.1.md
@@ -1,0 +1,8 @@
+---
+date: 2026-05-20
+---
+# What's New in 0.13.1
+
+**Critical fix:** Editing a bookmark's labels no longer wipes its title, site name, and description.
+
+**Steadier sync:** Sync progress now shows a predictable indicator while your bookmarks first load.

--- a/app/src/main/assets/whatsnew/de/0.13.2.md
+++ b/app/src/main/assets/whatsnew/de/0.13.2.md
@@ -1,0 +1,8 @@
+---
+date: 2026-05-29
+---
+# What's New in 0.13.2
+
+**Reading time filters:** Filter your list by estimated reading time or word count, including a Min/Max range and an option to include bookmarks with no estimate.
+
+**Fresh-content fix:** The reader no longer briefly shows stale content for a bookmark opened right after adding it, before server-side extraction finishes.

--- a/app/src/main/assets/whatsnew/de/0.14.0.md
+++ b/app/src/main/assets/whatsnew/de/0.14.0.md
@@ -1,0 +1,12 @@
+---
+date: 2026-06-04
+---
+# What's New in 0.14.0
+
+**Multi-select:** Long-press a bookmark card to select multiple bookmarks, then favorite, archive, delete, or label them all at once.
+
+**Overflow menu:** The top app bar gains an overflow menu with more bookmark-list actions.
+
+**Native reader bar:** The reader's action bar is now a native control for smoother, more consistent interactions.
+
+**HTTPS-only releases:** Standard release builds now require HTTPS server connections.

--- a/app/src/main/assets/whatsnew/de/0.14.1.md
+++ b/app/src/main/assets/whatsnew/de/0.14.1.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-08
+---
+# What's New in 0.14.1
+
+**About screen polish:** Refined the About screen's copy, project links, and license and attribution wording.

--- a/app/src/main/assets/whatsnew/de/0.14.2.md
+++ b/app/src/main/assets/whatsnew/de/0.14.2.md
@@ -1,0 +1,12 @@
+---
+date: 2026-06-19
+---
+# What's New in 0.14.2
+
+**Offline pinning:** Pin articles to keep them available offline and protected from automatic cleanup, from bookmark multi-select or the reader's overflow menu.
+
+**Reliable downloads:** Offline downloads reworked so text and images download together and completely, instead of sometimes getting stuck as text-only.
+
+**Storage breakdown:** Settings now shows your current on-device offline storage, split into automatic and pinned content.
+
+**Sync fixes:** Resolved dropped syncs and stuck downloads on flaky networks, "Clear All Offline Content" missing some content, and duplicate bookmarks when saving over a bad connection.

--- a/app/src/main/assets/whatsnew/de/0.14.3.md
+++ b/app/src/main/assets/whatsnew/de/0.14.3.md
@@ -1,0 +1,14 @@
+---
+date: 2026-06-27
+---
+# What's New in 0.14.3
+
+**Reorganized settings:** User Interface Settings are now grouped into clear sections: Appearance, Bookmark List, Reading, and Sharing.
+
+**Internal browser toggle:** Choose whether a bookmark's original page opens in the in-app viewer or your device's browser.
+
+**Label search options:** Match the start of a label or anywhere within it, and sort labels alphabetically or by most used.
+
+**Error badges:** A new "With errors" filter finds bookmarks whose content couldn't be extracted, plus card badges mark extraction errors or missing content.
+
+**List tweaks:** Show or hide the add-bookmark button and the Compact layout's website source icons.

--- a/app/src/main/assets/whatsnew/de/0.14.4.md
+++ b/app/src/main/assets/whatsnew/de/0.14.4.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-29
+---
+# What's New in 0.14.4
+
+**Sign-in fix:** Corrected sign-in against newer Readeck nightly server builds.

--- a/app/src/main/assets/whatsnew/de/0.14.5.md
+++ b/app/src/main/assets/whatsnew/de/0.14.5.md
@@ -1,0 +1,12 @@
+---
+date: 2026-07-03
+---
+# What's New in 0.14.5
+
+**Collections:** Save a set of filter criteria (search, labels, type, date range, and more) as a named, reusable view. Create one from the new Collections screen or "Save as Collection" on any list, layer extra filters on top without changing the saved collection, and rename, edit, or delete it anytime.
+
+**Welcome screen quick access:** Reach About, the User Guide, and Logs before you've even connected to a server.
+
+**User Guide search:** Look up a feature by name and jump straight to it; the guide also gains dedicated pages for Labels, Highlights, Collections, and Offline Reading.
+
+**Clearer sign-in errors:** Better messages when a Readeck server is too old or isn't a Readeck server at all.

--- a/app/src/main/assets/whatsnew/de/0.9.0.md
+++ b/app/src/main/assets/whatsnew/de/0.9.0.md
@@ -1,0 +1,24 @@
+---
+date: 2026-02-20
+---
+# What's New in 0.9.0
+
+Welcome to MyDeck. This first release is a comprehensive rebrand and major feature expansion.
+
+**Sign in with a code:** OAuth Device Code authentication. Get a URL and one-time code, authorize in your browser, and the app picks up automatically.
+
+**Redesigned navigation:** A Pocket-style sidebar with My List, Archive, and Favorites, plus item-count badges throughout.
+
+**Three list layouts:** Choose between Grid, Compact, and Mosaic views.
+
+**Reading progress tracking:** See progress at a glance on every card, and pick up right where you left off.
+
+**Labels:** Full label management, one-tap label filtering from bookmark cards, and a dedicated Labels view.
+
+**Article and Original views:** Toggle between Readeck's extracted article content and the original web page.
+
+**Search and typography:** Global search across titles, site names, and labels, plus reading customization (font, size, spacing, width, justification, hyphenation) with in-article Find.
+
+**Works offline:** Actions taken without a connection are queued and applied once you're back online.
+
+**Adaptive layouts:** Tablet and landscape support, and a full visual refresh under Material Design 3.

--- a/app/src/main/assets/whatsnew/de/0.9.1.md
+++ b/app/src/main/assets/whatsnew/de/0.9.1.md
@@ -1,0 +1,6 @@
+---
+date: 2026-02-21
+---
+# What's New in 0.9.1
+
+**Read state fix:** Corrected the read/unread icon and label not always matching in the reading view's overflow menu.

--- a/app/src/main/assets/whatsnew/de/0.9.2.md
+++ b/app/src/main/assets/whatsnew/de/0.9.2.md
@@ -1,0 +1,8 @@
+---
+date: 2026-02-22
+---
+# What's New in 0.9.2
+
+**Redesigned mobile grid:** Fixed-height cards with a left thumbnail and right content split, and a larger title.
+
+**Fixes:** Resolved a brief blank-state flash on cold start, TopBar jitter during overscroll, and label chips not dismissing pending delete actions before navigating away.

--- a/app/src/main/assets/whatsnew/en/0.10.0.md
+++ b/app/src/main/assets/whatsnew/en/0.10.0.md
@@ -1,0 +1,10 @@
+---
+date: 2026-02-26
+---
+# What's New in 0.10.0
+
+**Refined sign-in screen:** Cleaner branding and layout on the sign-in and authorization screens.
+
+**Simpler account settings:** Account settings now show the server's base URL instead of the full API path.
+
+**Better filtering:** Improved keyboard actions and preset reset handling in the filter UI.

--- a/app/src/main/assets/whatsnew/en/0.11.0.md
+++ b/app/src/main/assets/whatsnew/en/0.11.0.md
@@ -1,0 +1,18 @@
+---
+date: 2026-03-14
+---
+# What's New in 0.11.0
+
+**Image gallery:** Tap any article image to open a full-screen gallery with swipe navigation, pinch-to-zoom, double-tap to zoom, and a thumbnail strip.
+
+**Highlights and annotations:** View, create, and edit Readeck highlights directly in the reading view.
+
+**Reader appearance settings:** Curated themes, font size, line spacing, content width, and a fullscreen reading mode that hides the top bar until you swipe up.
+
+**Long-press menus:** Quick actions for images and links, in both the reader and the bookmark list.
+
+**Keep screen on:** A new toggle to stop the screen dimming while you read, plus an About screen showing app and server info in collapsible cards.
+
+**More for media bookmarks:** Typography and Find in Page now work for Video and Picture bookmarks too.
+
+**Reorganized reading actions:** Favorite and Archive moved to the overflow menu and inline buttons at the end of the article, and deleted bookmarks are detected immediately on pull-to-refresh.

--- a/app/src/main/assets/whatsnew/en/0.11.1.md
+++ b/app/src/main/assets/whatsnew/en/0.11.1.md
@@ -1,0 +1,10 @@
+---
+date: 2026-03-19
+---
+# What's New in 0.11.1
+
+**Smarter filter chips:** Dismissing a suggested chip now restores the preset default instead of clearing everything.
+
+**Faster app open:** Cached bookmarks show immediately on open instead of a blocking spinner while syncing in the background.
+
+**Fixes:** Corrected the "With errors" filter after a refresh, a text-size jump when switching reader width, missing "Copy to clipboard" translations, and a rare race condition on rapid successive deletes.

--- a/app/src/main/assets/whatsnew/en/0.12.0.md
+++ b/app/src/main/assets/whatsnew/en/0.12.0.md
@@ -1,0 +1,14 @@
+---
+date: 2026-04-11
+---
+# What's New in 0.12.0
+
+**In-article anchor links:** Table-of-contents and fragment links now navigate correctly within articles, with a long-press menu to open or copy the target.
+
+**Download status at a glance:** A content download-status icon now appears on reading-view bookmark cards, plus a reading-progress icon in Compact view.
+
+**Sync overhauled:** More reliable multipart sync for bookmark and content updates, plus new automatic offline-content sync policies based on volume, item count, or date range.
+
+**HTTP servers supported:** Server URLs can now use http:// for self-hosted or local setups, not just https://.
+
+**Reflow fix:** Corrected a bug where article text could disappear after a layout or font change.

--- a/app/src/main/assets/whatsnew/en/0.12.6.md
+++ b/app/src/main/assets/whatsnew/en/0.12.6.md
@@ -1,0 +1,6 @@
+---
+date: 2026-05-05
+---
+# What's New in 0.12.6
+
+**Crash fix:** Resolved an out-of-memory crash that could occur during offline content synchronization.

--- a/app/src/main/assets/whatsnew/en/0.13.0.md
+++ b/app/src/main/assets/whatsnew/en/0.13.0.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-18
+---
+# What's New in 0.13.0
+
+**Highlights:** Select and save text highlights while reading an article, with support for adding notes to each one.
+
+**Highlights list:** Browse, search, filter, and sort every highlight across all your bookmarks from the navigation drawer.
+
+**Swipe actions:** Swipe a bookmark card for quick favorite, archive, and delete.
+
+**Smoother reading:** More reliable article scrolling, a fix for a crash on Android 14+ devices, and improved sync resilience.

--- a/app/src/main/assets/whatsnew/en/0.13.1.md
+++ b/app/src/main/assets/whatsnew/en/0.13.1.md
@@ -1,0 +1,8 @@
+---
+date: 2026-05-20
+---
+# What's New in 0.13.1
+
+**Critical fix:** Editing a bookmark's labels no longer wipes its title, site name, and description.
+
+**Steadier sync:** Sync progress now shows a predictable indicator while your bookmarks first load.

--- a/app/src/main/assets/whatsnew/en/0.13.2.md
+++ b/app/src/main/assets/whatsnew/en/0.13.2.md
@@ -1,0 +1,8 @@
+---
+date: 2026-05-29
+---
+# What's New in 0.13.2
+
+**Reading time filters:** Filter your list by estimated reading time or word count, including a Min/Max range and an option to include bookmarks with no estimate.
+
+**Fresh-content fix:** The reader no longer briefly shows stale content for a bookmark opened right after adding it, before server-side extraction finishes.

--- a/app/src/main/assets/whatsnew/en/0.14.0.md
+++ b/app/src/main/assets/whatsnew/en/0.14.0.md
@@ -1,0 +1,12 @@
+---
+date: 2026-06-04
+---
+# What's New in 0.14.0
+
+**Multi-select:** Long-press a bookmark card to select multiple bookmarks, then favorite, archive, delete, or label them all at once.
+
+**Overflow menu:** The top app bar gains an overflow menu with more bookmark-list actions.
+
+**Native reader bar:** The reader's action bar is now a native control for smoother, more consistent interactions.
+
+**HTTPS-only releases:** Standard release builds now require HTTPS server connections.

--- a/app/src/main/assets/whatsnew/en/0.14.1.md
+++ b/app/src/main/assets/whatsnew/en/0.14.1.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-08
+---
+# What's New in 0.14.1
+
+**About screen polish:** Refined the About screen's copy, project links, and license and attribution wording.

--- a/app/src/main/assets/whatsnew/en/0.14.2.md
+++ b/app/src/main/assets/whatsnew/en/0.14.2.md
@@ -1,0 +1,12 @@
+---
+date: 2026-06-19
+---
+# What's New in 0.14.2
+
+**Offline pinning:** Pin articles to keep them available offline and protected from automatic cleanup, from bookmark multi-select or the reader's overflow menu.
+
+**Reliable downloads:** Offline downloads reworked so text and images download together and completely, instead of sometimes getting stuck as text-only.
+
+**Storage breakdown:** Settings now shows your current on-device offline storage, split into automatic and pinned content.
+
+**Sync fixes:** Resolved dropped syncs and stuck downloads on flaky networks, "Clear All Offline Content" missing some content, and duplicate bookmarks when saving over a bad connection.

--- a/app/src/main/assets/whatsnew/en/0.14.3.md
+++ b/app/src/main/assets/whatsnew/en/0.14.3.md
@@ -1,0 +1,14 @@
+---
+date: 2026-06-27
+---
+# What's New in 0.14.3
+
+**Reorganized settings:** User Interface Settings are now grouped into clear sections: Appearance, Bookmark List, Reading, and Sharing.
+
+**Internal browser toggle:** Choose whether a bookmark's original page opens in the in-app viewer or your device's browser.
+
+**Label search options:** Match the start of a label or anywhere within it, and sort labels alphabetically or by most used.
+
+**Error badges:** A new "With errors" filter finds bookmarks whose content couldn't be extracted, plus card badges mark extraction errors or missing content.
+
+**List tweaks:** Show or hide the add-bookmark button and the Compact layout's website source icons.

--- a/app/src/main/assets/whatsnew/en/0.14.4.md
+++ b/app/src/main/assets/whatsnew/en/0.14.4.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-29
+---
+# What's New in 0.14.4
+
+**Sign-in fix:** Corrected sign-in against newer Readeck nightly server builds.

--- a/app/src/main/assets/whatsnew/en/0.14.5.md
+++ b/app/src/main/assets/whatsnew/en/0.14.5.md
@@ -1,0 +1,12 @@
+---
+date: 2026-07-03
+---
+# What's New in 0.14.5
+
+**Collections:** Save a set of filter criteria (search, labels, type, date range, and more) as a named, reusable view. Create one from the new Collections screen or "Save as Collection" on any list, layer extra filters on top without changing the saved collection, and rename, edit, or delete it anytime.
+
+**Welcome screen quick access:** Reach About, the User Guide, and Logs before you've even connected to a server.
+
+**User Guide search:** Look up a feature by name and jump straight to it; the guide also gains dedicated pages for Labels, Highlights, Collections, and Offline Reading.
+
+**Clearer sign-in errors:** Better messages when a Readeck server is too old or isn't a Readeck server at all.

--- a/app/src/main/assets/whatsnew/en/0.9.0.md
+++ b/app/src/main/assets/whatsnew/en/0.9.0.md
@@ -1,0 +1,24 @@
+---
+date: 2026-02-20
+---
+# What's New in 0.9.0
+
+Welcome to MyDeck. This first release is a comprehensive rebrand and major feature expansion.
+
+**Sign in with a code:** OAuth Device Code authentication. Get a URL and one-time code, authorize in your browser, and the app picks up automatically.
+
+**Redesigned navigation:** A Pocket-style sidebar with My List, Archive, and Favorites, plus item-count badges throughout.
+
+**Three list layouts:** Choose between Grid, Compact, and Mosaic views.
+
+**Reading progress tracking:** See progress at a glance on every card, and pick up right where you left off.
+
+**Labels:** Full label management, one-tap label filtering from bookmark cards, and a dedicated Labels view.
+
+**Article and Original views:** Toggle between Readeck's extracted article content and the original web page.
+
+**Search and typography:** Global search across titles, site names, and labels, plus reading customization (font, size, spacing, width, justification, hyphenation) with in-article Find.
+
+**Works offline:** Actions taken without a connection are queued and applied once you're back online.
+
+**Adaptive layouts:** Tablet and landscape support, and a full visual refresh under Material Design 3.

--- a/app/src/main/assets/whatsnew/en/0.9.1.md
+++ b/app/src/main/assets/whatsnew/en/0.9.1.md
@@ -1,0 +1,6 @@
+---
+date: 2026-02-21
+---
+# What's New in 0.9.1
+
+**Read state fix:** Corrected the read/unread icon and label not always matching in the reading view's overflow menu.

--- a/app/src/main/assets/whatsnew/en/0.9.2.md
+++ b/app/src/main/assets/whatsnew/en/0.9.2.md
@@ -1,0 +1,8 @@
+---
+date: 2026-02-22
+---
+# What's New in 0.9.2
+
+**Redesigned mobile grid:** Fixed-height cards with a left thumbnail and right content split, and a larger title.
+
+**Fixes:** Resolved a brief blank-state flash on cold start, TopBar jitter during overscroll, and label chips not dismissing pending delete actions before navigating away.

--- a/app/src/main/assets/whatsnew/es/0.10.0.md
+++ b/app/src/main/assets/whatsnew/es/0.10.0.md
@@ -1,0 +1,10 @@
+---
+date: 2026-02-26
+---
+# What's New in 0.10.0
+
+**Refined sign-in screen:** Cleaner branding and layout on the sign-in and authorization screens.
+
+**Simpler account settings:** Account settings now show the server's base URL instead of the full API path.
+
+**Better filtering:** Improved keyboard actions and preset reset handling in the filter UI.

--- a/app/src/main/assets/whatsnew/es/0.11.0.md
+++ b/app/src/main/assets/whatsnew/es/0.11.0.md
@@ -1,0 +1,18 @@
+---
+date: 2026-03-14
+---
+# What's New in 0.11.0
+
+**Image gallery:** Tap any article image to open a full-screen gallery with swipe navigation, pinch-to-zoom, double-tap to zoom, and a thumbnail strip.
+
+**Highlights and annotations:** View, create, and edit Readeck highlights directly in the reading view.
+
+**Reader appearance settings:** Curated themes, font size, line spacing, content width, and a fullscreen reading mode that hides the top bar until you swipe up.
+
+**Long-press menus:** Quick actions for images and links, in both the reader and the bookmark list.
+
+**Keep screen on:** A new toggle to stop the screen dimming while you read, plus an About screen showing app and server info in collapsible cards.
+
+**More for media bookmarks:** Typography and Find in Page now work for Video and Picture bookmarks too.
+
+**Reorganized reading actions:** Favorite and Archive moved to the overflow menu and inline buttons at the end of the article, and deleted bookmarks are detected immediately on pull-to-refresh.

--- a/app/src/main/assets/whatsnew/es/0.11.1.md
+++ b/app/src/main/assets/whatsnew/es/0.11.1.md
@@ -1,0 +1,10 @@
+---
+date: 2026-03-19
+---
+# What's New in 0.11.1
+
+**Smarter filter chips:** Dismissing a suggested chip now restores the preset default instead of clearing everything.
+
+**Faster app open:** Cached bookmarks show immediately on open instead of a blocking spinner while syncing in the background.
+
+**Fixes:** Corrected the "With errors" filter after a refresh, a text-size jump when switching reader width, missing "Copy to clipboard" translations, and a rare race condition on rapid successive deletes.

--- a/app/src/main/assets/whatsnew/es/0.12.0.md
+++ b/app/src/main/assets/whatsnew/es/0.12.0.md
@@ -1,0 +1,14 @@
+---
+date: 2026-04-11
+---
+# What's New in 0.12.0
+
+**In-article anchor links:** Table-of-contents and fragment links now navigate correctly within articles, with a long-press menu to open or copy the target.
+
+**Download status at a glance:** A content download-status icon now appears on reading-view bookmark cards, plus a reading-progress icon in Compact view.
+
+**Sync overhauled:** More reliable multipart sync for bookmark and content updates, plus new automatic offline-content sync policies based on volume, item count, or date range.
+
+**HTTP servers supported:** Server URLs can now use http:// for self-hosted or local setups, not just https://.
+
+**Reflow fix:** Corrected a bug where article text could disappear after a layout or font change.

--- a/app/src/main/assets/whatsnew/es/0.12.6.md
+++ b/app/src/main/assets/whatsnew/es/0.12.6.md
@@ -1,0 +1,6 @@
+---
+date: 2026-05-05
+---
+# What's New in 0.12.6
+
+**Crash fix:** Resolved an out-of-memory crash that could occur during offline content synchronization.

--- a/app/src/main/assets/whatsnew/es/0.13.0.md
+++ b/app/src/main/assets/whatsnew/es/0.13.0.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-18
+---
+# What's New in 0.13.0
+
+**Highlights:** Select and save text highlights while reading an article, with support for adding notes to each one.
+
+**Highlights list:** Browse, search, filter, and sort every highlight across all your bookmarks from the navigation drawer.
+
+**Swipe actions:** Swipe a bookmark card for quick favorite, archive, and delete.
+
+**Smoother reading:** More reliable article scrolling, a fix for a crash on Android 14+ devices, and improved sync resilience.

--- a/app/src/main/assets/whatsnew/es/0.13.1.md
+++ b/app/src/main/assets/whatsnew/es/0.13.1.md
@@ -1,0 +1,8 @@
+---
+date: 2026-05-20
+---
+# What's New in 0.13.1
+
+**Critical fix:** Editing a bookmark's labels no longer wipes its title, site name, and description.
+
+**Steadier sync:** Sync progress now shows a predictable indicator while your bookmarks first load.

--- a/app/src/main/assets/whatsnew/es/0.13.2.md
+++ b/app/src/main/assets/whatsnew/es/0.13.2.md
@@ -1,0 +1,8 @@
+---
+date: 2026-05-29
+---
+# What's New in 0.13.2
+
+**Reading time filters:** Filter your list by estimated reading time or word count, including a Min/Max range and an option to include bookmarks with no estimate.
+
+**Fresh-content fix:** The reader no longer briefly shows stale content for a bookmark opened right after adding it, before server-side extraction finishes.

--- a/app/src/main/assets/whatsnew/es/0.14.0.md
+++ b/app/src/main/assets/whatsnew/es/0.14.0.md
@@ -1,0 +1,12 @@
+---
+date: 2026-06-04
+---
+# What's New in 0.14.0
+
+**Multi-select:** Long-press a bookmark card to select multiple bookmarks, then favorite, archive, delete, or label them all at once.
+
+**Overflow menu:** The top app bar gains an overflow menu with more bookmark-list actions.
+
+**Native reader bar:** The reader's action bar is now a native control for smoother, more consistent interactions.
+
+**HTTPS-only releases:** Standard release builds now require HTTPS server connections.

--- a/app/src/main/assets/whatsnew/es/0.14.1.md
+++ b/app/src/main/assets/whatsnew/es/0.14.1.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-08
+---
+# What's New in 0.14.1
+
+**About screen polish:** Refined the About screen's copy, project links, and license and attribution wording.

--- a/app/src/main/assets/whatsnew/es/0.14.2.md
+++ b/app/src/main/assets/whatsnew/es/0.14.2.md
@@ -1,0 +1,12 @@
+---
+date: 2026-06-19
+---
+# What's New in 0.14.2
+
+**Offline pinning:** Pin articles to keep them available offline and protected from automatic cleanup, from bookmark multi-select or the reader's overflow menu.
+
+**Reliable downloads:** Offline downloads reworked so text and images download together and completely, instead of sometimes getting stuck as text-only.
+
+**Storage breakdown:** Settings now shows your current on-device offline storage, split into automatic and pinned content.
+
+**Sync fixes:** Resolved dropped syncs and stuck downloads on flaky networks, "Clear All Offline Content" missing some content, and duplicate bookmarks when saving over a bad connection.

--- a/app/src/main/assets/whatsnew/es/0.14.3.md
+++ b/app/src/main/assets/whatsnew/es/0.14.3.md
@@ -1,0 +1,14 @@
+---
+date: 2026-06-27
+---
+# What's New in 0.14.3
+
+**Reorganized settings:** User Interface Settings are now grouped into clear sections: Appearance, Bookmark List, Reading, and Sharing.
+
+**Internal browser toggle:** Choose whether a bookmark's original page opens in the in-app viewer or your device's browser.
+
+**Label search options:** Match the start of a label or anywhere within it, and sort labels alphabetically or by most used.
+
+**Error badges:** A new "With errors" filter finds bookmarks whose content couldn't be extracted, plus card badges mark extraction errors or missing content.
+
+**List tweaks:** Show or hide the add-bookmark button and the Compact layout's website source icons.

--- a/app/src/main/assets/whatsnew/es/0.14.4.md
+++ b/app/src/main/assets/whatsnew/es/0.14.4.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-29
+---
+# What's New in 0.14.4
+
+**Sign-in fix:** Corrected sign-in against newer Readeck nightly server builds.

--- a/app/src/main/assets/whatsnew/es/0.14.5.md
+++ b/app/src/main/assets/whatsnew/es/0.14.5.md
@@ -1,0 +1,12 @@
+---
+date: 2026-07-03
+---
+# What's New in 0.14.5
+
+**Collections:** Save a set of filter criteria (search, labels, type, date range, and more) as a named, reusable view. Create one from the new Collections screen or "Save as Collection" on any list, layer extra filters on top without changing the saved collection, and rename, edit, or delete it anytime.
+
+**Welcome screen quick access:** Reach About, the User Guide, and Logs before you've even connected to a server.
+
+**User Guide search:** Look up a feature by name and jump straight to it; the guide also gains dedicated pages for Labels, Highlights, Collections, and Offline Reading.
+
+**Clearer sign-in errors:** Better messages when a Readeck server is too old or isn't a Readeck server at all.

--- a/app/src/main/assets/whatsnew/es/0.9.0.md
+++ b/app/src/main/assets/whatsnew/es/0.9.0.md
@@ -1,0 +1,24 @@
+---
+date: 2026-02-20
+---
+# What's New in 0.9.0
+
+Welcome to MyDeck. This first release is a comprehensive rebrand and major feature expansion.
+
+**Sign in with a code:** OAuth Device Code authentication. Get a URL and one-time code, authorize in your browser, and the app picks up automatically.
+
+**Redesigned navigation:** A Pocket-style sidebar with My List, Archive, and Favorites, plus item-count badges throughout.
+
+**Three list layouts:** Choose between Grid, Compact, and Mosaic views.
+
+**Reading progress tracking:** See progress at a glance on every card, and pick up right where you left off.
+
+**Labels:** Full label management, one-tap label filtering from bookmark cards, and a dedicated Labels view.
+
+**Article and Original views:** Toggle between Readeck's extracted article content and the original web page.
+
+**Search and typography:** Global search across titles, site names, and labels, plus reading customization (font, size, spacing, width, justification, hyphenation) with in-article Find.
+
+**Works offline:** Actions taken without a connection are queued and applied once you're back online.
+
+**Adaptive layouts:** Tablet and landscape support, and a full visual refresh under Material Design 3.

--- a/app/src/main/assets/whatsnew/es/0.9.1.md
+++ b/app/src/main/assets/whatsnew/es/0.9.1.md
@@ -1,0 +1,6 @@
+---
+date: 2026-02-21
+---
+# What's New in 0.9.1
+
+**Read state fix:** Corrected the read/unread icon and label not always matching in the reading view's overflow menu.

--- a/app/src/main/assets/whatsnew/es/0.9.2.md
+++ b/app/src/main/assets/whatsnew/es/0.9.2.md
@@ -1,0 +1,8 @@
+---
+date: 2026-02-22
+---
+# What's New in 0.9.2
+
+**Redesigned mobile grid:** Fixed-height cards with a left thumbnail and right content split, and a larger title.
+
+**Fixes:** Resolved a brief blank-state flash on cold start, TopBar jitter during overscroll, and label chips not dismissing pending delete actions before navigating away.

--- a/app/src/main/assets/whatsnew/fr/0.10.0.md
+++ b/app/src/main/assets/whatsnew/fr/0.10.0.md
@@ -1,0 +1,10 @@
+---
+date: 2026-02-26
+---
+# What's New in 0.10.0
+
+**Refined sign-in screen:** Cleaner branding and layout on the sign-in and authorization screens.
+
+**Simpler account settings:** Account settings now show the server's base URL instead of the full API path.
+
+**Better filtering:** Improved keyboard actions and preset reset handling in the filter UI.

--- a/app/src/main/assets/whatsnew/fr/0.11.0.md
+++ b/app/src/main/assets/whatsnew/fr/0.11.0.md
@@ -1,0 +1,18 @@
+---
+date: 2026-03-14
+---
+# What's New in 0.11.0
+
+**Image gallery:** Tap any article image to open a full-screen gallery with swipe navigation, pinch-to-zoom, double-tap to zoom, and a thumbnail strip.
+
+**Highlights and annotations:** View, create, and edit Readeck highlights directly in the reading view.
+
+**Reader appearance settings:** Curated themes, font size, line spacing, content width, and a fullscreen reading mode that hides the top bar until you swipe up.
+
+**Long-press menus:** Quick actions for images and links, in both the reader and the bookmark list.
+
+**Keep screen on:** A new toggle to stop the screen dimming while you read, plus an About screen showing app and server info in collapsible cards.
+
+**More for media bookmarks:** Typography and Find in Page now work for Video and Picture bookmarks too.
+
+**Reorganized reading actions:** Favorite and Archive moved to the overflow menu and inline buttons at the end of the article, and deleted bookmarks are detected immediately on pull-to-refresh.

--- a/app/src/main/assets/whatsnew/fr/0.11.1.md
+++ b/app/src/main/assets/whatsnew/fr/0.11.1.md
@@ -1,0 +1,10 @@
+---
+date: 2026-03-19
+---
+# What's New in 0.11.1
+
+**Smarter filter chips:** Dismissing a suggested chip now restores the preset default instead of clearing everything.
+
+**Faster app open:** Cached bookmarks show immediately on open instead of a blocking spinner while syncing in the background.
+
+**Fixes:** Corrected the "With errors" filter after a refresh, a text-size jump when switching reader width, missing "Copy to clipboard" translations, and a rare race condition on rapid successive deletes.

--- a/app/src/main/assets/whatsnew/fr/0.12.0.md
+++ b/app/src/main/assets/whatsnew/fr/0.12.0.md
@@ -1,0 +1,14 @@
+---
+date: 2026-04-11
+---
+# What's New in 0.12.0
+
+**In-article anchor links:** Table-of-contents and fragment links now navigate correctly within articles, with a long-press menu to open or copy the target.
+
+**Download status at a glance:** A content download-status icon now appears on reading-view bookmark cards, plus a reading-progress icon in Compact view.
+
+**Sync overhauled:** More reliable multipart sync for bookmark and content updates, plus new automatic offline-content sync policies based on volume, item count, or date range.
+
+**HTTP servers supported:** Server URLs can now use http:// for self-hosted or local setups, not just https://.
+
+**Reflow fix:** Corrected a bug where article text could disappear after a layout or font change.

--- a/app/src/main/assets/whatsnew/fr/0.12.6.md
+++ b/app/src/main/assets/whatsnew/fr/0.12.6.md
@@ -1,0 +1,6 @@
+---
+date: 2026-05-05
+---
+# What's New in 0.12.6
+
+**Crash fix:** Resolved an out-of-memory crash that could occur during offline content synchronization.

--- a/app/src/main/assets/whatsnew/fr/0.13.0.md
+++ b/app/src/main/assets/whatsnew/fr/0.13.0.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-18
+---
+# What's New in 0.13.0
+
+**Highlights:** Select and save text highlights while reading an article, with support for adding notes to each one.
+
+**Highlights list:** Browse, search, filter, and sort every highlight across all your bookmarks from the navigation drawer.
+
+**Swipe actions:** Swipe a bookmark card for quick favorite, archive, and delete.
+
+**Smoother reading:** More reliable article scrolling, a fix for a crash on Android 14+ devices, and improved sync resilience.

--- a/app/src/main/assets/whatsnew/fr/0.13.1.md
+++ b/app/src/main/assets/whatsnew/fr/0.13.1.md
@@ -1,0 +1,8 @@
+---
+date: 2026-05-20
+---
+# What's New in 0.13.1
+
+**Critical fix:** Editing a bookmark's labels no longer wipes its title, site name, and description.
+
+**Steadier sync:** Sync progress now shows a predictable indicator while your bookmarks first load.

--- a/app/src/main/assets/whatsnew/fr/0.13.2.md
+++ b/app/src/main/assets/whatsnew/fr/0.13.2.md
@@ -1,0 +1,8 @@
+---
+date: 2026-05-29
+---
+# What's New in 0.13.2
+
+**Reading time filters:** Filter your list by estimated reading time or word count, including a Min/Max range and an option to include bookmarks with no estimate.
+
+**Fresh-content fix:** The reader no longer briefly shows stale content for a bookmark opened right after adding it, before server-side extraction finishes.

--- a/app/src/main/assets/whatsnew/fr/0.14.0.md
+++ b/app/src/main/assets/whatsnew/fr/0.14.0.md
@@ -1,0 +1,12 @@
+---
+date: 2026-06-04
+---
+# What's New in 0.14.0
+
+**Multi-select:** Long-press a bookmark card to select multiple bookmarks, then favorite, archive, delete, or label them all at once.
+
+**Overflow menu:** The top app bar gains an overflow menu with more bookmark-list actions.
+
+**Native reader bar:** The reader's action bar is now a native control for smoother, more consistent interactions.
+
+**HTTPS-only releases:** Standard release builds now require HTTPS server connections.

--- a/app/src/main/assets/whatsnew/fr/0.14.1.md
+++ b/app/src/main/assets/whatsnew/fr/0.14.1.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-08
+---
+# What's New in 0.14.1
+
+**About screen polish:** Refined the About screen's copy, project links, and license and attribution wording.

--- a/app/src/main/assets/whatsnew/fr/0.14.2.md
+++ b/app/src/main/assets/whatsnew/fr/0.14.2.md
@@ -1,0 +1,12 @@
+---
+date: 2026-06-19
+---
+# What's New in 0.14.2
+
+**Offline pinning:** Pin articles to keep them available offline and protected from automatic cleanup, from bookmark multi-select or the reader's overflow menu.
+
+**Reliable downloads:** Offline downloads reworked so text and images download together and completely, instead of sometimes getting stuck as text-only.
+
+**Storage breakdown:** Settings now shows your current on-device offline storage, split into automatic and pinned content.
+
+**Sync fixes:** Resolved dropped syncs and stuck downloads on flaky networks, "Clear All Offline Content" missing some content, and duplicate bookmarks when saving over a bad connection.

--- a/app/src/main/assets/whatsnew/fr/0.14.3.md
+++ b/app/src/main/assets/whatsnew/fr/0.14.3.md
@@ -1,0 +1,14 @@
+---
+date: 2026-06-27
+---
+# What's New in 0.14.3
+
+**Reorganized settings:** User Interface Settings are now grouped into clear sections: Appearance, Bookmark List, Reading, and Sharing.
+
+**Internal browser toggle:** Choose whether a bookmark's original page opens in the in-app viewer or your device's browser.
+
+**Label search options:** Match the start of a label or anywhere within it, and sort labels alphabetically or by most used.
+
+**Error badges:** A new "With errors" filter finds bookmarks whose content couldn't be extracted, plus card badges mark extraction errors or missing content.
+
+**List tweaks:** Show or hide the add-bookmark button and the Compact layout's website source icons.

--- a/app/src/main/assets/whatsnew/fr/0.14.4.md
+++ b/app/src/main/assets/whatsnew/fr/0.14.4.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-29
+---
+# What's New in 0.14.4
+
+**Sign-in fix:** Corrected sign-in against newer Readeck nightly server builds.

--- a/app/src/main/assets/whatsnew/fr/0.14.5.md
+++ b/app/src/main/assets/whatsnew/fr/0.14.5.md
@@ -1,0 +1,12 @@
+---
+date: 2026-07-03
+---
+# What's New in 0.14.5
+
+**Collections:** Save a set of filter criteria (search, labels, type, date range, and more) as a named, reusable view. Create one from the new Collections screen or "Save as Collection" on any list, layer extra filters on top without changing the saved collection, and rename, edit, or delete it anytime.
+
+**Welcome screen quick access:** Reach About, the User Guide, and Logs before you've even connected to a server.
+
+**User Guide search:** Look up a feature by name and jump straight to it; the guide also gains dedicated pages for Labels, Highlights, Collections, and Offline Reading.
+
+**Clearer sign-in errors:** Better messages when a Readeck server is too old or isn't a Readeck server at all.

--- a/app/src/main/assets/whatsnew/fr/0.9.0.md
+++ b/app/src/main/assets/whatsnew/fr/0.9.0.md
@@ -1,0 +1,24 @@
+---
+date: 2026-02-20
+---
+# What's New in 0.9.0
+
+Welcome to MyDeck. This first release is a comprehensive rebrand and major feature expansion.
+
+**Sign in with a code:** OAuth Device Code authentication. Get a URL and one-time code, authorize in your browser, and the app picks up automatically.
+
+**Redesigned navigation:** A Pocket-style sidebar with My List, Archive, and Favorites, plus item-count badges throughout.
+
+**Three list layouts:** Choose between Grid, Compact, and Mosaic views.
+
+**Reading progress tracking:** See progress at a glance on every card, and pick up right where you left off.
+
+**Labels:** Full label management, one-tap label filtering from bookmark cards, and a dedicated Labels view.
+
+**Article and Original views:** Toggle between Readeck's extracted article content and the original web page.
+
+**Search and typography:** Global search across titles, site names, and labels, plus reading customization (font, size, spacing, width, justification, hyphenation) with in-article Find.
+
+**Works offline:** Actions taken without a connection are queued and applied once you're back online.
+
+**Adaptive layouts:** Tablet and landscape support, and a full visual refresh under Material Design 3.

--- a/app/src/main/assets/whatsnew/fr/0.9.1.md
+++ b/app/src/main/assets/whatsnew/fr/0.9.1.md
@@ -1,0 +1,6 @@
+---
+date: 2026-02-21
+---
+# What's New in 0.9.1
+
+**Read state fix:** Corrected the read/unread icon and label not always matching in the reading view's overflow menu.

--- a/app/src/main/assets/whatsnew/fr/0.9.2.md
+++ b/app/src/main/assets/whatsnew/fr/0.9.2.md
@@ -1,0 +1,8 @@
+---
+date: 2026-02-22
+---
+# What's New in 0.9.2
+
+**Redesigned mobile grid:** Fixed-height cards with a left thumbnail and right content split, and a larger title.
+
+**Fixes:** Resolved a brief blank-state flash on cold start, TopBar jitter during overscroll, and label chips not dismissing pending delete actions before navigating away.

--- a/app/src/main/assets/whatsnew/gl/0.10.0.md
+++ b/app/src/main/assets/whatsnew/gl/0.10.0.md
@@ -1,0 +1,10 @@
+---
+date: 2026-02-26
+---
+# What's New in 0.10.0
+
+**Refined sign-in screen:** Cleaner branding and layout on the sign-in and authorization screens.
+
+**Simpler account settings:** Account settings now show the server's base URL instead of the full API path.
+
+**Better filtering:** Improved keyboard actions and preset reset handling in the filter UI.

--- a/app/src/main/assets/whatsnew/gl/0.11.0.md
+++ b/app/src/main/assets/whatsnew/gl/0.11.0.md
@@ -1,0 +1,18 @@
+---
+date: 2026-03-14
+---
+# What's New in 0.11.0
+
+**Image gallery:** Tap any article image to open a full-screen gallery with swipe navigation, pinch-to-zoom, double-tap to zoom, and a thumbnail strip.
+
+**Highlights and annotations:** View, create, and edit Readeck highlights directly in the reading view.
+
+**Reader appearance settings:** Curated themes, font size, line spacing, content width, and a fullscreen reading mode that hides the top bar until you swipe up.
+
+**Long-press menus:** Quick actions for images and links, in both the reader and the bookmark list.
+
+**Keep screen on:** A new toggle to stop the screen dimming while you read, plus an About screen showing app and server info in collapsible cards.
+
+**More for media bookmarks:** Typography and Find in Page now work for Video and Picture bookmarks too.
+
+**Reorganized reading actions:** Favorite and Archive moved to the overflow menu and inline buttons at the end of the article, and deleted bookmarks are detected immediately on pull-to-refresh.

--- a/app/src/main/assets/whatsnew/gl/0.11.1.md
+++ b/app/src/main/assets/whatsnew/gl/0.11.1.md
@@ -1,0 +1,10 @@
+---
+date: 2026-03-19
+---
+# What's New in 0.11.1
+
+**Smarter filter chips:** Dismissing a suggested chip now restores the preset default instead of clearing everything.
+
+**Faster app open:** Cached bookmarks show immediately on open instead of a blocking spinner while syncing in the background.
+
+**Fixes:** Corrected the "With errors" filter after a refresh, a text-size jump when switching reader width, missing "Copy to clipboard" translations, and a rare race condition on rapid successive deletes.

--- a/app/src/main/assets/whatsnew/gl/0.12.0.md
+++ b/app/src/main/assets/whatsnew/gl/0.12.0.md
@@ -1,0 +1,14 @@
+---
+date: 2026-04-11
+---
+# What's New in 0.12.0
+
+**In-article anchor links:** Table-of-contents and fragment links now navigate correctly within articles, with a long-press menu to open or copy the target.
+
+**Download status at a glance:** A content download-status icon now appears on reading-view bookmark cards, plus a reading-progress icon in Compact view.
+
+**Sync overhauled:** More reliable multipart sync for bookmark and content updates, plus new automatic offline-content sync policies based on volume, item count, or date range.
+
+**HTTP servers supported:** Server URLs can now use http:// for self-hosted or local setups, not just https://.
+
+**Reflow fix:** Corrected a bug where article text could disappear after a layout or font change.

--- a/app/src/main/assets/whatsnew/gl/0.12.6.md
+++ b/app/src/main/assets/whatsnew/gl/0.12.6.md
@@ -1,0 +1,6 @@
+---
+date: 2026-05-05
+---
+# What's New in 0.12.6
+
+**Crash fix:** Resolved an out-of-memory crash that could occur during offline content synchronization.

--- a/app/src/main/assets/whatsnew/gl/0.13.0.md
+++ b/app/src/main/assets/whatsnew/gl/0.13.0.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-18
+---
+# What's New in 0.13.0
+
+**Highlights:** Select and save text highlights while reading an article, with support for adding notes to each one.
+
+**Highlights list:** Browse, search, filter, and sort every highlight across all your bookmarks from the navigation drawer.
+
+**Swipe actions:** Swipe a bookmark card for quick favorite, archive, and delete.
+
+**Smoother reading:** More reliable article scrolling, a fix for a crash on Android 14+ devices, and improved sync resilience.

--- a/app/src/main/assets/whatsnew/gl/0.13.1.md
+++ b/app/src/main/assets/whatsnew/gl/0.13.1.md
@@ -1,0 +1,8 @@
+---
+date: 2026-05-20
+---
+# What's New in 0.13.1
+
+**Critical fix:** Editing a bookmark's labels no longer wipes its title, site name, and description.
+
+**Steadier sync:** Sync progress now shows a predictable indicator while your bookmarks first load.

--- a/app/src/main/assets/whatsnew/gl/0.13.2.md
+++ b/app/src/main/assets/whatsnew/gl/0.13.2.md
@@ -1,0 +1,8 @@
+---
+date: 2026-05-29
+---
+# What's New in 0.13.2
+
+**Reading time filters:** Filter your list by estimated reading time or word count, including a Min/Max range and an option to include bookmarks with no estimate.
+
+**Fresh-content fix:** The reader no longer briefly shows stale content for a bookmark opened right after adding it, before server-side extraction finishes.

--- a/app/src/main/assets/whatsnew/gl/0.14.0.md
+++ b/app/src/main/assets/whatsnew/gl/0.14.0.md
@@ -1,0 +1,12 @@
+---
+date: 2026-06-04
+---
+# What's New in 0.14.0
+
+**Multi-select:** Long-press a bookmark card to select multiple bookmarks, then favorite, archive, delete, or label them all at once.
+
+**Overflow menu:** The top app bar gains an overflow menu with more bookmark-list actions.
+
+**Native reader bar:** The reader's action bar is now a native control for smoother, more consistent interactions.
+
+**HTTPS-only releases:** Standard release builds now require HTTPS server connections.

--- a/app/src/main/assets/whatsnew/gl/0.14.1.md
+++ b/app/src/main/assets/whatsnew/gl/0.14.1.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-08
+---
+# What's New in 0.14.1
+
+**About screen polish:** Refined the About screen's copy, project links, and license and attribution wording.

--- a/app/src/main/assets/whatsnew/gl/0.14.2.md
+++ b/app/src/main/assets/whatsnew/gl/0.14.2.md
@@ -1,0 +1,12 @@
+---
+date: 2026-06-19
+---
+# What's New in 0.14.2
+
+**Offline pinning:** Pin articles to keep them available offline and protected from automatic cleanup, from bookmark multi-select or the reader's overflow menu.
+
+**Reliable downloads:** Offline downloads reworked so text and images download together and completely, instead of sometimes getting stuck as text-only.
+
+**Storage breakdown:** Settings now shows your current on-device offline storage, split into automatic and pinned content.
+
+**Sync fixes:** Resolved dropped syncs and stuck downloads on flaky networks, "Clear All Offline Content" missing some content, and duplicate bookmarks when saving over a bad connection.

--- a/app/src/main/assets/whatsnew/gl/0.14.3.md
+++ b/app/src/main/assets/whatsnew/gl/0.14.3.md
@@ -1,0 +1,14 @@
+---
+date: 2026-06-27
+---
+# What's New in 0.14.3
+
+**Reorganized settings:** User Interface Settings are now grouped into clear sections: Appearance, Bookmark List, Reading, and Sharing.
+
+**Internal browser toggle:** Choose whether a bookmark's original page opens in the in-app viewer or your device's browser.
+
+**Label search options:** Match the start of a label or anywhere within it, and sort labels alphabetically or by most used.
+
+**Error badges:** A new "With errors" filter finds bookmarks whose content couldn't be extracted, plus card badges mark extraction errors or missing content.
+
+**List tweaks:** Show or hide the add-bookmark button and the Compact layout's website source icons.

--- a/app/src/main/assets/whatsnew/gl/0.14.4.md
+++ b/app/src/main/assets/whatsnew/gl/0.14.4.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-29
+---
+# What's New in 0.14.4
+
+**Sign-in fix:** Corrected sign-in against newer Readeck nightly server builds.

--- a/app/src/main/assets/whatsnew/gl/0.14.5.md
+++ b/app/src/main/assets/whatsnew/gl/0.14.5.md
@@ -1,0 +1,12 @@
+---
+date: 2026-07-03
+---
+# What's New in 0.14.5
+
+**Collections:** Save a set of filter criteria (search, labels, type, date range, and more) as a named, reusable view. Create one from the new Collections screen or "Save as Collection" on any list, layer extra filters on top without changing the saved collection, and rename, edit, or delete it anytime.
+
+**Welcome screen quick access:** Reach About, the User Guide, and Logs before you've even connected to a server.
+
+**User Guide search:** Look up a feature by name and jump straight to it; the guide also gains dedicated pages for Labels, Highlights, Collections, and Offline Reading.
+
+**Clearer sign-in errors:** Better messages when a Readeck server is too old or isn't a Readeck server at all.

--- a/app/src/main/assets/whatsnew/gl/0.9.0.md
+++ b/app/src/main/assets/whatsnew/gl/0.9.0.md
@@ -1,0 +1,24 @@
+---
+date: 2026-02-20
+---
+# What's New in 0.9.0
+
+Welcome to MyDeck. This first release is a comprehensive rebrand and major feature expansion.
+
+**Sign in with a code:** OAuth Device Code authentication. Get a URL and one-time code, authorize in your browser, and the app picks up automatically.
+
+**Redesigned navigation:** A Pocket-style sidebar with My List, Archive, and Favorites, plus item-count badges throughout.
+
+**Three list layouts:** Choose between Grid, Compact, and Mosaic views.
+
+**Reading progress tracking:** See progress at a glance on every card, and pick up right where you left off.
+
+**Labels:** Full label management, one-tap label filtering from bookmark cards, and a dedicated Labels view.
+
+**Article and Original views:** Toggle between Readeck's extracted article content and the original web page.
+
+**Search and typography:** Global search across titles, site names, and labels, plus reading customization (font, size, spacing, width, justification, hyphenation) with in-article Find.
+
+**Works offline:** Actions taken without a connection are queued and applied once you're back online.
+
+**Adaptive layouts:** Tablet and landscape support, and a full visual refresh under Material Design 3.

--- a/app/src/main/assets/whatsnew/gl/0.9.1.md
+++ b/app/src/main/assets/whatsnew/gl/0.9.1.md
@@ -1,0 +1,6 @@
+---
+date: 2026-02-21
+---
+# What's New in 0.9.1
+
+**Read state fix:** Corrected the read/unread icon and label not always matching in the reading view's overflow menu.

--- a/app/src/main/assets/whatsnew/gl/0.9.2.md
+++ b/app/src/main/assets/whatsnew/gl/0.9.2.md
@@ -1,0 +1,8 @@
+---
+date: 2026-02-22
+---
+# What's New in 0.9.2
+
+**Redesigned mobile grid:** Fixed-height cards with a left thumbnail and right content split, and a larger title.
+
+**Fixes:** Resolved a brief blank-state flash on cold start, TopBar jitter during overscroll, and label chips not dismissing pending delete actions before navigating away.

--- a/app/src/main/assets/whatsnew/pl/0.10.0.md
+++ b/app/src/main/assets/whatsnew/pl/0.10.0.md
@@ -1,0 +1,10 @@
+---
+date: 2026-02-26
+---
+# What's New in 0.10.0
+
+**Refined sign-in screen:** Cleaner branding and layout on the sign-in and authorization screens.
+
+**Simpler account settings:** Account settings now show the server's base URL instead of the full API path.
+
+**Better filtering:** Improved keyboard actions and preset reset handling in the filter UI.

--- a/app/src/main/assets/whatsnew/pl/0.11.0.md
+++ b/app/src/main/assets/whatsnew/pl/0.11.0.md
@@ -1,0 +1,18 @@
+---
+date: 2026-03-14
+---
+# What's New in 0.11.0
+
+**Image gallery:** Tap any article image to open a full-screen gallery with swipe navigation, pinch-to-zoom, double-tap to zoom, and a thumbnail strip.
+
+**Highlights and annotations:** View, create, and edit Readeck highlights directly in the reading view.
+
+**Reader appearance settings:** Curated themes, font size, line spacing, content width, and a fullscreen reading mode that hides the top bar until you swipe up.
+
+**Long-press menus:** Quick actions for images and links, in both the reader and the bookmark list.
+
+**Keep screen on:** A new toggle to stop the screen dimming while you read, plus an About screen showing app and server info in collapsible cards.
+
+**More for media bookmarks:** Typography and Find in Page now work for Video and Picture bookmarks too.
+
+**Reorganized reading actions:** Favorite and Archive moved to the overflow menu and inline buttons at the end of the article, and deleted bookmarks are detected immediately on pull-to-refresh.

--- a/app/src/main/assets/whatsnew/pl/0.11.1.md
+++ b/app/src/main/assets/whatsnew/pl/0.11.1.md
@@ -1,0 +1,10 @@
+---
+date: 2026-03-19
+---
+# What's New in 0.11.1
+
+**Smarter filter chips:** Dismissing a suggested chip now restores the preset default instead of clearing everything.
+
+**Faster app open:** Cached bookmarks show immediately on open instead of a blocking spinner while syncing in the background.
+
+**Fixes:** Corrected the "With errors" filter after a refresh, a text-size jump when switching reader width, missing "Copy to clipboard" translations, and a rare race condition on rapid successive deletes.

--- a/app/src/main/assets/whatsnew/pl/0.12.0.md
+++ b/app/src/main/assets/whatsnew/pl/0.12.0.md
@@ -1,0 +1,14 @@
+---
+date: 2026-04-11
+---
+# What's New in 0.12.0
+
+**In-article anchor links:** Table-of-contents and fragment links now navigate correctly within articles, with a long-press menu to open or copy the target.
+
+**Download status at a glance:** A content download-status icon now appears on reading-view bookmark cards, plus a reading-progress icon in Compact view.
+
+**Sync overhauled:** More reliable multipart sync for bookmark and content updates, plus new automatic offline-content sync policies based on volume, item count, or date range.
+
+**HTTP servers supported:** Server URLs can now use http:// for self-hosted or local setups, not just https://.
+
+**Reflow fix:** Corrected a bug where article text could disappear after a layout or font change.

--- a/app/src/main/assets/whatsnew/pl/0.12.6.md
+++ b/app/src/main/assets/whatsnew/pl/0.12.6.md
@@ -1,0 +1,6 @@
+---
+date: 2026-05-05
+---
+# What's New in 0.12.6
+
+**Crash fix:** Resolved an out-of-memory crash that could occur during offline content synchronization.

--- a/app/src/main/assets/whatsnew/pl/0.13.0.md
+++ b/app/src/main/assets/whatsnew/pl/0.13.0.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-18
+---
+# What's New in 0.13.0
+
+**Highlights:** Select and save text highlights while reading an article, with support for adding notes to each one.
+
+**Highlights list:** Browse, search, filter, and sort every highlight across all your bookmarks from the navigation drawer.
+
+**Swipe actions:** Swipe a bookmark card for quick favorite, archive, and delete.
+
+**Smoother reading:** More reliable article scrolling, a fix for a crash on Android 14+ devices, and improved sync resilience.

--- a/app/src/main/assets/whatsnew/pl/0.13.1.md
+++ b/app/src/main/assets/whatsnew/pl/0.13.1.md
@@ -1,0 +1,8 @@
+---
+date: 2026-05-20
+---
+# What's New in 0.13.1
+
+**Critical fix:** Editing a bookmark's labels no longer wipes its title, site name, and description.
+
+**Steadier sync:** Sync progress now shows a predictable indicator while your bookmarks first load.

--- a/app/src/main/assets/whatsnew/pl/0.13.2.md
+++ b/app/src/main/assets/whatsnew/pl/0.13.2.md
@@ -1,0 +1,8 @@
+---
+date: 2026-05-29
+---
+# What's New in 0.13.2
+
+**Reading time filters:** Filter your list by estimated reading time or word count, including a Min/Max range and an option to include bookmarks with no estimate.
+
+**Fresh-content fix:** The reader no longer briefly shows stale content for a bookmark opened right after adding it, before server-side extraction finishes.

--- a/app/src/main/assets/whatsnew/pl/0.14.0.md
+++ b/app/src/main/assets/whatsnew/pl/0.14.0.md
@@ -1,0 +1,12 @@
+---
+date: 2026-06-04
+---
+# What's New in 0.14.0
+
+**Multi-select:** Long-press a bookmark card to select multiple bookmarks, then favorite, archive, delete, or label them all at once.
+
+**Overflow menu:** The top app bar gains an overflow menu with more bookmark-list actions.
+
+**Native reader bar:** The reader's action bar is now a native control for smoother, more consistent interactions.
+
+**HTTPS-only releases:** Standard release builds now require HTTPS server connections.

--- a/app/src/main/assets/whatsnew/pl/0.14.1.md
+++ b/app/src/main/assets/whatsnew/pl/0.14.1.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-08
+---
+# What's New in 0.14.1
+
+**About screen polish:** Refined the About screen's copy, project links, and license and attribution wording.

--- a/app/src/main/assets/whatsnew/pl/0.14.2.md
+++ b/app/src/main/assets/whatsnew/pl/0.14.2.md
@@ -1,0 +1,12 @@
+---
+date: 2026-06-19
+---
+# What's New in 0.14.2
+
+**Offline pinning:** Pin articles to keep them available offline and protected from automatic cleanup, from bookmark multi-select or the reader's overflow menu.
+
+**Reliable downloads:** Offline downloads reworked so text and images download together and completely, instead of sometimes getting stuck as text-only.
+
+**Storage breakdown:** Settings now shows your current on-device offline storage, split into automatic and pinned content.
+
+**Sync fixes:** Resolved dropped syncs and stuck downloads on flaky networks, "Clear All Offline Content" missing some content, and duplicate bookmarks when saving over a bad connection.

--- a/app/src/main/assets/whatsnew/pl/0.14.3.md
+++ b/app/src/main/assets/whatsnew/pl/0.14.3.md
@@ -1,0 +1,14 @@
+---
+date: 2026-06-27
+---
+# What's New in 0.14.3
+
+**Reorganized settings:** User Interface Settings are now grouped into clear sections: Appearance, Bookmark List, Reading, and Sharing.
+
+**Internal browser toggle:** Choose whether a bookmark's original page opens in the in-app viewer or your device's browser.
+
+**Label search options:** Match the start of a label or anywhere within it, and sort labels alphabetically or by most used.
+
+**Error badges:** A new "With errors" filter finds bookmarks whose content couldn't be extracted, plus card badges mark extraction errors or missing content.
+
+**List tweaks:** Show or hide the add-bookmark button and the Compact layout's website source icons.

--- a/app/src/main/assets/whatsnew/pl/0.14.4.md
+++ b/app/src/main/assets/whatsnew/pl/0.14.4.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-29
+---
+# What's New in 0.14.4
+
+**Sign-in fix:** Corrected sign-in against newer Readeck nightly server builds.

--- a/app/src/main/assets/whatsnew/pl/0.14.5.md
+++ b/app/src/main/assets/whatsnew/pl/0.14.5.md
@@ -1,0 +1,12 @@
+---
+date: 2026-07-03
+---
+# What's New in 0.14.5
+
+**Collections:** Save a set of filter criteria (search, labels, type, date range, and more) as a named, reusable view. Create one from the new Collections screen or "Save as Collection" on any list, layer extra filters on top without changing the saved collection, and rename, edit, or delete it anytime.
+
+**Welcome screen quick access:** Reach About, the User Guide, and Logs before you've even connected to a server.
+
+**User Guide search:** Look up a feature by name and jump straight to it; the guide also gains dedicated pages for Labels, Highlights, Collections, and Offline Reading.
+
+**Clearer sign-in errors:** Better messages when a Readeck server is too old or isn't a Readeck server at all.

--- a/app/src/main/assets/whatsnew/pl/0.9.0.md
+++ b/app/src/main/assets/whatsnew/pl/0.9.0.md
@@ -1,0 +1,24 @@
+---
+date: 2026-02-20
+---
+# What's New in 0.9.0
+
+Welcome to MyDeck. This first release is a comprehensive rebrand and major feature expansion.
+
+**Sign in with a code:** OAuth Device Code authentication. Get a URL and one-time code, authorize in your browser, and the app picks up automatically.
+
+**Redesigned navigation:** A Pocket-style sidebar with My List, Archive, and Favorites, plus item-count badges throughout.
+
+**Three list layouts:** Choose between Grid, Compact, and Mosaic views.
+
+**Reading progress tracking:** See progress at a glance on every card, and pick up right where you left off.
+
+**Labels:** Full label management, one-tap label filtering from bookmark cards, and a dedicated Labels view.
+
+**Article and Original views:** Toggle between Readeck's extracted article content and the original web page.
+
+**Search and typography:** Global search across titles, site names, and labels, plus reading customization (font, size, spacing, width, justification, hyphenation) with in-article Find.
+
+**Works offline:** Actions taken without a connection are queued and applied once you're back online.
+
+**Adaptive layouts:** Tablet and landscape support, and a full visual refresh under Material Design 3.

--- a/app/src/main/assets/whatsnew/pl/0.9.1.md
+++ b/app/src/main/assets/whatsnew/pl/0.9.1.md
@@ -1,0 +1,6 @@
+---
+date: 2026-02-21
+---
+# What's New in 0.9.1
+
+**Read state fix:** Corrected the read/unread icon and label not always matching in the reading view's overflow menu.

--- a/app/src/main/assets/whatsnew/pl/0.9.2.md
+++ b/app/src/main/assets/whatsnew/pl/0.9.2.md
@@ -1,0 +1,8 @@
+---
+date: 2026-02-22
+---
+# What's New in 0.9.2
+
+**Redesigned mobile grid:** Fixed-height cards with a left thumbnail and right content split, and a larger title.
+
+**Fixes:** Resolved a brief blank-state flash on cold start, TopBar jitter during overscroll, and label chips not dismissing pending delete actions before navigating away.

--- a/app/src/main/assets/whatsnew/pt/0.10.0.md
+++ b/app/src/main/assets/whatsnew/pt/0.10.0.md
@@ -1,0 +1,10 @@
+---
+date: 2026-02-26
+---
+# What's New in 0.10.0
+
+**Refined sign-in screen:** Cleaner branding and layout on the sign-in and authorization screens.
+
+**Simpler account settings:** Account settings now show the server's base URL instead of the full API path.
+
+**Better filtering:** Improved keyboard actions and preset reset handling in the filter UI.

--- a/app/src/main/assets/whatsnew/pt/0.11.0.md
+++ b/app/src/main/assets/whatsnew/pt/0.11.0.md
@@ -1,0 +1,18 @@
+---
+date: 2026-03-14
+---
+# What's New in 0.11.0
+
+**Image gallery:** Tap any article image to open a full-screen gallery with swipe navigation, pinch-to-zoom, double-tap to zoom, and a thumbnail strip.
+
+**Highlights and annotations:** View, create, and edit Readeck highlights directly in the reading view.
+
+**Reader appearance settings:** Curated themes, font size, line spacing, content width, and a fullscreen reading mode that hides the top bar until you swipe up.
+
+**Long-press menus:** Quick actions for images and links, in both the reader and the bookmark list.
+
+**Keep screen on:** A new toggle to stop the screen dimming while you read, plus an About screen showing app and server info in collapsible cards.
+
+**More for media bookmarks:** Typography and Find in Page now work for Video and Picture bookmarks too.
+
+**Reorganized reading actions:** Favorite and Archive moved to the overflow menu and inline buttons at the end of the article, and deleted bookmarks are detected immediately on pull-to-refresh.

--- a/app/src/main/assets/whatsnew/pt/0.11.1.md
+++ b/app/src/main/assets/whatsnew/pt/0.11.1.md
@@ -1,0 +1,10 @@
+---
+date: 2026-03-19
+---
+# What's New in 0.11.1
+
+**Smarter filter chips:** Dismissing a suggested chip now restores the preset default instead of clearing everything.
+
+**Faster app open:** Cached bookmarks show immediately on open instead of a blocking spinner while syncing in the background.
+
+**Fixes:** Corrected the "With errors" filter after a refresh, a text-size jump when switching reader width, missing "Copy to clipboard" translations, and a rare race condition on rapid successive deletes.

--- a/app/src/main/assets/whatsnew/pt/0.12.0.md
+++ b/app/src/main/assets/whatsnew/pt/0.12.0.md
@@ -1,0 +1,14 @@
+---
+date: 2026-04-11
+---
+# What's New in 0.12.0
+
+**In-article anchor links:** Table-of-contents and fragment links now navigate correctly within articles, with a long-press menu to open or copy the target.
+
+**Download status at a glance:** A content download-status icon now appears on reading-view bookmark cards, plus a reading-progress icon in Compact view.
+
+**Sync overhauled:** More reliable multipart sync for bookmark and content updates, plus new automatic offline-content sync policies based on volume, item count, or date range.
+
+**HTTP servers supported:** Server URLs can now use http:// for self-hosted or local setups, not just https://.
+
+**Reflow fix:** Corrected a bug where article text could disappear after a layout or font change.

--- a/app/src/main/assets/whatsnew/pt/0.12.6.md
+++ b/app/src/main/assets/whatsnew/pt/0.12.6.md
@@ -1,0 +1,6 @@
+---
+date: 2026-05-05
+---
+# What's New in 0.12.6
+
+**Crash fix:** Resolved an out-of-memory crash that could occur during offline content synchronization.

--- a/app/src/main/assets/whatsnew/pt/0.13.0.md
+++ b/app/src/main/assets/whatsnew/pt/0.13.0.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-18
+---
+# What's New in 0.13.0
+
+**Highlights:** Select and save text highlights while reading an article, with support for adding notes to each one.
+
+**Highlights list:** Browse, search, filter, and sort every highlight across all your bookmarks from the navigation drawer.
+
+**Swipe actions:** Swipe a bookmark card for quick favorite, archive, and delete.
+
+**Smoother reading:** More reliable article scrolling, a fix for a crash on Android 14+ devices, and improved sync resilience.

--- a/app/src/main/assets/whatsnew/pt/0.13.1.md
+++ b/app/src/main/assets/whatsnew/pt/0.13.1.md
@@ -1,0 +1,8 @@
+---
+date: 2026-05-20
+---
+# What's New in 0.13.1
+
+**Critical fix:** Editing a bookmark's labels no longer wipes its title, site name, and description.
+
+**Steadier sync:** Sync progress now shows a predictable indicator while your bookmarks first load.

--- a/app/src/main/assets/whatsnew/pt/0.13.2.md
+++ b/app/src/main/assets/whatsnew/pt/0.13.2.md
@@ -1,0 +1,8 @@
+---
+date: 2026-05-29
+---
+# What's New in 0.13.2
+
+**Reading time filters:** Filter your list by estimated reading time or word count, including a Min/Max range and an option to include bookmarks with no estimate.
+
+**Fresh-content fix:** The reader no longer briefly shows stale content for a bookmark opened right after adding it, before server-side extraction finishes.

--- a/app/src/main/assets/whatsnew/pt/0.14.0.md
+++ b/app/src/main/assets/whatsnew/pt/0.14.0.md
@@ -1,0 +1,12 @@
+---
+date: 2026-06-04
+---
+# What's New in 0.14.0
+
+**Multi-select:** Long-press a bookmark card to select multiple bookmarks, then favorite, archive, delete, or label them all at once.
+
+**Overflow menu:** The top app bar gains an overflow menu with more bookmark-list actions.
+
+**Native reader bar:** The reader's action bar is now a native control for smoother, more consistent interactions.
+
+**HTTPS-only releases:** Standard release builds now require HTTPS server connections.

--- a/app/src/main/assets/whatsnew/pt/0.14.1.md
+++ b/app/src/main/assets/whatsnew/pt/0.14.1.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-08
+---
+# What's New in 0.14.1
+
+**About screen polish:** Refined the About screen's copy, project links, and license and attribution wording.

--- a/app/src/main/assets/whatsnew/pt/0.14.2.md
+++ b/app/src/main/assets/whatsnew/pt/0.14.2.md
@@ -1,0 +1,12 @@
+---
+date: 2026-06-19
+---
+# What's New in 0.14.2
+
+**Offline pinning:** Pin articles to keep them available offline and protected from automatic cleanup, from bookmark multi-select or the reader's overflow menu.
+
+**Reliable downloads:** Offline downloads reworked so text and images download together and completely, instead of sometimes getting stuck as text-only.
+
+**Storage breakdown:** Settings now shows your current on-device offline storage, split into automatic and pinned content.
+
+**Sync fixes:** Resolved dropped syncs and stuck downloads on flaky networks, "Clear All Offline Content" missing some content, and duplicate bookmarks when saving over a bad connection.

--- a/app/src/main/assets/whatsnew/pt/0.14.3.md
+++ b/app/src/main/assets/whatsnew/pt/0.14.3.md
@@ -1,0 +1,14 @@
+---
+date: 2026-06-27
+---
+# What's New in 0.14.3
+
+**Reorganized settings:** User Interface Settings are now grouped into clear sections: Appearance, Bookmark List, Reading, and Sharing.
+
+**Internal browser toggle:** Choose whether a bookmark's original page opens in the in-app viewer or your device's browser.
+
+**Label search options:** Match the start of a label or anywhere within it, and sort labels alphabetically or by most used.
+
+**Error badges:** A new "With errors" filter finds bookmarks whose content couldn't be extracted, plus card badges mark extraction errors or missing content.
+
+**List tweaks:** Show or hide the add-bookmark button and the Compact layout's website source icons.

--- a/app/src/main/assets/whatsnew/pt/0.14.4.md
+++ b/app/src/main/assets/whatsnew/pt/0.14.4.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-29
+---
+# What's New in 0.14.4
+
+**Sign-in fix:** Corrected sign-in against newer Readeck nightly server builds.

--- a/app/src/main/assets/whatsnew/pt/0.14.5.md
+++ b/app/src/main/assets/whatsnew/pt/0.14.5.md
@@ -1,0 +1,12 @@
+---
+date: 2026-07-03
+---
+# What's New in 0.14.5
+
+**Collections:** Save a set of filter criteria (search, labels, type, date range, and more) as a named, reusable view. Create one from the new Collections screen or "Save as Collection" on any list, layer extra filters on top without changing the saved collection, and rename, edit, or delete it anytime.
+
+**Welcome screen quick access:** Reach About, the User Guide, and Logs before you've even connected to a server.
+
+**User Guide search:** Look up a feature by name and jump straight to it; the guide also gains dedicated pages for Labels, Highlights, Collections, and Offline Reading.
+
+**Clearer sign-in errors:** Better messages when a Readeck server is too old or isn't a Readeck server at all.

--- a/app/src/main/assets/whatsnew/pt/0.9.0.md
+++ b/app/src/main/assets/whatsnew/pt/0.9.0.md
@@ -1,0 +1,24 @@
+---
+date: 2026-02-20
+---
+# What's New in 0.9.0
+
+Welcome to MyDeck. This first release is a comprehensive rebrand and major feature expansion.
+
+**Sign in with a code:** OAuth Device Code authentication. Get a URL and one-time code, authorize in your browser, and the app picks up automatically.
+
+**Redesigned navigation:** A Pocket-style sidebar with My List, Archive, and Favorites, plus item-count badges throughout.
+
+**Three list layouts:** Choose between Grid, Compact, and Mosaic views.
+
+**Reading progress tracking:** See progress at a glance on every card, and pick up right where you left off.
+
+**Labels:** Full label management, one-tap label filtering from bookmark cards, and a dedicated Labels view.
+
+**Article and Original views:** Toggle between Readeck's extracted article content and the original web page.
+
+**Search and typography:** Global search across titles, site names, and labels, plus reading customization (font, size, spacing, width, justification, hyphenation) with in-article Find.
+
+**Works offline:** Actions taken without a connection are queued and applied once you're back online.
+
+**Adaptive layouts:** Tablet and landscape support, and a full visual refresh under Material Design 3.

--- a/app/src/main/assets/whatsnew/pt/0.9.1.md
+++ b/app/src/main/assets/whatsnew/pt/0.9.1.md
@@ -1,0 +1,6 @@
+---
+date: 2026-02-21
+---
+# What's New in 0.9.1
+
+**Read state fix:** Corrected the read/unread icon and label not always matching in the reading view's overflow menu.

--- a/app/src/main/assets/whatsnew/pt/0.9.2.md
+++ b/app/src/main/assets/whatsnew/pt/0.9.2.md
@@ -1,0 +1,8 @@
+---
+date: 2026-02-22
+---
+# What's New in 0.9.2
+
+**Redesigned mobile grid:** Fixed-height cards with a left thumbnail and right content split, and a larger title.
+
+**Fixes:** Resolved a brief blank-state flash on cold start, TopBar jitter during overscroll, and label chips not dismissing pending delete actions before navigating away.

--- a/app/src/main/assets/whatsnew/ru/0.10.0.md
+++ b/app/src/main/assets/whatsnew/ru/0.10.0.md
@@ -1,0 +1,10 @@
+---
+date: 2026-02-26
+---
+# What's New in 0.10.0
+
+**Refined sign-in screen:** Cleaner branding and layout on the sign-in and authorization screens.
+
+**Simpler account settings:** Account settings now show the server's base URL instead of the full API path.
+
+**Better filtering:** Improved keyboard actions and preset reset handling in the filter UI.

--- a/app/src/main/assets/whatsnew/ru/0.11.0.md
+++ b/app/src/main/assets/whatsnew/ru/0.11.0.md
@@ -1,0 +1,18 @@
+---
+date: 2026-03-14
+---
+# What's New in 0.11.0
+
+**Image gallery:** Tap any article image to open a full-screen gallery with swipe navigation, pinch-to-zoom, double-tap to zoom, and a thumbnail strip.
+
+**Highlights and annotations:** View, create, and edit Readeck highlights directly in the reading view.
+
+**Reader appearance settings:** Curated themes, font size, line spacing, content width, and a fullscreen reading mode that hides the top bar until you swipe up.
+
+**Long-press menus:** Quick actions for images and links, in both the reader and the bookmark list.
+
+**Keep screen on:** A new toggle to stop the screen dimming while you read, plus an About screen showing app and server info in collapsible cards.
+
+**More for media bookmarks:** Typography and Find in Page now work for Video and Picture bookmarks too.
+
+**Reorganized reading actions:** Favorite and Archive moved to the overflow menu and inline buttons at the end of the article, and deleted bookmarks are detected immediately on pull-to-refresh.

--- a/app/src/main/assets/whatsnew/ru/0.11.1.md
+++ b/app/src/main/assets/whatsnew/ru/0.11.1.md
@@ -1,0 +1,10 @@
+---
+date: 2026-03-19
+---
+# What's New in 0.11.1
+
+**Smarter filter chips:** Dismissing a suggested chip now restores the preset default instead of clearing everything.
+
+**Faster app open:** Cached bookmarks show immediately on open instead of a blocking spinner while syncing in the background.
+
+**Fixes:** Corrected the "With errors" filter after a refresh, a text-size jump when switching reader width, missing "Copy to clipboard" translations, and a rare race condition on rapid successive deletes.

--- a/app/src/main/assets/whatsnew/ru/0.12.0.md
+++ b/app/src/main/assets/whatsnew/ru/0.12.0.md
@@ -1,0 +1,14 @@
+---
+date: 2026-04-11
+---
+# What's New in 0.12.0
+
+**In-article anchor links:** Table-of-contents and fragment links now navigate correctly within articles, with a long-press menu to open or copy the target.
+
+**Download status at a glance:** A content download-status icon now appears on reading-view bookmark cards, plus a reading-progress icon in Compact view.
+
+**Sync overhauled:** More reliable multipart sync for bookmark and content updates, plus new automatic offline-content sync policies based on volume, item count, or date range.
+
+**HTTP servers supported:** Server URLs can now use http:// for self-hosted or local setups, not just https://.
+
+**Reflow fix:** Corrected a bug where article text could disappear after a layout or font change.

--- a/app/src/main/assets/whatsnew/ru/0.12.6.md
+++ b/app/src/main/assets/whatsnew/ru/0.12.6.md
@@ -1,0 +1,6 @@
+---
+date: 2026-05-05
+---
+# What's New in 0.12.6
+
+**Crash fix:** Resolved an out-of-memory crash that could occur during offline content synchronization.

--- a/app/src/main/assets/whatsnew/ru/0.13.0.md
+++ b/app/src/main/assets/whatsnew/ru/0.13.0.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-18
+---
+# What's New in 0.13.0
+
+**Highlights:** Select and save text highlights while reading an article, with support for adding notes to each one.
+
+**Highlights list:** Browse, search, filter, and sort every highlight across all your bookmarks from the navigation drawer.
+
+**Swipe actions:** Swipe a bookmark card for quick favorite, archive, and delete.
+
+**Smoother reading:** More reliable article scrolling, a fix for a crash on Android 14+ devices, and improved sync resilience.

--- a/app/src/main/assets/whatsnew/ru/0.13.1.md
+++ b/app/src/main/assets/whatsnew/ru/0.13.1.md
@@ -1,0 +1,8 @@
+---
+date: 2026-05-20
+---
+# What's New in 0.13.1
+
+**Critical fix:** Editing a bookmark's labels no longer wipes its title, site name, and description.
+
+**Steadier sync:** Sync progress now shows a predictable indicator while your bookmarks first load.

--- a/app/src/main/assets/whatsnew/ru/0.13.2.md
+++ b/app/src/main/assets/whatsnew/ru/0.13.2.md
@@ -1,0 +1,8 @@
+---
+date: 2026-05-29
+---
+# What's New in 0.13.2
+
+**Reading time filters:** Filter your list by estimated reading time or word count, including a Min/Max range and an option to include bookmarks with no estimate.
+
+**Fresh-content fix:** The reader no longer briefly shows stale content for a bookmark opened right after adding it, before server-side extraction finishes.

--- a/app/src/main/assets/whatsnew/ru/0.14.0.md
+++ b/app/src/main/assets/whatsnew/ru/0.14.0.md
@@ -1,0 +1,12 @@
+---
+date: 2026-06-04
+---
+# What's New in 0.14.0
+
+**Multi-select:** Long-press a bookmark card to select multiple bookmarks, then favorite, archive, delete, or label them all at once.
+
+**Overflow menu:** The top app bar gains an overflow menu with more bookmark-list actions.
+
+**Native reader bar:** The reader's action bar is now a native control for smoother, more consistent interactions.
+
+**HTTPS-only releases:** Standard release builds now require HTTPS server connections.

--- a/app/src/main/assets/whatsnew/ru/0.14.1.md
+++ b/app/src/main/assets/whatsnew/ru/0.14.1.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-08
+---
+# What's New in 0.14.1
+
+**About screen polish:** Refined the About screen's copy, project links, and license and attribution wording.

--- a/app/src/main/assets/whatsnew/ru/0.14.2.md
+++ b/app/src/main/assets/whatsnew/ru/0.14.2.md
@@ -1,0 +1,12 @@
+---
+date: 2026-06-19
+---
+# What's New in 0.14.2
+
+**Offline pinning:** Pin articles to keep them available offline and protected from automatic cleanup, from bookmark multi-select or the reader's overflow menu.
+
+**Reliable downloads:** Offline downloads reworked so text and images download together and completely, instead of sometimes getting stuck as text-only.
+
+**Storage breakdown:** Settings now shows your current on-device offline storage, split into automatic and pinned content.
+
+**Sync fixes:** Resolved dropped syncs and stuck downloads on flaky networks, "Clear All Offline Content" missing some content, and duplicate bookmarks when saving over a bad connection.

--- a/app/src/main/assets/whatsnew/ru/0.14.3.md
+++ b/app/src/main/assets/whatsnew/ru/0.14.3.md
@@ -1,0 +1,14 @@
+---
+date: 2026-06-27
+---
+# What's New in 0.14.3
+
+**Reorganized settings:** User Interface Settings are now grouped into clear sections: Appearance, Bookmark List, Reading, and Sharing.
+
+**Internal browser toggle:** Choose whether a bookmark's original page opens in the in-app viewer or your device's browser.
+
+**Label search options:** Match the start of a label or anywhere within it, and sort labels alphabetically or by most used.
+
+**Error badges:** A new "With errors" filter finds bookmarks whose content couldn't be extracted, plus card badges mark extraction errors or missing content.
+
+**List tweaks:** Show or hide the add-bookmark button and the Compact layout's website source icons.

--- a/app/src/main/assets/whatsnew/ru/0.14.4.md
+++ b/app/src/main/assets/whatsnew/ru/0.14.4.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-29
+---
+# What's New in 0.14.4
+
+**Sign-in fix:** Corrected sign-in against newer Readeck nightly server builds.

--- a/app/src/main/assets/whatsnew/ru/0.14.5.md
+++ b/app/src/main/assets/whatsnew/ru/0.14.5.md
@@ -1,0 +1,12 @@
+---
+date: 2026-07-03
+---
+# What's New in 0.14.5
+
+**Collections:** Save a set of filter criteria (search, labels, type, date range, and more) as a named, reusable view. Create one from the new Collections screen or "Save as Collection" on any list, layer extra filters on top without changing the saved collection, and rename, edit, or delete it anytime.
+
+**Welcome screen quick access:** Reach About, the User Guide, and Logs before you've even connected to a server.
+
+**User Guide search:** Look up a feature by name and jump straight to it; the guide also gains dedicated pages for Labels, Highlights, Collections, and Offline Reading.
+
+**Clearer sign-in errors:** Better messages when a Readeck server is too old or isn't a Readeck server at all.

--- a/app/src/main/assets/whatsnew/ru/0.9.0.md
+++ b/app/src/main/assets/whatsnew/ru/0.9.0.md
@@ -1,0 +1,24 @@
+---
+date: 2026-02-20
+---
+# What's New in 0.9.0
+
+Welcome to MyDeck. This first release is a comprehensive rebrand and major feature expansion.
+
+**Sign in with a code:** OAuth Device Code authentication. Get a URL and one-time code, authorize in your browser, and the app picks up automatically.
+
+**Redesigned navigation:** A Pocket-style sidebar with My List, Archive, and Favorites, plus item-count badges throughout.
+
+**Three list layouts:** Choose between Grid, Compact, and Mosaic views.
+
+**Reading progress tracking:** See progress at a glance on every card, and pick up right where you left off.
+
+**Labels:** Full label management, one-tap label filtering from bookmark cards, and a dedicated Labels view.
+
+**Article and Original views:** Toggle between Readeck's extracted article content and the original web page.
+
+**Search and typography:** Global search across titles, site names, and labels, plus reading customization (font, size, spacing, width, justification, hyphenation) with in-article Find.
+
+**Works offline:** Actions taken without a connection are queued and applied once you're back online.
+
+**Adaptive layouts:** Tablet and landscape support, and a full visual refresh under Material Design 3.

--- a/app/src/main/assets/whatsnew/ru/0.9.1.md
+++ b/app/src/main/assets/whatsnew/ru/0.9.1.md
@@ -1,0 +1,6 @@
+---
+date: 2026-02-21
+---
+# What's New in 0.9.1
+
+**Read state fix:** Corrected the read/unread icon and label not always matching in the reading view's overflow menu.

--- a/app/src/main/assets/whatsnew/ru/0.9.2.md
+++ b/app/src/main/assets/whatsnew/ru/0.9.2.md
@@ -1,0 +1,8 @@
+---
+date: 2026-02-22
+---
+# What's New in 0.9.2
+
+**Redesigned mobile grid:** Fixed-height cards with a left thumbnail and right content split, and a larger title.
+
+**Fixes:** Resolved a brief blank-state flash on cold start, TopBar jitter during overscroll, and label chips not dismissing pending delete actions before navigating away.

--- a/app/src/main/assets/whatsnew/uk/0.10.0.md
+++ b/app/src/main/assets/whatsnew/uk/0.10.0.md
@@ -1,0 +1,10 @@
+---
+date: 2026-02-26
+---
+# What's New in 0.10.0
+
+**Refined sign-in screen:** Cleaner branding and layout on the sign-in and authorization screens.
+
+**Simpler account settings:** Account settings now show the server's base URL instead of the full API path.
+
+**Better filtering:** Improved keyboard actions and preset reset handling in the filter UI.

--- a/app/src/main/assets/whatsnew/uk/0.11.0.md
+++ b/app/src/main/assets/whatsnew/uk/0.11.0.md
@@ -1,0 +1,18 @@
+---
+date: 2026-03-14
+---
+# What's New in 0.11.0
+
+**Image gallery:** Tap any article image to open a full-screen gallery with swipe navigation, pinch-to-zoom, double-tap to zoom, and a thumbnail strip.
+
+**Highlights and annotations:** View, create, and edit Readeck highlights directly in the reading view.
+
+**Reader appearance settings:** Curated themes, font size, line spacing, content width, and a fullscreen reading mode that hides the top bar until you swipe up.
+
+**Long-press menus:** Quick actions for images and links, in both the reader and the bookmark list.
+
+**Keep screen on:** A new toggle to stop the screen dimming while you read, plus an About screen showing app and server info in collapsible cards.
+
+**More for media bookmarks:** Typography and Find in Page now work for Video and Picture bookmarks too.
+
+**Reorganized reading actions:** Favorite and Archive moved to the overflow menu and inline buttons at the end of the article, and deleted bookmarks are detected immediately on pull-to-refresh.

--- a/app/src/main/assets/whatsnew/uk/0.11.1.md
+++ b/app/src/main/assets/whatsnew/uk/0.11.1.md
@@ -1,0 +1,10 @@
+---
+date: 2026-03-19
+---
+# What's New in 0.11.1
+
+**Smarter filter chips:** Dismissing a suggested chip now restores the preset default instead of clearing everything.
+
+**Faster app open:** Cached bookmarks show immediately on open instead of a blocking spinner while syncing in the background.
+
+**Fixes:** Corrected the "With errors" filter after a refresh, a text-size jump when switching reader width, missing "Copy to clipboard" translations, and a rare race condition on rapid successive deletes.

--- a/app/src/main/assets/whatsnew/uk/0.12.0.md
+++ b/app/src/main/assets/whatsnew/uk/0.12.0.md
@@ -1,0 +1,14 @@
+---
+date: 2026-04-11
+---
+# What's New in 0.12.0
+
+**In-article anchor links:** Table-of-contents and fragment links now navigate correctly within articles, with a long-press menu to open or copy the target.
+
+**Download status at a glance:** A content download-status icon now appears on reading-view bookmark cards, plus a reading-progress icon in Compact view.
+
+**Sync overhauled:** More reliable multipart sync for bookmark and content updates, plus new automatic offline-content sync policies based on volume, item count, or date range.
+
+**HTTP servers supported:** Server URLs can now use http:// for self-hosted or local setups, not just https://.
+
+**Reflow fix:** Corrected a bug where article text could disappear after a layout or font change.

--- a/app/src/main/assets/whatsnew/uk/0.12.6.md
+++ b/app/src/main/assets/whatsnew/uk/0.12.6.md
@@ -1,0 +1,6 @@
+---
+date: 2026-05-05
+---
+# What's New in 0.12.6
+
+**Crash fix:** Resolved an out-of-memory crash that could occur during offline content synchronization.

--- a/app/src/main/assets/whatsnew/uk/0.13.0.md
+++ b/app/src/main/assets/whatsnew/uk/0.13.0.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-18
+---
+# What's New in 0.13.0
+
+**Highlights:** Select and save text highlights while reading an article, with support for adding notes to each one.
+
+**Highlights list:** Browse, search, filter, and sort every highlight across all your bookmarks from the navigation drawer.
+
+**Swipe actions:** Swipe a bookmark card for quick favorite, archive, and delete.
+
+**Smoother reading:** More reliable article scrolling, a fix for a crash on Android 14+ devices, and improved sync resilience.

--- a/app/src/main/assets/whatsnew/uk/0.13.1.md
+++ b/app/src/main/assets/whatsnew/uk/0.13.1.md
@@ -1,0 +1,8 @@
+---
+date: 2026-05-20
+---
+# What's New in 0.13.1
+
+**Critical fix:** Editing a bookmark's labels no longer wipes its title, site name, and description.
+
+**Steadier sync:** Sync progress now shows a predictable indicator while your bookmarks first load.

--- a/app/src/main/assets/whatsnew/uk/0.13.2.md
+++ b/app/src/main/assets/whatsnew/uk/0.13.2.md
@@ -1,0 +1,8 @@
+---
+date: 2026-05-29
+---
+# What's New in 0.13.2
+
+**Reading time filters:** Filter your list by estimated reading time or word count, including a Min/Max range and an option to include bookmarks with no estimate.
+
+**Fresh-content fix:** The reader no longer briefly shows stale content for a bookmark opened right after adding it, before server-side extraction finishes.

--- a/app/src/main/assets/whatsnew/uk/0.14.0.md
+++ b/app/src/main/assets/whatsnew/uk/0.14.0.md
@@ -1,0 +1,12 @@
+---
+date: 2026-06-04
+---
+# What's New in 0.14.0
+
+**Multi-select:** Long-press a bookmark card to select multiple bookmarks, then favorite, archive, delete, or label them all at once.
+
+**Overflow menu:** The top app bar gains an overflow menu with more bookmark-list actions.
+
+**Native reader bar:** The reader's action bar is now a native control for smoother, more consistent interactions.
+
+**HTTPS-only releases:** Standard release builds now require HTTPS server connections.

--- a/app/src/main/assets/whatsnew/uk/0.14.1.md
+++ b/app/src/main/assets/whatsnew/uk/0.14.1.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-08
+---
+# What's New in 0.14.1
+
+**About screen polish:** Refined the About screen's copy, project links, and license and attribution wording.

--- a/app/src/main/assets/whatsnew/uk/0.14.2.md
+++ b/app/src/main/assets/whatsnew/uk/0.14.2.md
@@ -1,0 +1,12 @@
+---
+date: 2026-06-19
+---
+# What's New in 0.14.2
+
+**Offline pinning:** Pin articles to keep them available offline and protected from automatic cleanup, from bookmark multi-select or the reader's overflow menu.
+
+**Reliable downloads:** Offline downloads reworked so text and images download together and completely, instead of sometimes getting stuck as text-only.
+
+**Storage breakdown:** Settings now shows your current on-device offline storage, split into automatic and pinned content.
+
+**Sync fixes:** Resolved dropped syncs and stuck downloads on flaky networks, "Clear All Offline Content" missing some content, and duplicate bookmarks when saving over a bad connection.

--- a/app/src/main/assets/whatsnew/uk/0.14.3.md
+++ b/app/src/main/assets/whatsnew/uk/0.14.3.md
@@ -1,0 +1,14 @@
+---
+date: 2026-06-27
+---
+# What's New in 0.14.3
+
+**Reorganized settings:** User Interface Settings are now grouped into clear sections: Appearance, Bookmark List, Reading, and Sharing.
+
+**Internal browser toggle:** Choose whether a bookmark's original page opens in the in-app viewer or your device's browser.
+
+**Label search options:** Match the start of a label or anywhere within it, and sort labels alphabetically or by most used.
+
+**Error badges:** A new "With errors" filter finds bookmarks whose content couldn't be extracted, plus card badges mark extraction errors or missing content.
+
+**List tweaks:** Show or hide the add-bookmark button and the Compact layout's website source icons.

--- a/app/src/main/assets/whatsnew/uk/0.14.4.md
+++ b/app/src/main/assets/whatsnew/uk/0.14.4.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-29
+---
+# What's New in 0.14.4
+
+**Sign-in fix:** Corrected sign-in against newer Readeck nightly server builds.

--- a/app/src/main/assets/whatsnew/uk/0.14.5.md
+++ b/app/src/main/assets/whatsnew/uk/0.14.5.md
@@ -1,0 +1,12 @@
+---
+date: 2026-07-03
+---
+# What's New in 0.14.5
+
+**Collections:** Save a set of filter criteria (search, labels, type, date range, and more) as a named, reusable view. Create one from the new Collections screen or "Save as Collection" on any list, layer extra filters on top without changing the saved collection, and rename, edit, or delete it anytime.
+
+**Welcome screen quick access:** Reach About, the User Guide, and Logs before you've even connected to a server.
+
+**User Guide search:** Look up a feature by name and jump straight to it; the guide also gains dedicated pages for Labels, Highlights, Collections, and Offline Reading.
+
+**Clearer sign-in errors:** Better messages when a Readeck server is too old or isn't a Readeck server at all.

--- a/app/src/main/assets/whatsnew/uk/0.9.0.md
+++ b/app/src/main/assets/whatsnew/uk/0.9.0.md
@@ -1,0 +1,24 @@
+---
+date: 2026-02-20
+---
+# What's New in 0.9.0
+
+Welcome to MyDeck. This first release is a comprehensive rebrand and major feature expansion.
+
+**Sign in with a code:** OAuth Device Code authentication. Get a URL and one-time code, authorize in your browser, and the app picks up automatically.
+
+**Redesigned navigation:** A Pocket-style sidebar with My List, Archive, and Favorites, plus item-count badges throughout.
+
+**Three list layouts:** Choose between Grid, Compact, and Mosaic views.
+
+**Reading progress tracking:** See progress at a glance on every card, and pick up right where you left off.
+
+**Labels:** Full label management, one-tap label filtering from bookmark cards, and a dedicated Labels view.
+
+**Article and Original views:** Toggle between Readeck's extracted article content and the original web page.
+
+**Search and typography:** Global search across titles, site names, and labels, plus reading customization (font, size, spacing, width, justification, hyphenation) with in-article Find.
+
+**Works offline:** Actions taken without a connection are queued and applied once you're back online.
+
+**Adaptive layouts:** Tablet and landscape support, and a full visual refresh under Material Design 3.

--- a/app/src/main/assets/whatsnew/uk/0.9.1.md
+++ b/app/src/main/assets/whatsnew/uk/0.9.1.md
@@ -1,0 +1,6 @@
+---
+date: 2026-02-21
+---
+# What's New in 0.9.1
+
+**Read state fix:** Corrected the read/unread icon and label not always matching in the reading view's overflow menu.

--- a/app/src/main/assets/whatsnew/uk/0.9.2.md
+++ b/app/src/main/assets/whatsnew/uk/0.9.2.md
@@ -1,0 +1,8 @@
+---
+date: 2026-02-22
+---
+# What's New in 0.9.2
+
+**Redesigned mobile grid:** Fixed-height cards with a left thumbnail and right content split, and a larger title.
+
+**Fixes:** Resolved a brief blank-state flash on cold start, TopBar jitter during overscroll, and label chips not dismissing pending delete actions before navigating away.

--- a/app/src/main/assets/whatsnew/zh/0.10.0.md
+++ b/app/src/main/assets/whatsnew/zh/0.10.0.md
@@ -1,0 +1,10 @@
+---
+date: 2026-02-26
+---
+# What's New in 0.10.0
+
+**Refined sign-in screen:** Cleaner branding and layout on the sign-in and authorization screens.
+
+**Simpler account settings:** Account settings now show the server's base URL instead of the full API path.
+
+**Better filtering:** Improved keyboard actions and preset reset handling in the filter UI.

--- a/app/src/main/assets/whatsnew/zh/0.11.0.md
+++ b/app/src/main/assets/whatsnew/zh/0.11.0.md
@@ -1,0 +1,18 @@
+---
+date: 2026-03-14
+---
+# What's New in 0.11.0
+
+**Image gallery:** Tap any article image to open a full-screen gallery with swipe navigation, pinch-to-zoom, double-tap to zoom, and a thumbnail strip.
+
+**Highlights and annotations:** View, create, and edit Readeck highlights directly in the reading view.
+
+**Reader appearance settings:** Curated themes, font size, line spacing, content width, and a fullscreen reading mode that hides the top bar until you swipe up.
+
+**Long-press menus:** Quick actions for images and links, in both the reader and the bookmark list.
+
+**Keep screen on:** A new toggle to stop the screen dimming while you read, plus an About screen showing app and server info in collapsible cards.
+
+**More for media bookmarks:** Typography and Find in Page now work for Video and Picture bookmarks too.
+
+**Reorganized reading actions:** Favorite and Archive moved to the overflow menu and inline buttons at the end of the article, and deleted bookmarks are detected immediately on pull-to-refresh.

--- a/app/src/main/assets/whatsnew/zh/0.11.1.md
+++ b/app/src/main/assets/whatsnew/zh/0.11.1.md
@@ -1,0 +1,10 @@
+---
+date: 2026-03-19
+---
+# What's New in 0.11.1
+
+**Smarter filter chips:** Dismissing a suggested chip now restores the preset default instead of clearing everything.
+
+**Faster app open:** Cached bookmarks show immediately on open instead of a blocking spinner while syncing in the background.
+
+**Fixes:** Corrected the "With errors" filter after a refresh, a text-size jump when switching reader width, missing "Copy to clipboard" translations, and a rare race condition on rapid successive deletes.

--- a/app/src/main/assets/whatsnew/zh/0.12.0.md
+++ b/app/src/main/assets/whatsnew/zh/0.12.0.md
@@ -1,0 +1,14 @@
+---
+date: 2026-04-11
+---
+# What's New in 0.12.0
+
+**In-article anchor links:** Table-of-contents and fragment links now navigate correctly within articles, with a long-press menu to open or copy the target.
+
+**Download status at a glance:** A content download-status icon now appears on reading-view bookmark cards, plus a reading-progress icon in Compact view.
+
+**Sync overhauled:** More reliable multipart sync for bookmark and content updates, plus new automatic offline-content sync policies based on volume, item count, or date range.
+
+**HTTP servers supported:** Server URLs can now use http:// for self-hosted or local setups, not just https://.
+
+**Reflow fix:** Corrected a bug where article text could disappear after a layout or font change.

--- a/app/src/main/assets/whatsnew/zh/0.12.6.md
+++ b/app/src/main/assets/whatsnew/zh/0.12.6.md
@@ -1,0 +1,6 @@
+---
+date: 2026-05-05
+---
+# What's New in 0.12.6
+
+**Crash fix:** Resolved an out-of-memory crash that could occur during offline content synchronization.

--- a/app/src/main/assets/whatsnew/zh/0.13.0.md
+++ b/app/src/main/assets/whatsnew/zh/0.13.0.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-18
+---
+# What's New in 0.13.0
+
+**Highlights:** Select and save text highlights while reading an article, with support for adding notes to each one.
+
+**Highlights list:** Browse, search, filter, and sort every highlight across all your bookmarks from the navigation drawer.
+
+**Swipe actions:** Swipe a bookmark card for quick favorite, archive, and delete.
+
+**Smoother reading:** More reliable article scrolling, a fix for a crash on Android 14+ devices, and improved sync resilience.

--- a/app/src/main/assets/whatsnew/zh/0.13.1.md
+++ b/app/src/main/assets/whatsnew/zh/0.13.1.md
@@ -1,0 +1,8 @@
+---
+date: 2026-05-20
+---
+# What's New in 0.13.1
+
+**Critical fix:** Editing a bookmark's labels no longer wipes its title, site name, and description.
+
+**Steadier sync:** Sync progress now shows a predictable indicator while your bookmarks first load.

--- a/app/src/main/assets/whatsnew/zh/0.13.2.md
+++ b/app/src/main/assets/whatsnew/zh/0.13.2.md
@@ -1,0 +1,8 @@
+---
+date: 2026-05-29
+---
+# What's New in 0.13.2
+
+**Reading time filters:** Filter your list by estimated reading time or word count, including a Min/Max range and an option to include bookmarks with no estimate.
+
+**Fresh-content fix:** The reader no longer briefly shows stale content for a bookmark opened right after adding it, before server-side extraction finishes.

--- a/app/src/main/assets/whatsnew/zh/0.14.0.md
+++ b/app/src/main/assets/whatsnew/zh/0.14.0.md
@@ -1,0 +1,12 @@
+---
+date: 2026-06-04
+---
+# What's New in 0.14.0
+
+**Multi-select:** Long-press a bookmark card to select multiple bookmarks, then favorite, archive, delete, or label them all at once.
+
+**Overflow menu:** The top app bar gains an overflow menu with more bookmark-list actions.
+
+**Native reader bar:** The reader's action bar is now a native control for smoother, more consistent interactions.
+
+**HTTPS-only releases:** Standard release builds now require HTTPS server connections.

--- a/app/src/main/assets/whatsnew/zh/0.14.1.md
+++ b/app/src/main/assets/whatsnew/zh/0.14.1.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-08
+---
+# What's New in 0.14.1
+
+**About screen polish:** Refined the About screen's copy, project links, and license and attribution wording.

--- a/app/src/main/assets/whatsnew/zh/0.14.2.md
+++ b/app/src/main/assets/whatsnew/zh/0.14.2.md
@@ -1,0 +1,12 @@
+---
+date: 2026-06-19
+---
+# What's New in 0.14.2
+
+**Offline pinning:** Pin articles to keep them available offline and protected from automatic cleanup, from bookmark multi-select or the reader's overflow menu.
+
+**Reliable downloads:** Offline downloads reworked so text and images download together and completely, instead of sometimes getting stuck as text-only.
+
+**Storage breakdown:** Settings now shows your current on-device offline storage, split into automatic and pinned content.
+
+**Sync fixes:** Resolved dropped syncs and stuck downloads on flaky networks, "Clear All Offline Content" missing some content, and duplicate bookmarks when saving over a bad connection.

--- a/app/src/main/assets/whatsnew/zh/0.14.3.md
+++ b/app/src/main/assets/whatsnew/zh/0.14.3.md
@@ -1,0 +1,14 @@
+---
+date: 2026-06-27
+---
+# What's New in 0.14.3
+
+**Reorganized settings:** User Interface Settings are now grouped into clear sections: Appearance, Bookmark List, Reading, and Sharing.
+
+**Internal browser toggle:** Choose whether a bookmark's original page opens in the in-app viewer or your device's browser.
+
+**Label search options:** Match the start of a label or anywhere within it, and sort labels alphabetically or by most used.
+
+**Error badges:** A new "With errors" filter finds bookmarks whose content couldn't be extracted, plus card badges mark extraction errors or missing content.
+
+**List tweaks:** Show or hide the add-bookmark button and the Compact layout's website source icons.

--- a/app/src/main/assets/whatsnew/zh/0.14.4.md
+++ b/app/src/main/assets/whatsnew/zh/0.14.4.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-29
+---
+# What's New in 0.14.4
+
+**Sign-in fix:** Corrected sign-in against newer Readeck nightly server builds.

--- a/app/src/main/assets/whatsnew/zh/0.14.5.md
+++ b/app/src/main/assets/whatsnew/zh/0.14.5.md
@@ -1,0 +1,12 @@
+---
+date: 2026-07-03
+---
+# What's New in 0.14.5
+
+**Collections:** Save a set of filter criteria (search, labels, type, date range, and more) as a named, reusable view. Create one from the new Collections screen or "Save as Collection" on any list, layer extra filters on top without changing the saved collection, and rename, edit, or delete it anytime.
+
+**Welcome screen quick access:** Reach About, the User Guide, and Logs before you've even connected to a server.
+
+**User Guide search:** Look up a feature by name and jump straight to it; the guide also gains dedicated pages for Labels, Highlights, Collections, and Offline Reading.
+
+**Clearer sign-in errors:** Better messages when a Readeck server is too old or isn't a Readeck server at all.

--- a/app/src/main/assets/whatsnew/zh/0.9.0.md
+++ b/app/src/main/assets/whatsnew/zh/0.9.0.md
@@ -1,0 +1,24 @@
+---
+date: 2026-02-20
+---
+# What's New in 0.9.0
+
+Welcome to MyDeck. This first release is a comprehensive rebrand and major feature expansion.
+
+**Sign in with a code:** OAuth Device Code authentication. Get a URL and one-time code, authorize in your browser, and the app picks up automatically.
+
+**Redesigned navigation:** A Pocket-style sidebar with My List, Archive, and Favorites, plus item-count badges throughout.
+
+**Three list layouts:** Choose between Grid, Compact, and Mosaic views.
+
+**Reading progress tracking:** See progress at a glance on every card, and pick up right where you left off.
+
+**Labels:** Full label management, one-tap label filtering from bookmark cards, and a dedicated Labels view.
+
+**Article and Original views:** Toggle between Readeck's extracted article content and the original web page.
+
+**Search and typography:** Global search across titles, site names, and labels, plus reading customization (font, size, spacing, width, justification, hyphenation) with in-article Find.
+
+**Works offline:** Actions taken without a connection are queued and applied once you're back online.
+
+**Adaptive layouts:** Tablet and landscape support, and a full visual refresh under Material Design 3.

--- a/app/src/main/assets/whatsnew/zh/0.9.1.md
+++ b/app/src/main/assets/whatsnew/zh/0.9.1.md
@@ -1,0 +1,6 @@
+---
+date: 2026-02-21
+---
+# What's New in 0.9.1
+
+**Read state fix:** Corrected the read/unread icon and label not always matching in the reading view's overflow menu.

--- a/app/src/main/assets/whatsnew/zh/0.9.2.md
+++ b/app/src/main/assets/whatsnew/zh/0.9.2.md
@@ -1,0 +1,8 @@
+---
+date: 2026-02-22
+---
+# What's New in 0.9.2
+
+**Redesigned mobile grid:** Fixed-height cards with a left thumbnail and right content split, and a larger title.
+
+**Fixes:** Resolved a brief blank-state flash on cold start, TopBar jitter during overscroll, and label chips not dismissing pending delete actions before navigating away.

--- a/app/src/main/java/com/mydeck/app/io/prefs/SettingsDataStore.kt
+++ b/app/src/main/java/com/mydeck/app/io/prefs/SettingsDataStore.kt
@@ -124,6 +124,14 @@ interface SettingsDataStore {
     suspend fun saveFullscreenWhileReading(enabled: Boolean)
     suspend fun isFullscreenWhileReading(): Boolean
 
+    // "What's New" on-update sheet: last app version whose notes were shown (or
+    // silently recorded on fresh install), and whether the first-launch guide
+    // nudge has already been shown.
+    suspend fun getLastSeenWhatsNewVersion(): String?
+    suspend fun saveLastSeenWhatsNewVersion(version: String)
+    suspend fun isWelcomeGuidePromptShown(): Boolean
+    suspend fun saveWelcomeGuidePromptShown(shown: Boolean)
+
     // Bookmark list display preferences
     val showCompactFaviconsFlow: StateFlow<Boolean>
     suspend fun saveShowCompactFavicons(enabled: Boolean)

--- a/app/src/main/java/com/mydeck/app/io/prefs/SettingsDataStoreImpl.kt
+++ b/app/src/main/java/com/mydeck/app/io/prefs/SettingsDataStoreImpl.kt
@@ -134,6 +134,9 @@ class SettingsDataStoreImpl @Inject constructor(@ApplicationContext private val 
     private val KEY_SWIPE_LEFT_ACTION = stringPreferencesKey("swipe_left_action")
     private val KEY_SWIPE_RIGHT_ACTION = stringPreferencesKey("swipe_right_action")
 
+    private val KEY_LAST_SEEN_WHATSNEW_VERSION = stringPreferencesKey("last_seen_whatsnew_version")
+    private val KEY_WELCOME_GUIDE_PROMPT_SHOWN = booleanPreferencesKey("welcome_guide_prompt_shown")
+
     init {
         migrateLegacySepiaSetting(encryptedSharedPreferences)
         migrateNonSensitivePreferencesIfNeeded()
@@ -407,6 +410,26 @@ class SettingsDataStoreImpl @Inject constructor(@ApplicationContext private val 
 
     override suspend fun isFullscreenWhileReading(): Boolean {
         return userPreferences.getBoolean(KEY_FULLSCREEN_WHILE_READING.name, false)
+    }
+
+    override suspend fun getLastSeenWhatsNewVersion(): String? {
+        return userPreferences.getString(KEY_LAST_SEEN_WHATSNEW_VERSION.name, null)
+    }
+
+    override suspend fun saveLastSeenWhatsNewVersion(version: String) {
+        userPreferences.edit {
+            putString(KEY_LAST_SEEN_WHATSNEW_VERSION.name, version)
+        }
+    }
+
+    override suspend fun isWelcomeGuidePromptShown(): Boolean {
+        return userPreferences.getBoolean(KEY_WELCOME_GUIDE_PROMPT_SHOWN.name, false)
+    }
+
+    override suspend fun saveWelcomeGuidePromptShown(shown: Boolean) {
+        userPreferences.edit {
+            putBoolean(KEY_WELCOME_GUIDE_PROMPT_SHOWN.name, shown)
+        }
     }
 
     override suspend fun saveShowCompactFavicons(enabled: Boolean) {

--- a/app/src/main/java/com/mydeck/app/ui/about/AboutScreen.kt
+++ b/app/src/main/java/com/mydeck/app/ui/about/AboutScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Link
 import androidx.compose.material.icons.filled.List
+import androidx.compose.material.icons.filled.NewReleases
 import androidx.compose.material.icons.filled.TextFields
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -54,6 +55,7 @@ import com.mydeck.app.domain.model.CachedServerInfo
 import com.mydeck.app.ui.components.MyDeckBrandHeader
 import com.mydeck.app.ui.navigation.FontLicensesRoute
 import com.mydeck.app.ui.navigation.OpenSourceLibrariesRoute
+import com.mydeck.app.ui.whatsnew.WhatsNewSheet
 import com.mydeck.app.util.openUrlInCustomTab
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -88,6 +90,8 @@ fun AboutScreen(navHostController: NavHostController, showBackButton: Boolean = 
         onBackClick = { viewModel.onClickBack() },
         onOpenSourceLibrariesClick = { viewModel.onClickOpenSourceLibraries() },
         onFontLicensesClick = { viewModel.onClickFontLicenses() },
+        onWhatsNewClick = { viewModel.onClickWhatsNew() },
+        onDismissWhatsNewSheet = { viewModel.onDismissWhatsNewSheet() },
         onUrlClick = { url -> openUrlInCustomTab(context, url) },
         showBackButton = showBackButton,
     )
@@ -101,6 +105,8 @@ fun AboutScreenContent(
     onBackClick: () -> Unit,
     onOpenSourceLibrariesClick: () -> Unit,
     onFontLicensesClick: () -> Unit = {},
+    onWhatsNewClick: () -> Unit = {},
+    onDismissWhatsNewSheet: () -> Unit = {},
     onUrlClick: (String) -> Unit,
     showBackButton: Boolean = true,
 ) {
@@ -157,6 +163,38 @@ fun AboutScreenContent(
             )
 
             Spacer(modifier = Modifier.height(24.dp))
+
+            // What's New Link (only when notes exist for the current version)
+            if (uiState.whatsNewContent != null) {
+                HorizontalDivider()
+                Spacer(modifier = Modifier.height(16.dp))
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { onWhatsNewClick() }
+                        .padding(vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Icon(
+                        Icons.Filled.NewReleases,
+                        contentDescription = stringResource(R.string.about_whats_new),
+                        modifier = Modifier.padding(end = 16.dp)
+                    )
+                    Column {
+                        Text(
+                            text = stringResource(R.string.about_whats_new),
+                            style = MaterialTheme.typography.titleMedium
+                        )
+                        Text(
+                            text = stringResource(R.string.about_whats_new_subtitle),
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(24.dp))
+            }
 
             // Credits Section
             HorizontalDivider()
@@ -471,6 +509,14 @@ fun AboutScreenContent(
 
             Spacer(modifier = Modifier.height(16.dp))
         }
+    }
+
+    if (uiState.showWhatsNewSheet && uiState.whatsNewContent != null) {
+        WhatsNewSheet(
+            version = uiState.whatsNewVersion,
+            content = uiState.whatsNewContent,
+            onDismiss = onDismissWhatsNewSheet,
+        )
     }
 }
 

--- a/app/src/main/java/com/mydeck/app/ui/about/AboutScreen.kt
+++ b/app/src/main/java/com/mydeck/app/ui/about/AboutScreen.kt
@@ -56,6 +56,7 @@ import com.mydeck.app.ui.components.MyDeckBrandHeader
 import com.mydeck.app.ui.navigation.FontLicensesRoute
 import com.mydeck.app.ui.navigation.OpenSourceLibrariesRoute
 import com.mydeck.app.ui.navigation.WhatsNewHistoryRoute
+import com.mydeck.app.ui.whatsnew.WhatsNewSheet
 import com.mydeck.app.util.openUrlInCustomTab
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -94,6 +95,8 @@ fun AboutScreen(navHostController: NavHostController, showBackButton: Boolean = 
         onOpenSourceLibrariesClick = { viewModel.onClickOpenSourceLibraries() },
         onFontLicensesClick = { viewModel.onClickFontLicenses() },
         onWhatsNewClick = { viewModel.onClickWhatsNew() },
+        onWhatsNewDismiss = { viewModel.onDismissWhatsNewSheet() },
+        onWhatsNewHistoryClick = { viewModel.onClickWhatsNewHistory() },
         onUrlClick = { url -> openUrlInCustomTab(context, url) },
         showBackButton = showBackButton,
     )
@@ -108,6 +111,8 @@ fun AboutScreenContent(
     onOpenSourceLibrariesClick: () -> Unit,
     onFontLicensesClick: () -> Unit = {},
     onWhatsNewClick: () -> Unit = {},
+    onWhatsNewDismiss: () -> Unit = {},
+    onWhatsNewHistoryClick: () -> Unit = {},
     onUrlClick: (String) -> Unit,
     showBackButton: Boolean = true,
 ) {
@@ -510,6 +515,17 @@ fun AboutScreenContent(
 
             Spacer(modifier = Modifier.height(16.dp))
         }
+    }
+
+    val whatsNewVersion = uiState.whatsNewVersion
+    val whatsNewContent = uiState.whatsNewContent
+    if (whatsNewVersion != null && whatsNewContent != null) {
+        WhatsNewSheet(
+            version = whatsNewVersion,
+            content = whatsNewContent,
+            onDismiss = onWhatsNewDismiss,
+            onSeePreviousReleases = onWhatsNewHistoryClick,
+        )
     }
 }
 

--- a/app/src/main/java/com/mydeck/app/ui/about/AboutScreen.kt
+++ b/app/src/main/java/com/mydeck/app/ui/about/AboutScreen.kt
@@ -55,7 +55,7 @@ import com.mydeck.app.domain.model.CachedServerInfo
 import com.mydeck.app.ui.components.MyDeckBrandHeader
 import com.mydeck.app.ui.navigation.FontLicensesRoute
 import com.mydeck.app.ui.navigation.OpenSourceLibrariesRoute
-import com.mydeck.app.ui.whatsnew.WhatsNewSheet
+import com.mydeck.app.ui.navigation.WhatsNewHistoryRoute
 import com.mydeck.app.util.openUrlInCustomTab
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -78,6 +78,9 @@ fun AboutScreen(navHostController: NavHostController, showBackButton: Boolean = 
                 AboutViewModel.NavigationEvent.NavigateToFontLicenses -> {
                     navHostController.navigate(FontLicensesRoute) { launchSingleTop = true }
                 }
+                AboutViewModel.NavigationEvent.NavigateToWhatsNewHistory -> {
+                    navHostController.navigate(WhatsNewHistoryRoute) { launchSingleTop = true }
+                }
             }
         }
     }
@@ -91,7 +94,6 @@ fun AboutScreen(navHostController: NavHostController, showBackButton: Boolean = 
         onOpenSourceLibrariesClick = { viewModel.onClickOpenSourceLibraries() },
         onFontLicensesClick = { viewModel.onClickFontLicenses() },
         onWhatsNewClick = { viewModel.onClickWhatsNew() },
-        onDismissWhatsNewSheet = { viewModel.onDismissWhatsNewSheet() },
         onUrlClick = { url -> openUrlInCustomTab(context, url) },
         showBackButton = showBackButton,
     )
@@ -106,7 +108,6 @@ fun AboutScreenContent(
     onOpenSourceLibrariesClick: () -> Unit,
     onFontLicensesClick: () -> Unit = {},
     onWhatsNewClick: () -> Unit = {},
-    onDismissWhatsNewSheet: () -> Unit = {},
     onUrlClick: (String) -> Unit,
     showBackButton: Boolean = true,
 ) {
@@ -164,8 +165,8 @@ fun AboutScreenContent(
 
             Spacer(modifier = Modifier.height(24.dp))
 
-            // What's New Link (only when notes exist for the current version)
-            if (uiState.whatsNewContent != null) {
+            // What's New Link (only when there is any release history to show)
+            if (uiState.hasWhatsNewHistory) {
                 HorizontalDivider()
                 Spacer(modifier = Modifier.height(16.dp))
 
@@ -509,14 +510,6 @@ fun AboutScreenContent(
 
             Spacer(modifier = Modifier.height(16.dp))
         }
-    }
-
-    if (uiState.showWhatsNewSheet && uiState.whatsNewContent != null) {
-        WhatsNewSheet(
-            version = uiState.whatsNewVersion,
-            content = uiState.whatsNewContent,
-            onDismiss = onDismissWhatsNewSheet,
-        )
     }
 }
 

--- a/app/src/main/java/com/mydeck/app/ui/about/AboutViewModel.kt
+++ b/app/src/main/java/com/mydeck/app/ui/about/AboutViewModel.kt
@@ -1,12 +1,16 @@
 package com.mydeck.app.ui.about
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import com.mydeck.app.domain.model.CachedServerInfo
 import com.mydeck.app.domain.sync.ConnectivityMonitor
 import com.mydeck.app.io.prefs.SettingsDataStore
 import com.mydeck.app.io.rest.ReadeckApi
+import com.mydeck.app.ui.whatsnew.WhatsNewAssetLoader
+import com.mydeck.app.util.AppVersion
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -22,15 +26,20 @@ import javax.inject.Inject
 
 @HiltViewModel
 class AboutViewModel @Inject constructor(
+    @ApplicationContext private val context: Context,
     private val settingsDataStore: SettingsDataStore,
     private val connectivityMonitor: ConnectivityMonitor,
     private val readeckApi: ReadeckApi,
+    private val whatsNewLoader: WhatsNewAssetLoader,
 ) : ViewModel() {
 
     data class UiState(
         val serverInfo: CachedServerInfo? = null,
         val serverInfoLoading: Boolean = false,
-        val serverInfoError: Boolean = false
+        val serverInfoError: Boolean = false,
+        val showWhatsNewSheet: Boolean = false,
+        val whatsNewContent: String? = null,
+        val whatsNewVersion: String = "",
     )
 
     private val _navigationEvent = Channel<NavigationEvent>(Channel.BUFFERED)
@@ -44,6 +53,15 @@ class AboutViewModel @Inject constructor(
 
     init {
         loadAndRefreshServerInfo()
+        loadWhatsNewContent()
+    }
+
+    private fun loadWhatsNewContent() {
+        viewModelScope.launch {
+            val version = WhatsNewAssetLoader.normalizeVersion(AppVersion.versionName(context))
+            val content = whatsNewLoader.loadNotesForVersion(version)
+            _uiState.value = _uiState.value.copy(whatsNewContent = content, whatsNewVersion = version)
+        }
     }
 
     private fun loadAndRefreshServerInfo() {
@@ -136,6 +154,14 @@ class AboutViewModel @Inject constructor(
 
     fun onClickFontLicenses() {
         _navigationEvent.trySend(NavigationEvent.NavigateToFontLicenses)
+    }
+
+    fun onClickWhatsNew() {
+        _uiState.value = _uiState.value.copy(showWhatsNewSheet = true)
+    }
+
+    fun onDismissWhatsNewSheet() {
+        _uiState.value = _uiState.value.copy(showWhatsNewSheet = false)
     }
 
     sealed class NavigationEvent {

--- a/app/src/main/java/com/mydeck/app/ui/about/AboutViewModel.kt
+++ b/app/src/main/java/com/mydeck/app/ui/about/AboutViewModel.kt
@@ -1,16 +1,13 @@
 package com.mydeck.app.ui.about
 
-import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import com.mydeck.app.domain.model.CachedServerInfo
 import com.mydeck.app.domain.sync.ConnectivityMonitor
 import com.mydeck.app.io.prefs.SettingsDataStore
 import com.mydeck.app.io.rest.ReadeckApi
 import com.mydeck.app.ui.whatsnew.WhatsNewAssetLoader
-import com.mydeck.app.util.AppVersion
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -26,7 +23,6 @@ import javax.inject.Inject
 
 @HiltViewModel
 class AboutViewModel @Inject constructor(
-    @ApplicationContext private val context: Context,
     private val settingsDataStore: SettingsDataStore,
     private val connectivityMonitor: ConnectivityMonitor,
     private val readeckApi: ReadeckApi,
@@ -37,9 +33,7 @@ class AboutViewModel @Inject constructor(
         val serverInfo: CachedServerInfo? = null,
         val serverInfoLoading: Boolean = false,
         val serverInfoError: Boolean = false,
-        val showWhatsNewSheet: Boolean = false,
-        val whatsNewContent: String? = null,
-        val whatsNewVersion: String = "",
+        val hasWhatsNewHistory: Boolean = false,
     )
 
     private val _navigationEvent = Channel<NavigationEvent>(Channel.BUFFERED)
@@ -53,14 +47,13 @@ class AboutViewModel @Inject constructor(
 
     init {
         loadAndRefreshServerInfo()
-        loadWhatsNewContent()
+        checkWhatsNewHistoryAvailable()
     }
 
-    private fun loadWhatsNewContent() {
+    private fun checkWhatsNewHistoryAvailable() {
         viewModelScope.launch {
-            val version = WhatsNewAssetLoader.normalizeVersion(AppVersion.versionName(context))
-            val content = whatsNewLoader.loadNotesForVersion(version)
-            _uiState.value = _uiState.value.copy(whatsNewContent = content, whatsNewVersion = version)
+            val hasHistory = whatsNewLoader.listAvailableVersions().isNotEmpty()
+            _uiState.value = _uiState.value.copy(hasWhatsNewHistory = hasHistory)
         }
     }
 
@@ -157,16 +150,13 @@ class AboutViewModel @Inject constructor(
     }
 
     fun onClickWhatsNew() {
-        _uiState.value = _uiState.value.copy(showWhatsNewSheet = true)
-    }
-
-    fun onDismissWhatsNewSheet() {
-        _uiState.value = _uiState.value.copy(showWhatsNewSheet = false)
+        _navigationEvent.trySend(NavigationEvent.NavigateToWhatsNewHistory)
     }
 
     sealed class NavigationEvent {
         data object NavigateBack : NavigationEvent()
         data object NavigateToOpenSourceLibraries : NavigationEvent()
         data object NavigateToFontLicenses : NavigationEvent()
+        data object NavigateToWhatsNewHistory : NavigationEvent()
     }
 }

--- a/app/src/main/java/com/mydeck/app/ui/about/AboutViewModel.kt
+++ b/app/src/main/java/com/mydeck/app/ui/about/AboutViewModel.kt
@@ -1,13 +1,16 @@
 package com.mydeck.app.ui.about
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import dagger.hilt.android.lifecycle.HiltViewModel
 import com.mydeck.app.domain.model.CachedServerInfo
 import com.mydeck.app.domain.sync.ConnectivityMonitor
 import com.mydeck.app.io.prefs.SettingsDataStore
 import com.mydeck.app.io.rest.ReadeckApi
 import com.mydeck.app.ui.whatsnew.WhatsNewAssetLoader
+import com.mydeck.app.util.AppVersion
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -23,6 +26,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class AboutViewModel @Inject constructor(
+    @ApplicationContext private val context: Context,
     private val settingsDataStore: SettingsDataStore,
     private val connectivityMonitor: ConnectivityMonitor,
     private val readeckApi: ReadeckApi,
@@ -34,6 +38,8 @@ class AboutViewModel @Inject constructor(
         val serverInfoLoading: Boolean = false,
         val serverInfoError: Boolean = false,
         val hasWhatsNewHistory: Boolean = false,
+        val whatsNewVersion: String? = null,
+        val whatsNewContent: String? = null,
     )
 
     private val _navigationEvent = Channel<NavigationEvent>(Channel.BUFFERED)
@@ -150,6 +156,29 @@ class AboutViewModel @Inject constructor(
     }
 
     fun onClickWhatsNew() {
+        viewModelScope.launch {
+            val currentVersion = WhatsNewAssetLoader.normalizeVersion(AppVersion.versionName(context))
+            val content = whatsNewLoader.loadNotesForVersion(currentVersion)
+            if (content != null) {
+                _uiState.value = _uiState.value.copy(
+                    whatsNewVersion = currentVersion,
+                    whatsNewContent = content,
+                )
+            } else {
+                _navigationEvent.trySend(NavigationEvent.NavigateToWhatsNewHistory)
+            }
+        }
+    }
+
+    fun onDismissWhatsNewSheet() {
+        _uiState.value = _uiState.value.copy(
+            whatsNewVersion = null,
+            whatsNewContent = null,
+        )
+    }
+
+    fun onClickWhatsNewHistory() {
+        onDismissWhatsNewSheet()
         _navigationEvent.trySend(NavigationEvent.NavigateToWhatsNewHistory)
     }
 

--- a/app/src/main/java/com/mydeck/app/ui/navigation/Routes.kt
+++ b/app/src/main/java/com/mydeck/app/ui/navigation/Routes.kt
@@ -46,6 +46,9 @@ object UiSettingsRoute
 object AboutRoute
 
 @Serializable
+object WhatsNewHistoryRoute
+
+@Serializable
 object UserGuideRoute
 
 @Serializable

--- a/app/src/main/java/com/mydeck/app/ui/shell/AppShell.kt
+++ b/app/src/main/java/com/mydeck/app/ui/shell/AppShell.kt
@@ -66,6 +66,7 @@ import com.mydeck.app.ui.navigation.UiSettingsRoute
 import com.mydeck.app.ui.navigation.UserGuideRoute
 import com.mydeck.app.ui.navigation.UserGuideSectionRoute
 import com.mydeck.app.ui.navigation.WelcomeRoute
+import com.mydeck.app.ui.navigation.WhatsNewHistoryRoute
 import com.mydeck.app.ui.collections.CollectionsScreen
 import com.mydeck.app.ui.highlights.HighlightsScreen
 import com.mydeck.app.ui.settings.AccountSettingsScreen
@@ -79,6 +80,7 @@ import com.mydeck.app.ui.userguide.UserGuideIndexScreen
 import com.mydeck.app.ui.userguide.UserGuideSectionScreen
 import com.mydeck.app.ui.welcome.WelcomeScreen
 import com.mydeck.app.ui.whatsnew.WelcomeGuideNudgeDialog
+import com.mydeck.app.ui.whatsnew.WhatsNewHistoryScreen
 import com.mydeck.app.ui.whatsnew.WhatsNewSheet
 import com.mydeck.app.ui.whatsnew.WhatsNewViewModel
 import kotlinx.coroutines.flow.collectLatest
@@ -198,6 +200,10 @@ fun AppShell(
             version = whatsNewState.whatsNewVersion,
             content = content,
             onDismiss = whatsNewViewModel::onWhatsNewDismissed,
+            onSeePreviousReleases = {
+                whatsNewViewModel.onWhatsNewDismissed()
+                navController.navigate(WhatsNewHistoryRoute) { launchSingleTop = true }
+            },
         )
     }
     if (whatsNewState.showGuideNudge) {
@@ -436,6 +442,9 @@ private fun CompactAppShell(
                 composable<AboutRoute> {
                     AboutScreen(navHostController = navController)
                 }
+                composable<WhatsNewHistoryRoute> {
+                    WhatsNewHistoryScreen(navHostController = navController)
+                }
             }
         }
     }
@@ -661,6 +670,9 @@ private fun AppShellNavHost(
             }
             composable<AboutRoute> {
                 AboutScreen(navHostController = navController, showBackButton = false)
+            }
+            composable<WhatsNewHistoryRoute> {
+                WhatsNewHistoryScreen(navHostController = navController)
             }
         }
     }

--- a/app/src/main/java/com/mydeck/app/ui/shell/AppShell.kt
+++ b/app/src/main/java/com/mydeck/app/ui/shell/AppShell.kt
@@ -78,6 +78,9 @@ import com.mydeck.app.ui.settings.UiSettingsScreen
 import com.mydeck.app.ui.userguide.UserGuideIndexScreen
 import com.mydeck.app.ui.userguide.UserGuideSectionScreen
 import com.mydeck.app.ui.welcome.WelcomeScreen
+import com.mydeck.app.ui.whatsnew.WelcomeGuideNudgeDialog
+import com.mydeck.app.ui.whatsnew.WhatsNewSheet
+import com.mydeck.app.ui.whatsnew.WhatsNewViewModel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
@@ -129,6 +132,19 @@ fun AppShell(
 
     val isCollectionsScreen = currentDestination.matchesRoute<CollectionsRoute>()
 
+    // "What's New" on-update sheet + first-launch guide nudge. Lives once, here
+    // at the top-level shell (rather than duplicated in each layout tier below),
+    // since ModalBottomSheet/AlertDialog render into their own window regardless
+    // of which tier's NavHost is active.
+    val whatsNewViewModel: WhatsNewViewModel = hiltViewModel()
+    val whatsNewState = whatsNewViewModel.uiState
+    val token = settingsDataStore?.tokenFlow?.collectAsState()?.value
+    LaunchedEffect(token) {
+        if (!token.isNullOrBlank()) {
+            whatsNewViewModel.evaluateIfNeeded()
+        }
+    }
+
     when (layoutTier) {
         "compact" -> CompositionLocalProvider(
             LocalReaderMaxWidth provides Dp.Unspecified,
@@ -175,6 +191,23 @@ fun AppShell(
             collectionCount = collectionCount.value.size,
         )
         } // end MediumAppShell CompositionLocalProvider
+    }
+
+    whatsNewState.whatsNewContent?.let { content ->
+        WhatsNewSheet(
+            version = whatsNewState.whatsNewVersion,
+            content = content,
+            onDismiss = whatsNewViewModel::onWhatsNewDismissed,
+        )
+    }
+    if (whatsNewState.showGuideNudge) {
+        WelcomeGuideNudgeDialog(
+            onOpenGuide = {
+                whatsNewViewModel.onGuideNudgeOpenGuide()
+                navController.navigate(UserGuideRoute) { launchSingleTop = true }
+            },
+            onDismiss = whatsNewViewModel::onGuideNudgeDismissed,
+        )
     }
 }
 

--- a/app/src/main/java/com/mydeck/app/ui/whatsnew/WelcomeGuideNudgeDialog.kt
+++ b/app/src/main/java/com/mydeck/app/ui/whatsnew/WelcomeGuideNudgeDialog.kt
@@ -1,0 +1,30 @@
+package com.mydeck.app.ui.whatsnew
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.mydeck.app.R
+
+@Composable
+fun WelcomeGuideNudgeDialog(
+    onOpenGuide: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.whats_new_guide_nudge_title)) },
+        text = { Text(stringResource(R.string.whats_new_guide_nudge_body)) },
+        confirmButton = {
+            TextButton(onClick = onOpenGuide) {
+                Text(stringResource(R.string.whats_new_guide_nudge_open_guide))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.whats_new_guide_nudge_not_now))
+            }
+        }
+    )
+}

--- a/app/src/main/java/com/mydeck/app/ui/whatsnew/WhatsNewAssetLoader.kt
+++ b/app/src/main/java/com/mydeck/app/ui/whatsnew/WhatsNewAssetLoader.kt
@@ -6,6 +6,10 @@ import java.io.IOException
 import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.datetime.LocalDate
+
+/** A version with notes, plus the release date parsed from its frontmatter (if any). */
+data class WhatsNewHistoryEntry(val version: String, val date: LocalDate?)
 
 @Singleton
 class WhatsNewAssetLoader @Inject constructor(
@@ -58,6 +62,25 @@ class WhatsNewAssetLoader @Inject constructor(
             val main = parts[0].split(".").map { it.toIntOrNull() ?: 0 }
             return main to parts.getOrNull(1)
         }
+
+        /**
+         * Parses an optional `date: YYYY-MM-DD` field from a leading YAML
+         * frontmatter block (`--- ... ---`). Returns null if there's no
+         * frontmatter, no date field, or the date fails to parse — a
+         * missing/malformed date just means the history list shows no date for
+         * that entry, not an error.
+         */
+        fun parseFrontmatterDate(raw: String): LocalDate? {
+            val frontmatter = Regex("^---([\\s\\S]*?)---").find(raw)?.groupValues?.get(1)
+                ?: return null
+            val dateStr = Regex("""date:\s*(\S+)""").find(frontmatter)?.groupValues?.get(1)
+                ?: return null
+            return try {
+                LocalDate.parse(dateStr)
+            } catch (e: IllegalArgumentException) {
+                null
+            }
+        }
     }
 
     private fun getLocalePath(): String {
@@ -66,26 +89,30 @@ class WhatsNewAssetLoader @Inject constructor(
         return "$ASSETS_BASE_PATH/$locale"
     }
 
-    /**
-     * Loads the notes for [version], or null if no notes exist for that exact
-     * version — the expected outcome for rc/snapshot builds, not an error.
-     */
-    fun loadNotesForVersion(version: String): String? {
+    private fun readRawFile(version: String): String? {
         val localePath = getLocalePath()
         return try {
-            val raw = context.assets.open("$localePath/$version.md").use { inputStream ->
+            context.assets.open("$localePath/$version.md").use { inputStream ->
                 inputStream.bufferedReader().use { reader -> reader.readText() }
             }
-            raw
-                .replace(Regex("^---[\\s\\S]*?---\\n*"), "")
-                .replace(Regex("^# [^\n]+\\n+"), "")
         } catch (e: IOException) {
             null
         }
     }
 
+    /**
+     * Loads the notes for [version], or null if no notes exist for that exact
+     * version — the expected outcome for rc/snapshot builds, not an error.
+     */
+    fun loadNotesForVersion(version: String): String? {
+        val raw = readRawFile(version) ?: return null
+        return raw
+            .replace(Regex("^---[\\s\\S]*?---\\n*"), "")
+            .replace(Regex("^# [^\n]+\\n+"), "")
+    }
+
     /** All versions with notes for the resolved locale, newest first. */
-    fun listAvailableVersions(): List<String> {
+    fun listAvailableVersions(): List<WhatsNewHistoryEntry> {
         val localePath = getLocalePath()
         val versions = try {
             context.assets.list(localePath)
@@ -95,6 +122,8 @@ class WhatsNewAssetLoader @Inject constructor(
         } catch (e: IOException) {
             emptyList()
         }
-        return versions.sortedWith { a, b -> compareVersions(b, a) }
+        return versions
+            .sortedWith { a, b -> compareVersions(b, a) }
+            .map { version -> WhatsNewHistoryEntry(version, readRawFile(version)?.let(::parseFrontmatterDate)) }
     }
 }

--- a/app/src/main/java/com/mydeck/app/ui/whatsnew/WhatsNewAssetLoader.kt
+++ b/app/src/main/java/com/mydeck/app/ui/whatsnew/WhatsNewAssetLoader.kt
@@ -1,0 +1,55 @@
+package com.mydeck.app.ui.whatsnew
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.IOException
+import java.util.Locale
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class WhatsNewAssetLoader @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+
+    companion object {
+        private const val ASSETS_BASE_PATH = "whatsnew"
+        private const val DEFAULT_LOCALE = "en"
+        private val SUPPORTED_LOCALES =
+            listOf("en", "de", "es", "fr", "gl", "pl", "pt", "ru", "uk", "zh")
+        private const val SNAPSHOT_SUFFIX = "-snapshot"
+
+        /**
+         * Snapshot builds append "-snapshot" to the release versionName (see
+         * `SNAPSHOT_VERSION_NAME` handling in app/build.gradle.kts). What's New
+         * content is authored against the release version string, so strip that
+         * suffix before comparing/looking up notes — this lets a snapshot build
+         * preview the upcoming release's notes rather than never matching.
+         */
+        fun normalizeVersion(versionName: String): String = versionName.removeSuffix(SNAPSHOT_SUFFIX)
+    }
+
+    private fun getLocalePath(): String {
+        val currentLocale = Locale.getDefault().language
+        val locale = if (currentLocale in SUPPORTED_LOCALES) currentLocale else DEFAULT_LOCALE
+        return "$ASSETS_BASE_PATH/$locale"
+    }
+
+    /**
+     * Loads the notes for [version], or null if no notes exist for that exact
+     * version — the expected outcome for rc/snapshot builds, not an error.
+     */
+    fun loadNotesForVersion(version: String): String? {
+        val localePath = getLocalePath()
+        return try {
+            val raw = context.assets.open("$localePath/$version.md").use { inputStream ->
+                inputStream.bufferedReader().use { reader -> reader.readText() }
+            }
+            raw
+                .replace(Regex("^---[\\s\\S]*?---\\n*"), "")
+                .replace(Regex("^# [^\n]+\\n+"), "")
+        } catch (e: IOException) {
+            null
+        }
+    }
+}

--- a/app/src/main/java/com/mydeck/app/ui/whatsnew/WhatsNewAssetLoader.kt
+++ b/app/src/main/java/com/mydeck/app/ui/whatsnew/WhatsNewAssetLoader.kt
@@ -27,6 +27,37 @@ class WhatsNewAssetLoader @Inject constructor(
          * preview the upcoming release's notes rather than never matching.
          */
         fun normalizeVersion(versionName: String): String = versionName.removeSuffix(SNAPSHOT_SUFFIX)
+
+        /**
+         * Compares two `X.Y.Z[-preRelease]` version strings, newest-first when
+         * used with [sortedWith] directly (returns > 0 when [a] is newer than
+         * [b]). Numeric-component comparison so "1.0.10" sorts after "1.0.9"
+         * (a plain string sort would get this backwards); a version with no
+         * pre-release suffix is newer than one with (a release supersedes its
+         * own rc's), and two pre-release suffixes compare by their trailing
+         * digits (so "rc10" sorts after "rc9").
+         */
+        fun compareVersions(a: String, b: String): Int {
+            val (aMain, aPre) = splitVersion(a)
+            val (bMain, bPre) = splitVersion(b)
+            val maxParts = maxOf(aMain.size, bMain.size)
+            for (i in 0 until maxParts) {
+                val cmp = aMain.getOrElse(i) { 0 }.compareTo(bMain.getOrElse(i) { 0 })
+                if (cmp != 0) return cmp
+            }
+            if (aPre == null && bPre != null) return 1
+            if (aPre != null && bPre == null) return -1
+            if (aPre == null && bPre == null) return 0
+            val aPreNum = aPre.orEmpty().filter { it.isDigit() }.toIntOrNull() ?: 0
+            val bPreNum = bPre.orEmpty().filter { it.isDigit() }.toIntOrNull() ?: 0
+            return aPreNum.compareTo(bPreNum)
+        }
+
+        private fun splitVersion(version: String): Pair<List<Int>, String?> {
+            val parts = version.split("-", limit = 2)
+            val main = parts[0].split(".").map { it.toIntOrNull() ?: 0 }
+            return main to parts.getOrNull(1)
+        }
     }
 
     private fun getLocalePath(): String {
@@ -51,5 +82,19 @@ class WhatsNewAssetLoader @Inject constructor(
         } catch (e: IOException) {
             null
         }
+    }
+
+    /** All versions with notes for the resolved locale, newest first. */
+    fun listAvailableVersions(): List<String> {
+        val localePath = getLocalePath()
+        val versions = try {
+            context.assets.list(localePath)
+                ?.filter { it.endsWith(".md") }
+                ?.map { it.removeSuffix(".md") }
+                ?: emptyList()
+        } catch (e: IOException) {
+            emptyList()
+        }
+        return versions.sortedWith { a, b -> compareVersions(b, a) }
     }
 }

--- a/app/src/main/java/com/mydeck/app/ui/whatsnew/WhatsNewHistoryScreen.kt
+++ b/app/src/main/java/com/mydeck/app/ui/whatsnew/WhatsNewHistoryScreen.kt
@@ -1,0 +1,91 @@
+package com.mydeck.app.ui.whatsnew
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavHostController
+import com.mydeck.app.R
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun WhatsNewHistoryScreen(
+    navHostController: NavHostController,
+) {
+    val viewModel: WhatsNewHistoryViewModel = hiltViewModel()
+    val uiState = viewModel.uiState
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.whats_new_history_title)) },
+                navigationIcon = {
+                    IconButton(onClick = { navHostController.popBackStack() }) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.back)
+                        )
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        if (uiState.versions.isEmpty()) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = stringResource(R.string.whats_new_history_empty),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        } else {
+            LazyColumn(modifier = Modifier.padding(padding)) {
+                items(uiState.versions) { version ->
+                    Text(
+                        text = version,
+                        style = MaterialTheme.typography.titleMedium,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { viewModel.onVersionClick(version) }
+                            .padding(horizontal = 16.dp, vertical = 16.dp)
+                    )
+                    HorizontalDivider()
+                }
+            }
+        }
+    }
+
+    val selectedContent = uiState.selectedContent
+    val selectedVersion = uiState.selectedVersion
+    if (selectedContent != null && selectedVersion != null) {
+        WhatsNewSheet(
+            version = selectedVersion,
+            content = selectedContent,
+            onDismiss = viewModel::onSheetDismissed,
+        )
+    }
+}

--- a/app/src/main/java/com/mydeck/app/ui/whatsnew/WhatsNewHistoryScreen.kt
+++ b/app/src/main/java/com/mydeck/app/ui/whatsnew/WhatsNewHistoryScreen.kt
@@ -2,6 +2,7 @@ package com.mydeck.app.ui.whatsnew
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -64,15 +65,25 @@ fun WhatsNewHistoryScreen(
             }
         } else {
             LazyColumn(modifier = Modifier.padding(padding)) {
-                items(uiState.versions) { version ->
-                    Text(
-                        text = version,
-                        style = MaterialTheme.typography.titleMedium,
+                items(uiState.versions) { entry ->
+                    Column(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .clickable { viewModel.onVersionClick(version) }
+                            .clickable { viewModel.onVersionClick(entry.version) }
                             .padding(horizontal = 16.dp, vertical = 16.dp)
-                    )
+                    ) {
+                        Text(
+                            text = entry.version,
+                            style = MaterialTheme.typography.titleMedium
+                        )
+                        if (entry.date != null) {
+                            Text(
+                                text = entry.date.toString(),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
                     HorizontalDivider()
                 }
             }

--- a/app/src/main/java/com/mydeck/app/ui/whatsnew/WhatsNewHistoryViewModel.kt
+++ b/app/src/main/java/com/mydeck/app/ui/whatsnew/WhatsNewHistoryViewModel.kt
@@ -36,7 +36,7 @@ class WhatsNewHistoryViewModel @Inject constructor(
 }
 
 data class WhatsNewHistoryUiState(
-    val versions: List<String> = emptyList(),
+    val versions: List<WhatsNewHistoryEntry> = emptyList(),
     val selectedVersion: String? = null,
     val selectedContent: String? = null,
 )

--- a/app/src/main/java/com/mydeck/app/ui/whatsnew/WhatsNewHistoryViewModel.kt
+++ b/app/src/main/java/com/mydeck/app/ui/whatsnew/WhatsNewHistoryViewModel.kt
@@ -1,0 +1,42 @@
+package com.mydeck.app.ui.whatsnew
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class WhatsNewHistoryViewModel @Inject constructor(
+    private val loader: WhatsNewAssetLoader,
+) : ViewModel() {
+
+    var uiState by mutableStateOf(WhatsNewHistoryUiState())
+        private set
+
+    init {
+        uiState = uiState.copy(versions = loader.listAvailableVersions())
+    }
+
+    fun onVersionClick(version: String) {
+        viewModelScope.launch {
+            val content = loader.loadNotesForVersion(version)
+            if (content != null) {
+                uiState = uiState.copy(selectedVersion = version, selectedContent = content)
+            }
+        }
+    }
+
+    fun onSheetDismissed() {
+        uiState = uiState.copy(selectedVersion = null, selectedContent = null)
+    }
+}
+
+data class WhatsNewHistoryUiState(
+    val versions: List<String> = emptyList(),
+    val selectedVersion: String? = null,
+    val selectedContent: String? = null,
+)

--- a/app/src/main/java/com/mydeck/app/ui/whatsnew/WhatsNewSheet.kt
+++ b/app/src/main/java/com/mydeck/app/ui/whatsnew/WhatsNewSheet.kt
@@ -28,6 +28,7 @@ fun WhatsNewSheet(
     version: String,
     content: String,
     onDismiss: () -> Unit,
+    onSeePreviousReleases: (() -> Unit)? = null,
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val scope = rememberCoroutineScope()
@@ -71,12 +72,26 @@ fun WhatsNewSheet(
                 onClick = { scope.dismissSheet(sheetState) { onDismiss() } },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(vertical = 16.dp)
+                    .padding(top = 16.dp)
             ) {
                 Text(
                     text = stringResource(R.string.whats_new_got_it),
                     modifier = Modifier.padding(4.dp)
                 )
+            }
+
+            if (onSeePreviousReleases != null) {
+                TextButton(
+                    onClick = { scope.dismissSheet(sheetState) { onSeePreviousReleases() } },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = 16.dp)
+                ) {
+                    Text(
+                        text = stringResource(R.string.whats_new_see_previous_releases),
+                        modifier = Modifier.padding(4.dp)
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/mydeck/app/ui/whatsnew/WhatsNewSheet.kt
+++ b/app/src/main/java/com/mydeck/app/ui/whatsnew/WhatsNewSheet.kt
@@ -1,0 +1,83 @@
+package com.mydeck.app.ui.whatsnew
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import android.text.method.LinkMovementMethod
+import androidx.compose.ui.viewinterop.AndroidView
+import android.widget.TextView
+import com.mydeck.app.R
+import com.mydeck.app.ui.components.dismissSheet
+import com.mydeck.app.ui.userguide.applyMarkwonColors
+import com.mydeck.app.ui.userguide.rememberMarkwon
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun WhatsNewSheet(
+    version: String,
+    content: String,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val scope = rememberCoroutineScope()
+    val colorScheme = MaterialTheme.colorScheme
+    val markwon = rememberMarkwon(onSectionNavigate = {})
+
+    ModalBottomSheet(
+        onDismissRequest = { scope.dismissSheet(sheetState) { onDismiss() } },
+        sheetState = sheetState,
+    ) {
+        Column(modifier = Modifier.padding(horizontal = 24.dp)) {
+            Text(
+                text = stringResource(R.string.whats_new_title),
+                style = MaterialTheme.typography.headlineSmall
+            )
+            Text(
+                text = version,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            AndroidView(
+                factory = { ctx ->
+                    TextView(ctx).apply {
+                        setPadding(0, 32, 0, 0)
+                        setTextIsSelectable(true)
+                        movementMethod = LinkMovementMethod.getInstance()
+                    }
+                },
+                update = { textView ->
+                    applyMarkwonColors(textView, colorScheme)
+                    if (textView.tag != content) {
+                        markwon.setMarkdown(textView, content)
+                        textView.tag = content
+                    }
+                },
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            TextButton(
+                onClick = { scope.dismissSheet(sheetState) { onDismiss() } },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 16.dp)
+            ) {
+                Text(
+                    text = stringResource(R.string.whats_new_got_it),
+                    modifier = Modifier.padding(4.dp)
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/mydeck/app/ui/whatsnew/WhatsNewViewModel.kt
+++ b/app/src/main/java/com/mydeck/app/ui/whatsnew/WhatsNewViewModel.kt
@@ -36,22 +36,33 @@ class WhatsNewViewModel @Inject constructor(
             val current = WhatsNewAssetLoader.normalizeVersion(AppVersion.versionName(context))
             val lastSeen = settingsDataStore.getLastSeenWhatsNewVersion()
             if (lastSeen == null) {
-                // Fresh install (or upgrade from a build predating this feature).
-                // Never show What's New here; record silently so it can't fire
-                // retroactively, and offer the guide nudge instead.
                 settingsDataStore.saveLastSeenWhatsNewVersion(current)
-                if (!settingsDataStore.isWelcomeGuidePromptShown()) {
-                    uiState = uiState.copy(showGuideNudge = true)
+                if (settingsDataStore.isInitialSyncPerformed()) {
+                    // No marker, but this account has already completed its first
+                    // sync — this is an upgrade from a build that predates this
+                    // feature, not a fresh install. Treat it like any other
+                    // version change instead of silently suppressing.
+                    showNotesIfAvailable(current)
+                } else {
+                    // Genuinely fresh install: nothing to show yet, offer the
+                    // guide nudge instead.
+                    if (!settingsDataStore.isWelcomeGuidePromptShown()) {
+                        uiState = uiState.copy(showGuideNudge = true)
+                    }
                 }
                 return@launch
             }
             if (current != lastSeen) {
-                val notes = loader.loadNotesForVersion(current)
                 settingsDataStore.saveLastSeenWhatsNewVersion(current)
-                if (notes != null) {
-                    uiState = uiState.copy(whatsNewContent = notes, whatsNewVersion = current)
-                }
+                showNotesIfAvailable(current)
             }
+        }
+    }
+
+    private fun showNotesIfAvailable(version: String) {
+        val notes = loader.loadNotesForVersion(version)
+        if (notes != null) {
+            uiState = uiState.copy(whatsNewContent = notes, whatsNewVersion = version)
         }
     }
 

--- a/app/src/main/java/com/mydeck/app/ui/whatsnew/WhatsNewViewModel.kt
+++ b/app/src/main/java/com/mydeck/app/ui/whatsnew/WhatsNewViewModel.kt
@@ -1,0 +1,78 @@
+package com.mydeck.app.ui.whatsnew
+
+import android.content.Context
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.mydeck.app.io.prefs.SettingsDataStore
+import com.mydeck.app.util.AppVersion
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class WhatsNewViewModel @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val loader: WhatsNewAssetLoader,
+    private val settingsDataStore: SettingsDataStore,
+) : ViewModel() {
+
+    var uiState by mutableStateOf(WhatsNewUiState())
+        private set
+
+    private var evaluated = false
+
+    /**
+     * Runs once per ViewModel instance (i.e. once per cold start of the
+     * authenticated shell). Idempotent across recomposition/config changes.
+     */
+    fun evaluateIfNeeded() {
+        if (evaluated) return
+        evaluated = true
+        viewModelScope.launch {
+            val current = WhatsNewAssetLoader.normalizeVersion(AppVersion.versionName(context))
+            val lastSeen = settingsDataStore.getLastSeenWhatsNewVersion()
+            if (lastSeen == null) {
+                // Fresh install (or upgrade from a build predating this feature).
+                // Never show What's New here; record silently so it can't fire
+                // retroactively, and offer the guide nudge instead.
+                settingsDataStore.saveLastSeenWhatsNewVersion(current)
+                if (!settingsDataStore.isWelcomeGuidePromptShown()) {
+                    uiState = uiState.copy(showGuideNudge = true)
+                }
+                return@launch
+            }
+            if (current != lastSeen) {
+                val notes = loader.loadNotesForVersion(current)
+                settingsDataStore.saveLastSeenWhatsNewVersion(current)
+                if (notes != null) {
+                    uiState = uiState.copy(whatsNewContent = notes, whatsNewVersion = current)
+                }
+            }
+        }
+    }
+
+    fun onWhatsNewDismissed() {
+        uiState = uiState.copy(whatsNewContent = null)
+    }
+
+    fun onGuideNudgeDismissed() {
+        uiState = uiState.copy(showGuideNudge = false)
+        viewModelScope.launch { settingsDataStore.saveWelcomeGuidePromptShown(true) }
+    }
+
+    fun onGuideNudgeOpenGuide() {
+        // Marking the prompt as shown is the same regardless of which action the
+        // user took.
+        onGuideNudgeDismissed()
+    }
+}
+
+data class WhatsNewUiState(
+    val whatsNewContent: String? = null,
+    val whatsNewVersion: String = "",
+    val showGuideNudge: Boolean = false,
+)

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -735,4 +735,13 @@ other{}
     <string name="font_licenses_intro">The reading-view fonts bundled with the app are provided under the following licenses.</string>
     <string name="select_font_title">Select font</string>
     <string name="select_font_done">Done</string>
+    <!-- What's New -->
+    <string name="whats_new_title">What\'s New</string>
+    <string name="whats_new_got_it">Got it</string>
+    <string name="whats_new_guide_nudge_title">Welcome to MyDeck</string>
+    <string name="whats_new_guide_nudge_body">New here? Take a quick tour of the User Guide to get the most out of MyDeck.</string>
+    <string name="whats_new_guide_nudge_open_guide">Open the User Guide</string>
+    <string name="whats_new_guide_nudge_not_now">Not now</string>
+    <string name="about_whats_new">What\'s New</string>
+    <string name="about_whats_new_subtitle">See what changed in this version</string>
 </resources>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -742,6 +742,9 @@ other{}
     <string name="whats_new_guide_nudge_body">New here? Take a quick tour of the User Guide to get the most out of MyDeck.</string>
     <string name="whats_new_guide_nudge_open_guide">Open the User Guide</string>
     <string name="whats_new_guide_nudge_not_now">Not now</string>
+    <string name="whats_new_see_previous_releases">See previous releases</string>
+    <string name="whats_new_history_title">Release Notes</string>
+    <string name="whats_new_history_empty">No release notes available yet.</string>
     <string name="about_whats_new">What\'s New</string>
-    <string name="about_whats_new_subtitle">See what changed in this version</string>
+    <string name="about_whats_new_subtitle">See what changed across releases</string>
 </resources>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -741,6 +741,9 @@ other{}
     <string name="whats_new_guide_nudge_body">New here? Take a quick tour of the User Guide to get the most out of MyDeck.</string>
     <string name="whats_new_guide_nudge_open_guide">Open the User Guide</string>
     <string name="whats_new_guide_nudge_not_now">Not now</string>
+    <string name="whats_new_see_previous_releases">See previous releases</string>
+    <string name="whats_new_history_title">Release Notes</string>
+    <string name="whats_new_history_empty">No release notes available yet.</string>
     <string name="about_whats_new">What\'s New</string>
-    <string name="about_whats_new_subtitle">See what changed in this version</string>
+    <string name="about_whats_new_subtitle">See what changed across releases</string>
 </resources>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -734,4 +734,13 @@ other{}
     <string name="font_licenses_intro">The reading-view fonts bundled with the app are provided under the following licenses.</string>
     <string name="select_font_title">Select font</string>
     <string name="select_font_done">Done</string>
+    <!-- What's New -->
+    <string name="whats_new_title">What\'s New</string>
+    <string name="whats_new_got_it">Got it</string>
+    <string name="whats_new_guide_nudge_title">Welcome to MyDeck</string>
+    <string name="whats_new_guide_nudge_body">New here? Take a quick tour of the User Guide to get the most out of MyDeck.</string>
+    <string name="whats_new_guide_nudge_open_guide">Open the User Guide</string>
+    <string name="whats_new_guide_nudge_not_now">Not now</string>
+    <string name="about_whats_new">What\'s New</string>
+    <string name="about_whats_new_subtitle">See what changed in this version</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -741,6 +741,9 @@ other{}
     <string name="whats_new_guide_nudge_body">New here? Take a quick tour of the User Guide to get the most out of MyDeck.</string>
     <string name="whats_new_guide_nudge_open_guide">Open the User Guide</string>
     <string name="whats_new_guide_nudge_not_now">Not now</string>
+    <string name="whats_new_see_previous_releases">See previous releases</string>
+    <string name="whats_new_history_title">Release Notes</string>
+    <string name="whats_new_history_empty">No release notes available yet.</string>
     <string name="about_whats_new">What\'s New</string>
-    <string name="about_whats_new_subtitle">See what changed in this version</string>
+    <string name="about_whats_new_subtitle">See what changed across releases</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -734,4 +734,13 @@ other{}
     <string name="font_licenses_intro">The reading-view fonts bundled with the app are provided under the following licenses.</string>
     <string name="select_font_title">Select font</string>
     <string name="select_font_done">Done</string>
+    <!-- What's New -->
+    <string name="whats_new_title">What\'s New</string>
+    <string name="whats_new_got_it">Got it</string>
+    <string name="whats_new_guide_nudge_title">Welcome to MyDeck</string>
+    <string name="whats_new_guide_nudge_body">New here? Take a quick tour of the User Guide to get the most out of MyDeck.</string>
+    <string name="whats_new_guide_nudge_open_guide">Open the User Guide</string>
+    <string name="whats_new_guide_nudge_not_now">Not now</string>
+    <string name="about_whats_new">What\'s New</string>
+    <string name="about_whats_new_subtitle">See what changed in this version</string>
 </resources>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -741,6 +741,9 @@ other{}
     <string name="whats_new_guide_nudge_body">New here? Take a quick tour of the User Guide to get the most out of MyDeck.</string>
     <string name="whats_new_guide_nudge_open_guide">Open the User Guide</string>
     <string name="whats_new_guide_nudge_not_now">Not now</string>
+    <string name="whats_new_see_previous_releases">See previous releases</string>
+    <string name="whats_new_history_title">Release Notes</string>
+    <string name="whats_new_history_empty">No release notes available yet.</string>
     <string name="about_whats_new">What\'s New</string>
-    <string name="about_whats_new_subtitle">See what changed in this version</string>
+    <string name="about_whats_new_subtitle">See what changed across releases</string>
 </resources>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -734,4 +734,13 @@ other{}
     <string name="font_licenses_intro">The reading-view fonts bundled with the app are provided under the following licenses.</string>
     <string name="select_font_title">Select font</string>
     <string name="select_font_done">Done</string>
+    <!-- What's New -->
+    <string name="whats_new_title">What\'s New</string>
+    <string name="whats_new_got_it">Got it</string>
+    <string name="whats_new_guide_nudge_title">Welcome to MyDeck</string>
+    <string name="whats_new_guide_nudge_body">New here? Take a quick tour of the User Guide to get the most out of MyDeck.</string>
+    <string name="whats_new_guide_nudge_open_guide">Open the User Guide</string>
+    <string name="whats_new_guide_nudge_not_now">Not now</string>
+    <string name="about_whats_new">What\'s New</string>
+    <string name="about_whats_new_subtitle">See what changed in this version</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -741,6 +741,9 @@ other{}
     <string name="whats_new_guide_nudge_body">New here? Take a quick tour of the User Guide to get the most out of MyDeck.</string>
     <string name="whats_new_guide_nudge_open_guide">Open the User Guide</string>
     <string name="whats_new_guide_nudge_not_now">Not now</string>
+    <string name="whats_new_see_previous_releases">See previous releases</string>
+    <string name="whats_new_history_title">Release Notes</string>
+    <string name="whats_new_history_empty">No release notes available yet.</string>
     <string name="about_whats_new">What\'s New</string>
-    <string name="about_whats_new_subtitle">See what changed in this version</string>
+    <string name="about_whats_new_subtitle">See what changed across releases</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -734,4 +734,13 @@ other{}
     <string name="font_licenses_intro">The reading-view fonts bundled with the app are provided under the following licenses.</string>
     <string name="select_font_title">Select font</string>
     <string name="select_font_done">Done</string>
+    <!-- What's New -->
+    <string name="whats_new_title">What\'s New</string>
+    <string name="whats_new_got_it">Got it</string>
+    <string name="whats_new_guide_nudge_title">Welcome to MyDeck</string>
+    <string name="whats_new_guide_nudge_body">New here? Take a quick tour of the User Guide to get the most out of MyDeck.</string>
+    <string name="whats_new_guide_nudge_open_guide">Open the User Guide</string>
+    <string name="whats_new_guide_nudge_not_now">Not now</string>
+    <string name="about_whats_new">What\'s New</string>
+    <string name="about_whats_new_subtitle">See what changed in this version</string>
 </resources>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -741,6 +741,9 @@ other{}
     <string name="whats_new_guide_nudge_body">New here? Take a quick tour of the User Guide to get the most out of MyDeck.</string>
     <string name="whats_new_guide_nudge_open_guide">Open the User Guide</string>
     <string name="whats_new_guide_nudge_not_now">Not now</string>
+    <string name="whats_new_see_previous_releases">See previous releases</string>
+    <string name="whats_new_history_title">Release Notes</string>
+    <string name="whats_new_history_empty">No release notes available yet.</string>
     <string name="about_whats_new">What\'s New</string>
-    <string name="about_whats_new_subtitle">See what changed in this version</string>
+    <string name="about_whats_new_subtitle">See what changed across releases</string>
 </resources>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -734,4 +734,13 @@ other{}
     <string name="font_licenses_intro">The reading-view fonts bundled with the app are provided under the following licenses.</string>
     <string name="select_font_title">Select font</string>
     <string name="select_font_done">Done</string>
+    <!-- What's New -->
+    <string name="whats_new_title">What\'s New</string>
+    <string name="whats_new_got_it">Got it</string>
+    <string name="whats_new_guide_nudge_title">Welcome to MyDeck</string>
+    <string name="whats_new_guide_nudge_body">New here? Take a quick tour of the User Guide to get the most out of MyDeck.</string>
+    <string name="whats_new_guide_nudge_open_guide">Open the User Guide</string>
+    <string name="whats_new_guide_nudge_not_now">Not now</string>
+    <string name="about_whats_new">What\'s New</string>
+    <string name="about_whats_new_subtitle">See what changed in this version</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -741,6 +741,9 @@ other{}
     <string name="whats_new_guide_nudge_body">New here? Take a quick tour of the User Guide to get the most out of MyDeck.</string>
     <string name="whats_new_guide_nudge_open_guide">Open the User Guide</string>
     <string name="whats_new_guide_nudge_not_now">Not now</string>
+    <string name="whats_new_see_previous_releases">See previous releases</string>
+    <string name="whats_new_history_title">Release Notes</string>
+    <string name="whats_new_history_empty">No release notes available yet.</string>
     <string name="about_whats_new">What\'s New</string>
-    <string name="about_whats_new_subtitle">See what changed in this version</string>
+    <string name="about_whats_new_subtitle">See what changed across releases</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -734,4 +734,13 @@ other{}
     <string name="font_licenses_intro">The reading-view fonts bundled with the app are provided under the following licenses.</string>
     <string name="select_font_title">Select font</string>
     <string name="select_font_done">Done</string>
+    <!-- What's New -->
+    <string name="whats_new_title">What\'s New</string>
+    <string name="whats_new_got_it">Got it</string>
+    <string name="whats_new_guide_nudge_title">Welcome to MyDeck</string>
+    <string name="whats_new_guide_nudge_body">New here? Take a quick tour of the User Guide to get the most out of MyDeck.</string>
+    <string name="whats_new_guide_nudge_open_guide">Open the User Guide</string>
+    <string name="whats_new_guide_nudge_not_now">Not now</string>
+    <string name="about_whats_new">What\'s New</string>
+    <string name="about_whats_new_subtitle">See what changed in this version</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -741,6 +741,9 @@ other{}
     <string name="whats_new_guide_nudge_body">New here? Take a quick tour of the User Guide to get the most out of MyDeck.</string>
     <string name="whats_new_guide_nudge_open_guide">Open the User Guide</string>
     <string name="whats_new_guide_nudge_not_now">Not now</string>
+    <string name="whats_new_see_previous_releases">See previous releases</string>
+    <string name="whats_new_history_title">Release Notes</string>
+    <string name="whats_new_history_empty">No release notes available yet.</string>
     <string name="about_whats_new">What\'s New</string>
-    <string name="about_whats_new_subtitle">See what changed in this version</string>
+    <string name="about_whats_new_subtitle">See what changed across releases</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -734,4 +734,13 @@ other{}
     <string name="font_licenses_intro">The reading-view fonts bundled with the app are provided under the following licenses.</string>
     <string name="select_font_title">Select font</string>
     <string name="select_font_done">Done</string>
+    <!-- What's New -->
+    <string name="whats_new_title">What\'s New</string>
+    <string name="whats_new_got_it">Got it</string>
+    <string name="whats_new_guide_nudge_title">Welcome to MyDeck</string>
+    <string name="whats_new_guide_nudge_body">New here? Take a quick tour of the User Guide to get the most out of MyDeck.</string>
+    <string name="whats_new_guide_nudge_open_guide">Open the User Guide</string>
+    <string name="whats_new_guide_nudge_not_now">Not now</string>
+    <string name="about_whats_new">What\'s New</string>
+    <string name="about_whats_new_subtitle">See what changed in this version</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -733,6 +733,9 @@
     <string name="whats_new_guide_nudge_body">New here? Take a quick tour of the User Guide to get the most out of MyDeck.</string>
     <string name="whats_new_guide_nudge_open_guide">Open the User Guide</string>
     <string name="whats_new_guide_nudge_not_now">Not now</string>
+    <string name="whats_new_see_previous_releases">See previous releases</string>
+    <string name="whats_new_history_title">Release Notes</string>
+    <string name="whats_new_history_empty">No release notes available yet.</string>
     <string name="about_whats_new">What\'s New</string>
-    <string name="about_whats_new_subtitle">See what changed in this version</string>
+    <string name="about_whats_new_subtitle">See what changed across releases</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -726,4 +726,13 @@
     <string name="font_licenses_intro">The reading-view fonts bundled with the app are provided under the following licenses.</string>
     <string name="select_font_title">Select font</string>
     <string name="select_font_done">Done</string>
+    <!-- What's New -->
+    <string name="whats_new_title">What\'s New</string>
+    <string name="whats_new_got_it">Got it</string>
+    <string name="whats_new_guide_nudge_title">Welcome to MyDeck</string>
+    <string name="whats_new_guide_nudge_body">New here? Take a quick tour of the User Guide to get the most out of MyDeck.</string>
+    <string name="whats_new_guide_nudge_open_guide">Open the User Guide</string>
+    <string name="whats_new_guide_nudge_not_now">Not now</string>
+    <string name="about_whats_new">What\'s New</string>
+    <string name="about_whats_new_subtitle">See what changed in this version</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -766,6 +766,9 @@ other{}
     <string name="whats_new_guide_nudge_body">New here? Take a quick tour of the User Guide to get the most out of MyDeck.</string>
     <string name="whats_new_guide_nudge_open_guide">Open the User Guide</string>
     <string name="whats_new_guide_nudge_not_now">Not now</string>
+    <string name="whats_new_see_previous_releases">See previous releases</string>
+    <string name="whats_new_history_title">Release Notes</string>
+    <string name="whats_new_history_empty">No release notes available yet.</string>
     <string name="about_whats_new">What\'s New</string>
-    <string name="about_whats_new_subtitle">See what changed in this version</string>
+    <string name="about_whats_new_subtitle">See what changed across releases</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -759,4 +759,13 @@ other{}
     <string name="font_licenses_intro">The reading-view fonts bundled with the app are provided under the following licenses.</string>
     <string name="select_font_title">Select font</string>
     <string name="select_font_done">Done</string>
+    <!-- What's New -->
+    <string name="whats_new_title">What\'s New</string>
+    <string name="whats_new_got_it">Got it</string>
+    <string name="whats_new_guide_nudge_title">Welcome to MyDeck</string>
+    <string name="whats_new_guide_nudge_body">New here? Take a quick tour of the User Guide to get the most out of MyDeck.</string>
+    <string name="whats_new_guide_nudge_open_guide">Open the User Guide</string>
+    <string name="whats_new_guide_nudge_not_now">Not now</string>
+    <string name="about_whats_new">What\'s New</string>
+    <string name="about_whats_new_subtitle">See what changed in this version</string>
 </resources>

--- a/app/src/test/java/com/mydeck/app/ui/whatsnew/WhatsNewAssetLoaderTest.kt
+++ b/app/src/test/java/com/mydeck/app/ui/whatsnew/WhatsNewAssetLoaderTest.kt
@@ -1,0 +1,52 @@
+package com.mydeck.app.ui.whatsnew
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WhatsNewAssetLoaderTest {
+
+    @Test
+    fun `normalizeVersion strips the snapshot build suffix`() {
+        assertEquals("1.0.0-rc5", WhatsNewAssetLoader.normalizeVersion("1.0.0-rc5-snapshot"))
+    }
+
+    @Test
+    fun `normalizeVersion leaves a release version unchanged`() {
+        assertEquals("1.0.0", WhatsNewAssetLoader.normalizeVersion("1.0.0"))
+    }
+
+    @Test
+    fun `compareVersions orders numeric components correctly, not lexicographically`() {
+        // A plain string sort would put "1.0.10" before "1.0.9".
+        assertTrue(WhatsNewAssetLoader.compareVersions("1.0.10", "1.0.9") > 0)
+        assertTrue(WhatsNewAssetLoader.compareVersions("1.0.9", "1.0.10") < 0)
+    }
+
+    @Test
+    fun `compareVersions ranks a release above its own release candidates`() {
+        assertTrue(WhatsNewAssetLoader.compareVersions("1.0.0", "1.0.0-rc5") > 0)
+        assertTrue(WhatsNewAssetLoader.compareVersions("1.0.0-rc5", "1.0.0") < 0)
+    }
+
+    @Test
+    fun `compareVersions orders release candidates by their trailing number`() {
+        assertTrue(WhatsNewAssetLoader.compareVersions("1.0.0-rc10", "1.0.0-rc9") > 0)
+        assertTrue(WhatsNewAssetLoader.compareVersions("1.0.0-rc4", "1.0.0-rc5") < 0)
+    }
+
+    @Test
+    fun `compareVersions treats equal versions as equal`() {
+        assertEquals(0, WhatsNewAssetLoader.compareVersions("1.0.0-rc5", "1.0.0-rc5"))
+    }
+
+    @Test
+    fun `sorting with compareVersions descending yields newest first`() {
+        val versions = listOf("1.0.0-rc3", "1.0.0-rc5", "1.0.0", "1.0.0-rc4", "0.9.0")
+        val sorted = versions.sortedWith { a, b -> WhatsNewAssetLoader.compareVersions(b, a) }
+        assertEquals(
+            listOf("1.0.0", "1.0.0-rc5", "1.0.0-rc4", "1.0.0-rc3", "0.9.0"),
+            sorted
+        )
+    }
+}

--- a/app/src/test/java/com/mydeck/app/ui/whatsnew/WhatsNewAssetLoaderTest.kt
+++ b/app/src/test/java/com/mydeck/app/ui/whatsnew/WhatsNewAssetLoaderTest.kt
@@ -1,6 +1,8 @@
 package com.mydeck.app.ui.whatsnew
 
+import kotlinx.datetime.LocalDate
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -48,5 +50,45 @@ class WhatsNewAssetLoaderTest {
             listOf("1.0.0", "1.0.0-rc5", "1.0.0-rc4", "1.0.0-rc3", "0.9.0"),
             sorted
         )
+    }
+
+    @Test
+    fun `parseFrontmatterDate reads a date field from the frontmatter block`() {
+        val raw = """
+            ---
+            date: 2026-07-03
+            ---
+            # What's New in 1.0.0-rc5
+
+            Body text.
+        """.trimIndent()
+        assertEquals(LocalDate(2026, 7, 3), WhatsNewAssetLoader.parseFrontmatterDate(raw))
+    }
+
+    @Test
+    fun `parseFrontmatterDate returns null with no frontmatter block`() {
+        assertNull(WhatsNewAssetLoader.parseFrontmatterDate("# What's New in 1.0.0-rc5\n\nBody text."))
+    }
+
+    @Test
+    fun `parseFrontmatterDate returns null when frontmatter has no date field`() {
+        val raw = """
+            ---
+            title: Ignored
+            ---
+            Body text.
+        """.trimIndent()
+        assertNull(WhatsNewAssetLoader.parseFrontmatterDate(raw))
+    }
+
+    @Test
+    fun `parseFrontmatterDate returns null for a malformed date instead of throwing`() {
+        val raw = """
+            ---
+            date: not-a-date
+            ---
+            Body text.
+        """.trimIndent()
+        assertNull(WhatsNewAssetLoader.parseFrontmatterDate(raw))
     }
 }

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -137,8 +137,20 @@ This is documented in `AGENTS.md` and `CLAUDE.md` so the agent knows to ask rath
     *   `versionName`: `"X.Y.Z"`
 3.  Add changelog: `metadata/en-US/changelogs/<versionCode>.txt`.
 4.  Update `CHANGELOG.md`: move items from `[Unreleased]` into a new `## [X.Y.Z] - YYYY-MM-DD` section.
-5.  Commit: `chore(release): bump version to X.Y.Z`.
-6.  Open PR -> Merge to `main`.
+5.  Author `app/src/main/assets/whatsnew/en/X.Y.Z.md` — the in-app "What's New"
+    sheet shown on first launch after updating to this version (see
+    `docs/specs/whats-new-page-spec.md`). Curate this from the `CHANGELOG.md`
+    section just written, but don't copy it verbatim: use short, explanatory,
+    user-facing language (bold lead-ins per feature), and drop internal-only
+    entries (refactors, fixes with no visible behavior change) that don't merit
+    a user's attention. No file for a version = the sheet silently never fires
+    for it, so skip this step for an internal-only release with nothing worth
+    highlighting. Add English-placeholder copies at
+    `app/src/main/assets/whatsnew/<locale>/X.Y.Z.md` for every other supported
+    locale (`de, es, fr, gl, pl, pt, ru, uk, zh`), matching the localization
+    rule in `CLAUDE.md`.
+6.  Commit: `chore(release): bump version to X.Y.Z`.
+7.  Open PR -> Merge to `main`.
 
 ### Step 2: Pre-release Validation
 

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -139,13 +139,24 @@ This is documented in `AGENTS.md` and `CLAUDE.md` so the agent knows to ask rath
 4.  Update `CHANGELOG.md`: move items from `[Unreleased]` into a new `## [X.Y.Z] - YYYY-MM-DD` section.
 5.  Author `app/src/main/assets/whatsnew/en/X.Y.Z.md` — the in-app "What's New"
     sheet shown on first launch after updating to this version (see
-    `docs/specs/whats-new-page-spec.md`). Curate this from the `CHANGELOG.md`
-    section just written, but don't copy it verbatim: use short, explanatory,
-    user-facing language (bold lead-ins per feature), and drop internal-only
-    entries (refactors, fixes with no visible behavior change) that don't merit
-    a user's attention. No file for a version = the sheet silently never fires
-    for it, so skip this step for an internal-only release with nothing worth
-    highlighting. Add English-placeholder copies at
+    `docs/specs/whats-new-page-spec.md`). Start the file with a YAML
+    frontmatter block giving the release date (matching the `CHANGELOG.md`
+    heading just written), e.g.:
+    ```
+    ---
+    date: X.Y.Z's release date, YYYY-MM-DD
+    ---
+    # What's New in X.Y.Z
+    ```
+    The date is shown in the release-history list (About → What's New → See
+    previous releases); it's parsed from frontmatter, not the filename. Curate
+    the body from the `CHANGELOG.md` section just written, but don't copy it
+    verbatim: use short, explanatory, user-facing language (bold lead-ins per
+    feature), and drop internal-only entries (refactors, fixes with no visible
+    behavior change) that don't merit a user's attention. No file for a
+    version = the sheet silently never fires for it, so skip this step for an
+    internal-only release with nothing worth highlighting. Add
+    English-placeholder copies (frontmatter included) at
     `app/src/main/assets/whatsnew/<locale>/X.Y.Z.md` for every other supported
     locale (`de, es, fr, gl, pl, pt, ru, uk, zh`), matching the localization
     rule in `CLAUDE.md`.

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -147,15 +147,31 @@ This is documented in `AGENTS.md` and `CLAUDE.md` so the agent knows to ask rath
     date: X.Y.Z's release date, YYYY-MM-DD
     ---
     # What's New in X.Y.Z
+
+    **Feature name:** One or two sentences describing what it does, in plain
+    user-facing language.
+
+    **Another change:** Same shape — a bold lead-in, a colon, then the
+    description.
     ```
     The date is shown in the release-history list (About → What's New → See
     previous releases); it's parsed from frontmatter, not the filename. Curate
     the body from the `CHANGELOG.md` section just written, but don't copy it
-    verbatim: use short, explanatory, user-facing language (bold lead-ins per
-    feature), and drop internal-only entries (refactors, fixes with no visible
-    behavior change) that don't merit a user's attention. No file for a
-    version = the sheet silently never fires for it, so skip this step for an
-    internal-only release with nothing worth highlighting. Add
+    verbatim: use short, explanatory, user-facing language and drop
+    internal-only entries (refactors, fixes with no visible behavior change)
+    that don't merit a user's attention.
+
+    **Format each entry consistently** as `**Bold lead-in:** description` —
+    the bold title and its colon inside the `**…**`, followed by the
+    description on the same line, one blank line between entries. This inline
+    colon form keeps even a busy release to a single no-scroll sheet. Do **not**
+    use an em dash (`—`) as the title/description separator (or elsewhere in the
+    copy); the renderer collapses a bare newline to a space, so a title on its
+    own line would run into its paragraph anyway. Group several small fixes
+    under one `**Fixes:**` entry rather than listing each.
+
+    No file for a version = the sheet silently never fires for it, so skip this
+    step for an internal-only release with nothing worth highlighting. Add
     English-placeholder copies (frontmatter included) at
     `app/src/main/assets/whatsnew/<locale>/X.Y.Z.md` for every other supported
     locale (`de, es, fr, gl, pl, pt, ru, uk, zh`), matching the localization

--- a/docs/porting/whats-new-page-port.md
+++ b/docs/porting/whats-new-page-port.md
@@ -1,0 +1,171 @@
+# Port checklist — What's New sheet + release history
+
+**Source:** Readeck for Android branch `feat/whats-new-page` (commits `9ebe5bf`
+"feat: What's New sheet on update + first-launch guide nudge", `b241612`
+"feat: What's New release history screen", `1b43fa1` "feat: open current
+whats new from about") — **not yet merged to `main` or PR'd**; this port can
+proceed straight from the branch tip.
+**Target:** MyDeck `main`
+**Methodology:** `docs/porting/mydeck-readeck-port.md`
+**Design reference:** `docs/specs/whats-new-page-spec.md` (recommend copying
+this into MyDeck's `docs/specs/` too — see Branding deltas below — since the
+new `docs/WORKFLOW.md` step references it by path).
+
+## What this feature does
+
+A curated, per-version "What's New" sheet appears the first time the app is
+opened after an update (content lives in
+`app/src/main/assets/whatsnew/<locale>/<version>.md`, decoupled from
+`CHANGELOG.md`). Fresh installs never see it — instead they get a one-time
+dismissible nudge toward the User Guide. **About → What's New** opens the
+*current* version's notes if they exist (falling back straight to history if
+not); from that sheet, "See previous releases" — and the About row itself when
+there's no current-version note — leads to a full release-history list,
+newest-first via a numeric-aware comparator (a plain string sort would rank
+`"1.0.10"` before `"1.0.9"`, and would rank a release below its own `-rc`
+builds).
+
+## Branding deltas applied (§2)
+
+1. **`whats_new_guide_nudge_title`** — Readeck: `"Welcome to Readeck"` → MyDeck:
+   `"Welcome to MyDeck"`.
+2. **`whats_new_guide_nudge_body`** — Readeck: `"New here? Take a quick tour of
+   the User Guide to get the most out of Readeck."` → MyDeck: `"...get the most
+   out of MyDeck."` These are the only two of the twelve new string values that
+   name the app; the other ten (sheet title, "Got it", "See previous releases",
+   history title/empty-state, "Open the User Guide", "Not now", About row
+   label/subtitle) are brand-neutral and port as-is. All are still
+   English-placeholder text pending translation in the non-`en` locale files —
+   port the same placeholder pattern, just with "MyDeck" substituted in the two
+   strings above.
+3. **Do NOT port `app/src/main/assets/whatsnew/en/1.0.0-rc5.md`.** It's
+   Readeck's own curated notes for Readeck's `1.0.0-rc5` — content, not
+   branding, and tied to a version number MyDeck (currently `0.14.5`) will
+   never reach. MyDeck ships this feature with an **empty `whatsnew/`
+   directory** — by design, a version with no matching file simply never
+   triggers the sheet (see spec, "no file = silent skip"). Author MyDeck's own
+   first entry at MyDeck's own next release-prep (see delta 5 below), not as
+   part of this port.
+4. **`CHANGELOG.md` bullet** and the **`app/src/main/assets/guide/en/settings.md`**
+   sentence are brand-neutral — no app name in either — port the wording as-is.
+5. **`docs/WORKFLOW.md` step does NOT copy verbatim** — Readeck's release-prep
+   numbering/structure differs from MyDeck's (`docs/WORKFLOW.md` §"Step 1: Prep
+   the Release", items 1–6, vs. Readeck's §"Step 1 — Prep", items 1–5). Insert
+   an **analogous new step** in MyDeck's list — after item 4 ("Update
+   `CHANGELOG.md`"), before the existing "Commit" item — instructing the
+   release-prep author to write `app/src/main/assets/whatsnew/en/X.Y.Z.md` (+
+   locale placeholders) from the `CHANGELOG.md` section just written, in
+   explanatory/curated language, skipping internal-only entries; renumber the
+   remaining items. Reference `docs/specs/whats-new-page-spec.md` (copy that
+   spec doc into MyDeck too, swapping "Readeck" → "MyDeck" in its prose, so the
+   cross-reference resolves).
+
+## Files changed
+
+### New files (verbatim — no repo-specific logic)
+- `app/src/main/java/com/mydeck/app/ui/whatsnew/WhatsNewAssetLoader.kt` —
+  locale-fallback markdown loader (`loadNotesForVersion`, `normalizeVersion`
+  strips a snapshot build's `-snapshot` suffix so snapshot builds can preview
+  upcoming release notes, `listAvailableVersions` + numeric-aware
+  `compareVersions` for history sorting).
+- `app/src/main/java/com/mydeck/app/ui/whatsnew/WhatsNewViewModel.kt` — the
+  on-launch trigger (`evaluateIfNeeded`, idempotent per instance): fresh
+  install → silent marker + optional guide nudge; version change with a
+  matching notes file → shows the sheet; version change with no file → marker
+  still advances (see spec's "Resolved decisions" for why this is safe).
+- `app/src/main/java/com/mydeck/app/ui/whatsnew/WhatsNewSheet.kt` — the
+  `ModalBottomSheet`, reusing `ui/userguide`'s `rememberMarkwon`/
+  `applyMarkwonColors` render pattern and `ui/components`'
+  `dismissSheet` helper (from the earlier bottom-sheet-consistency port) so
+  "Got it" / swipe / tap-outside all animate identically. Optional
+  `onSeePreviousReleases` param.
+- `app/src/main/java/com/mydeck/app/ui/whatsnew/WelcomeGuideNudgeDialog.kt` —
+  simple `AlertDialog`, fresh-install-only nudge to the User Guide.
+- `app/src/main/java/com/mydeck/app/ui/whatsnew/WhatsNewHistoryViewModel.kt` +
+  `WhatsNewHistoryScreen.kt` — lists every version with notes (newest-first),
+  tapping one loads and shows it in the same `WhatsNewSheet`.
+- `app/src/test/java/com/mydeck/app/ui/whatsnew/WhatsNewAssetLoaderTest.kt` —
+  pure-function tests for `normalizeVersion` and `compareVersions` (numeric
+  ordering, rc-vs-release ranking, sort direction). No Robolectric needed.
+
+### Modified files — confirmed byte-identical baselines (§0.2), copy/cherry-pick cleanly
+- `app/src/main/java/com/mydeck/app/io/prefs/SettingsDataStore.kt` +
+  `SettingsDataStoreImpl.kt` — two new non-sensitive `userPreferences` keys
+  (`last_seen_whatsnew_version` string, `welcome_guide_prompt_shown` boolean) +
+  four accessor methods. **Pre-port sanity:** grep MyDeck's
+  `SettingsDataStoreImpl.kt` for those two key strings first — should be
+  absent (new keys), confirm before adding.
+- `app/src/main/java/com/mydeck/app/ui/navigation/Routes.kt` —
+  `WhatsNewHistoryRoute` (one new `@Serializable object`).
+- `app/src/main/java/com/mydeck/app/ui/shell/AppShell.kt` — the trigger
+  `LaunchedEffect` + sheet/dialog overlays live **once**, at the top-level
+  `AppShell()` composable (siblings after the `when (layoutTier) {...}` block)
+  — not duplicated per layout tier. `WhatsNewHistoryRoute` is registered in
+  **both** `NavHost` blocks (the inline one in `CompactAppShell`, and the
+  shared `AppShellNavHost` used by `MediumAppShell`/`ExpandedAppShell`) — check
+  MyDeck's `AppShell.kt` has the same two-NavHost shape before assuming the
+  same two insertion points apply.
+- `app/src/main/java/com/mydeck/app/ui/about/AboutViewModel.kt` — confirmed
+  byte-identical baseline; copies/cherry-picks cleanly. Adds:
+  `hasWhatsNewHistory` (gates the About row on *any* history existing, not
+  just the current version), `onClickWhatsNew()` (loads current version's
+  notes; if none, falls straight to `NavigateToWhatsNewHistory`),
+  `onDismissWhatsNewSheet()`, `onClickWhatsNewHistory()`.
+
+### Modified file — **diverged, do NOT copy wholesale**
+- `app/src/main/java/com/mydeck/app/ui/about/AboutScreen.kt` — MyDeck's
+  version differs from Readeck's pre-branch baseline **only** in the
+  "Project Links" section (the fork/original/server repo rows — MyDeck has its
+  own fork-info block with its own URLs, in a different row order; see
+  `FORK_INFO_START`/`END` markers). That section is **not touched** by this
+  feature — the What's New changes land between the Description and Credits
+  sections, and near (previously: after) the Font Licenses row, both well
+  clear of Project Links. A patch/cherry-pick merge (not `cp`/`git checkout
+  <ref> --`) will apply cleanly despite the divergence; just don't overwrite
+  the whole file. Adds: the "What's New" row (positioned just above the
+  Credits section, gated on `uiState.hasWhatsNewHistory`), and inline
+  `WhatsNewSheet` rendering driven by `uiState.whatsNewVersion`/`whatsNewContent`
+  with `onSeePreviousReleases` wired to `onClickWhatsNewHistory`.
+- `CHANGELOG.md`, `app/src/main/assets/guide/en/settings.md` — brand-neutral,
+  port wording as-is (see Branding deltas §4).
+- `docs/WORKFLOW.md` — do not copy verbatim; adapt per Branding deltas §5.
+- `app/src/main/res/values/strings.xml` + all locale files — insert the twelve
+  new keys surgically (never `git checkout <ref> -- strings.xml`, per the
+  methodology's §5 warning about clobbering independently-added keys). Swap
+  "Readeck" → "MyDeck" in the two nudge strings (delta 2).
+
+## §4 data-model check
+No Room schema changes — the two new preference keys are Preferences DataStore
+(`SharedPreferences`-backed), not Room. §4 is a no-op.
+
+## Pre-port sanity (§0.2)
+- `AboutViewModel.kt`, `AppShell.kt`, `Routes.kt`, `SettingsDataStore.kt`,
+  `SettingsDataStoreImpl.kt` — confirmed byte-identical to Readeck's
+  pre-branch `main` as of this writing. Re-confirm at port time in case MyDeck
+  has moved since.
+- `AboutScreen.kt` — confirmed diverged, but only in a non-overlapping section
+  (see above). Re-confirm the divergence is still confined there before
+  merging.
+- MyDeck is currently at `versionName = "0.14.5"` — nowhere near
+  `1.0.0-rc5`, reinforcing why the sample `whatsnew/en/1.0.0-rc5.md` content
+  must not be copied (delta 3).
+
+## Verification
+```
+./gradlew :app:assembleDebugAll :app:testDebugUnitTestAll :app:lintDebugAll
+./scripts/install-phone.sh
+```
+On-device / emulator:
+- Fresh install (clear app data) → sign in → guide nudge appears once, "Open
+  the User Guide" navigates correctly, "Not now" dismisses, never reappears.
+- Simulate an update to exercise the trigger: temporarily set
+  `versionName` to a fake older value (e.g. `"0.14.4"`) in
+  `app/build.gradle.kts`, build+install, sign in, close the app; then revert
+  to the real `versionName`, rebuild, and install over it (same
+  `versionCode`, so no downgrade-install issue) — the sheet should now fire
+  for the real version. (Author a matching `whatsnew/en/<real-version>.md`
+  first, or you'll correctly see nothing — see delta 3.)
+- About → What's New opens the current version's notes (or history, if none
+  exist for the current version); "See previous releases" from the sheet, and
+  the history screen's own list, both work; tapping a past entry reopens its
+  notes.

--- a/docs/porting/whats-new-page-port.md
+++ b/docs/porting/whats-new-page-port.md
@@ -169,3 +169,46 @@ On-device / emulator:
   exist for the current version); "See previous releases" from the sheet, and
   the history screen's own list, both work; tapping a past entry reopens its
   notes.
+
+## Addendum (2026-07-09): fresh-install disambiguation + release dates
+
+**Source:** Readeck for Android `feat/whats-new-page` commit `b6eeb55`
+("feat: disambiguate fresh installs from pre-feature upgrades; add release
+dates + rc1-rc5 history content").
+
+Ported the two logic refinements only — **not** the `whatsnew/*.md` content
+files (all locales' rc1–rc5 notes). Those are Readeck's own curated release
+notes, out of scope here for the same reason as delta 3 above.
+
+- **Fresh-install vs. pre-feature-upgrade disambiguation**
+  (`WhatsNewViewModel.kt`): a null `last_seen_whatsnew_version` marker used to
+  always mean "suppress the sheet, show the guide nudge instead" — but that's
+  wrong for an existing tester upgrading from a build that predates this
+  feature; they should see the sheet like any other version change. Fix: on a
+  null marker, check `settingsDataStore.isInitialSyncPerformed()` (pre-existing
+  flag, confirmed present in MyDeck) — true means treat it as a normal version
+  change; false means it's genuinely fresh. Extracted `showNotesIfAvailable()`
+  to share the "load notes, update state" logic between this branch and the
+  existing version-change branch.
+- **Release dates in history** (`WhatsNewAssetLoader.kt`,
+  `WhatsNewHistoryViewModel.kt`, `WhatsNewHistoryScreen.kt`): new
+  `WhatsNewHistoryEntry(version, date: LocalDate?)`; `listAvailableVersions()`
+  now returns `List<WhatsNewHistoryEntry>` instead of `List<String>`; new pure
+  `parseFrontmatterDate(raw): LocalDate?` reads an optional `date: YYYY-MM-DD`
+  YAML frontmatter field (missing/malformed → null, never throws); shared
+  `readRawFile()` private helper avoids duplicating the asset-open/try-catch
+  between note-loading and date-parsing. History rows show the date under the
+  version. `kotlinx.datetime.LocalDate` was already a MyDeck dependency — no
+  new dependency added. Date intentionally shown only in history, not on the
+  popup sheet itself (see source spec's Resolved decisions §7 for the
+  rationale).
+- `WhatsNewAssetLoaderTest.kt` — four new `parseFrontmatterDate` cases (valid
+  date, no frontmatter, frontmatter without `date:`, malformed date).
+- `docs/WORKFLOW.md` — amended MyDeck's own release-prep step (already
+  renumbered per delta 5 above) to show the `date:` frontmatter block in the
+  `whatsnew/en/X.Y.Z.md` template, instead of copying Readeck's differently-
+  numbered step verbatim.
+- All five touched code files were confirmed byte-identical to MyDeck's
+  existing (already-ported) versions before merging — a clean port, same as
+  the original three commits.
+- No new branding deltas, no schema changes.

--- a/docs/specs/whats-new-page-spec.md
+++ b/docs/specs/whats-new-page-spec.md
@@ -1,0 +1,457 @@
+# "What's New" on update + first-launch guide nudge (spec)
+
+Status: draft · Ported from Readeck for Android · Author aid: Claude
+
+## Problem
+
+After a user updates the app, there is no in-app surface that tells them what
+changed. The official iOS app shows a "What's New" sheet on first launch after an
+update. We want the same for Android, but with two refinements the iOS version
+lacks:
+
+1. **Scope to the delta.** Show only *this release's* highlights, not the entire
+   accumulated history every time.
+2. **Explanatory tone.** The copy should be able to say more (and say it more
+   plainly) than a terse changelog line — and it should be free to *omit*
+   changelog entries (internal fixes, refactors) that aren't worth a user's
+   attention.
+
+Separately, a **brand-new user** on first install has nothing to be "updated"
+about — they're in onboarding. Instead of a What's New sheet, they should get an
+optional, dismissible nudge toward the User Guide so they can learn the app
+before diving in.
+
+## Reference implementations
+
+### iOS (../readeck-ios)
+
+- `RELEASE_NOTES.md` — a single hand-curated markdown resource, **separate from
+  any changelog**, grouped by version newest-first with feature sub-headings and
+  bold lead-ins (`readeck/UI/Resources/RELEASE_NOTES.md`).
+- `VersionManager` — stores `lastSeenAppVersion` in `UserDefaults`; `isNewVersion`
+  is true on first launch *or* when stored ≠ current
+  (`readeck/UI/Utils/VersionManager.swift`).
+- `ReleaseNotesView` — a modal sheet rendering the markdown, shown from
+  `TabView.onAppear` when `isNewVersion`, and also reachable manually from
+  Settings (`readeck/UI/Settings/ReleaseNotesView.swift`).
+- Limitation we're deliberately not copying: it shows the **whole** file every
+  time it fires, and it fires on first install too.
+
+### Android — existing infrastructure to reuse
+
+- **Markdown:** Markwon via `ui/userguide/MarkdownRenderer.kt` and
+  `ui/userguide/MarkdownAssetLoader.kt` — already loads locale-scoped markdown
+  assets, strips frontmatter, and rewrites image/link paths. The User Guide is
+  the direct analog.
+- **Version:** `util/AppVersion.kt` reads `versionName`/`versionCode` from
+  `PackageInfo` at runtime. **Use this** — it deliberately avoids the inlined
+  `BuildConfig.VERSION_*` constants, which go stale across version bumps until a
+  clean build.
+- **Persistence:** `io/prefs/SettingsDataStoreImpl.kt` (Preferences DataStore).
+- **Nav/entry points:** `ui/navigation/Routes.kt` (`AboutRoute`,
+  `FontLicensesRoute`, `UserGuideRoute`, …). **Gotcha:** there are two nav graphs
+  — compact and expanded/tablet (see commit `695209a`, which fixed a route added
+  to only one). Any manual-entry route must be registered in **both**.
+- **Asset listing:** `AssetManager.list("whatsnew/en")` enumerates bundled files,
+  so a history screen needs no separate manifest.
+
+## Decisions (locked)
+
+| Question | Decision |
+| --- | --- |
+| Content source | **Curated, decoupled** from `CHANGELOG.md`; hand-synced at release-prep time. |
+| Scope shown on update | **Only the new release**, with an optional "See previous releases" link. |
+| Localization | **Full locale set** (en + placeholder files for all supported locales), following the guide pattern. |
+| Fresh install | **Suppress** What's New; show an optional dismissible **User Guide nudge** instead. |
+| Doc status | This spec stays **untracked** for now (active unrelated branch in flight). |
+
+## Design
+
+### 1. Content assets
+
+Per-version, per-locale markdown files:
+
+```
+app/src/main/assets/whatsnew/<locale>/<versionName>.md
+```
+
+- File name is the exact `versionName` the notes should first appear on, e.g.
+  `1.0.0.md`. (A `-snapshot`/`-rc` build has no matching file and therefore never
+  fires — a natural gate.)
+- Locales mirror the guide: `en, de, es, fr, gl, pl, pt, ru, uk, zh`. English is
+  authored; the others ship as **English placeholders** until translated (same
+  policy as `strings.xml` and the guide). Locale selection + `en` fallback reuse
+  the logic in `MarkdownAssetLoader.getLocalePath()`.
+- Content is authored in the explanatory/marketing tone of iOS's
+  `RELEASE_NOTES.md`: a short intro line optional, then feature sub-headings with
+  bold lead-ins. Frontmatter and a leading `# H1` are stripped by the loader, so
+  an optional `# What's New in 1.0.0` title is fine.
+
+### 2. Persistence
+
+Add to `SettingsDataStoreImpl`:
+
+- `stringPreferencesKey("last_seen_whatsnew_version")` — the `versionName` whose
+  notes were last shown (or recorded silently).
+- `booleanPreferencesKey("welcome_guide_prompt_shown")` — whether the first-launch
+  User Guide nudge has been shown.
+
+Expose reads as flows and suspend writes, matching the existing DataStore surface.
+
+### 3. Trigger logic (on update)
+
+Evaluated once per app entry into the authenticated shell (a `LaunchedEffect` in
+`AppShell`, on the *authenticated* path only — never on `WelcomeRoute`).
+
+```
+current = AppVersion.versionName(context)
+lastSeen = prefs.last_seen_whatsnew_version   // may be null
+
+if lastSeen == null:
+    // Fresh install (or upgrade from a build predating this feature).
+    // Do NOT show What's New. Record current so it never fires retroactively.
+    prefs.last_seen_whatsnew_version = current
+    maybeShowWelcomeGuidePrompt()             // see §5
+else if current != lastSeen AND assetExists("whatsnew/<locale-or-en>/$current.md"):
+    show What's New sheet for `current`
+    prefs.last_seen_whatsnew_version = current
+else if current != lastSeen:
+    // Updated to a build with no notes (rc/snapshot). Advance the marker so we
+    // don't nag on the next real update — see Resolved decisions §1.
+    prefs.last_seen_whatsnew_version = current
+```
+
+- Keying on exact `versionName` equality + file existence means **no version
+  ordering/parsing** is required.
+- The marker is advanced when the sheet is *shown* (not on dismiss), so a
+  mid-session process death can't re-trigger it. Acceptable trade-off: a crash
+  before the user reads it means they miss it, but it's always available from
+  About.
+
+### 4. Presentation (the sheet)
+
+- A `ModalBottomSheet` whose visibility is **state in `AppShell`**, not a nav
+  route. This sidesteps the dual-nav-graph trap entirely and keeps it as an
+  overlay above whatever screen is active.
+- Body: `MarkdownRenderer` on the loaded doc. Header: "What's New" + the version.
+  Primary action: **Got it**. Any dismissal path — tapping it, swipe-away, or
+  tap-outside — is equivalent, since the marker was already advanced at
+  show-time (§3); no extra dismiss-tracking state needed.
+- Reuse the guide's markdown styling for visual consistency.
+- No "See previous releases" link in v1 — History is deferred (§6).
+
+### 5. First-launch User Guide nudge (fresh-install alternative)
+
+Shown once, only on the fresh-install branch of §3 (or the first time the
+authenticated shell is reached with `welcome_guide_prompt_shown == false`).
+
+- Presentation: a small dismissible dialog or compact bottom sheet — **not** the
+  full-screen guide. Copy: a one-line welcome + "New here? Take a quick tour of
+  the User Guide to get the most out of MyDeck."
+- Actions:
+  - **Open the User Guide** → navigate to `UserGuideRoute` (existing).
+  - **Not now** → dismiss.
+- Either action sets `welcome_guide_prompt_shown = true` so it never reappears.
+- This is intentionally lightweight (reuses the existing guide); it is **not** an
+  interactive coached overlay. An overlay-style tutorial is noted as a possible
+  future enhancement in Open decisions.
+
+### 6. Manual entry (v1); history (fast-follow)
+
+- **About screen (v1):** add a "What's New" row (`ui/about/AboutScreen.kt`) that
+  opens the *current* version's notes sheet directly. Makes the content
+  re-findable after dismissal, matching iOS, without needing history.
+- **History screen (fast-follow, not v1):** `WhatsNewHistoryRoute` lists every
+  `whatsnew/<locale>/*.md` via `AssetManager.list(...)`, sorted newest-first,
+  each opening its notes. Register the route in **both** nav graphs when built.
+  At that point, the About row switches to opening history (or gains a second
+  entry point), and the sheet regains its "See previous releases" link.
+
+## Files touched (v1)
+
+- **New:** `app/src/main/assets/whatsnew/<locale>/<version>.md` (all locales).
+- **New:** `ui/whatsnew/WhatsNewSheet.kt`, `WhatsNewViewModel.kt`, a loader (either
+  generalize `MarkdownAssetLoader` to take a base path, or a thin sibling).
+- **Edit:** `io/prefs/SettingsDataStoreImpl.kt` (+ interface) — two new keys.
+- **Edit:** `ui/shell/AppShell.kt` — trigger `LaunchedEffect` + sheet state (both
+  compact and expanded shells).
+- **Edit:** `ui/about/AboutScreen.kt` — "What's New" row (opens current notes).
+- **New strings** in `values/strings.xml` **and every** `values-*/strings.xml`
+  (English placeholders) per the localization rule: sheet title, "Got it",
+  welcome-nudge title/body, "Open the User Guide", "Not now", About row label.
+
+**Deferred to fast-follow:** `ui/whatsnew/WhatsNewHistoryScreen.kt`,
+`WhatsNewHistoryRoute` + registration in both `NavHost` blocks, "See previous
+releases" string.
+
+## Workflow / process changes
+
+- Add a release-prep step (CLAUDE.md + `docs/WORKFLOW.md`): when the release PR
+  moves `[Unreleased]` into a versioned heading, it must also **author
+  `whatsnew/en/<version>.md`** (curated from, but not a copy of, the changelog)
+  and drop English placeholder copies into every other locale.
+- Update the User Guide (`assets/guide/en/…`, likely `settings.md` or
+  `getting-started.md`) to mention the What's New surface and the About entry.
+
+## MyDeck port notes
+
+- The Android package is already `com.mydeck.app`, so this is largely a content +
+  branding swap, not a code fork.
+- Keep all logic asset-driven and free of hardcoded product names; the only
+  MyDeck-specific artifacts are the `whatsnew/**` copy and any product-name
+  strings.
+
+## Resolved decisions
+
+1. **rc/snapshot marker advance (§3, third branch):** the marker always advances,
+   whether or not the current version has a notes file. The trigger only ever
+   checks for a file matching the *exact current running version*, and never
+   looks backward across skipped versions — so "advance always" vs. "advance
+   only when shown" are functionally equivalent here; always-advance is simpler.
+   Note this means a user who updates straight through several versions (e.g.
+   1.0.0 → 1.0.3) only ever auto-sees 1.0.3's notes, never the skipped-over ones
+   — those remain reachable manually once the History screen (below) ships.
+2. **History deferred to a fast-follow.** v1 ships the trigger, single-version
+   sheet, and an About row that opens the *current* version's notes only. The
+   `WhatsNewHistoryRoute` (asset-listing, newest-first, both nav graphs) is a
+   follow-up PR. The sheet's "See previous releases" link is omitted from v1
+   copy rather than shipped disabled.
+3. **Sheet dismissal:** any dismissal — "Got it", swipe-away, or tap-outside —
+   is equivalent, since the marker is already advanced at show-time (§3). No
+   extra state needed; standard `ModalBottomSheet` dismiss behavior applies.
+4. **Welcome nudge vs. What's New collision:** on fresh install we record the
+   version silently and show only the guide nudge — never both surfaces at once.
+5. **Future (out of scope):** an optional interactive coached-overlay tutorial
+   (spotlight tips on real UI) as a richer alternative to the guide-link nudge.
+
+## Implementation checklist
+
+- [ ] DataStore keys + interface/read/write plumbing.
+- [ ] `WhatsNewAssetLoader` (locale-fallback markdown load, null on missing file).
+- [ ] `WhatsNewViewModel` (trigger evaluation + persisted marker).
+- [ ] `WhatsNewSheet` composable (Markwon render, header, "Got it" via `dismissSheet`).
+- [ ] `WelcomeGuideNudgeDialog` composable.
+- [ ] `AppShell` trigger `LaunchedEffect` + overlay wiring — **once**, at the
+      top-level `AppShell` composable (not duplicated per shell tier).
+- [ ] About row (`AboutViewModel` + `AboutScreen`) opening current version's notes.
+- [ ] `whatsnew/en/<current-version>.md` authored; placeholders in all locales.
+- [ ] New strings in all `strings.xml` files.
+- [ ] User Guide + CHANGELOG `[Unreleased]` updated.
+- [ ] `./scripts/ci-verify.sh` green.
+
+---
+
+## Implementation plan (finalized 2026-07-08)
+
+This section is the concrete build plan, refined after reviewing the actual
+`AppShell.kt` / `AboutScreen.kt` / `SettingsDataStoreImpl.kt` code. It supersedes
+the file/route assumptions above where they differ (notably: **no new nav
+route is needed for v1** — see §4 below).
+
+### Key discovery that simplifies the design
+
+`AppShell.kt` has a **single top-level `AppShell()` composable**
+(`ui/shell/AppShell.kt:88-179`) that dispatches to `CompactAppShell` /
+`MediumAppShell` / `ExpandedAppShell` based on window size — each of those has
+its *own* `NavHost`. Rather than duplicating the trigger/sheet logic three
+times, or adding a nav route that would need registering in three separate
+`NavHost` blocks, the trigger + overlays live **once, at the top of
+`AppShell()`**, as siblings placed *after* the `when (layoutTier) { ... }`
+block. `ModalBottomSheet` and `AlertDialog` render into their own window, so
+this placement works regardless of which tier is active — no layout
+restructuring required.
+
+### 1. Content assets
+
+`app/src/main/assets/whatsnew/<locale>/<versionName>.md` — one file per version
+per locale (`en, de, es, fr, gl, pl, pt, ru, uk, zh`; English authored, others
+placeholders per `CLAUDE.md`'s localization rule). No file for a version = the
+auto-trigger silently skips it (rc/snapshot builds naturally excluded). Author
+the `en` file for the next real release as part of this work, sourced from —
+not copied verbatim from — the `CHANGELOG.md` `[Unreleased]` section, in the
+iOS `RELEASE_NOTES.md` tone (bold lead-ins, short explanatory phrasing, skip
+internal-only entries).
+
+### 2. New: `WhatsNewAssetLoader` (`ui/whatsnew/WhatsNewAssetLoader.kt`)
+
+`@Singleton class WhatsNewAssetLoader @Inject constructor(@ApplicationContext context)`.
+One method: `fun loadNotesForVersion(version: String): String?`. Mirrors
+`MarkdownAssetLoader.getLocalePath()`'s locale-list/`en`-fallback logic (a
+small parallel implementation, not a shared base class — `MarkdownAssetLoader`
+returns a rendered "Error Loading Content" placeholder string on failure,
+whereas this needs a clean `null` to gate the trigger; coupling the two through
+inheritance for ~15 lines of locale logic isn't worth it). Strips frontmatter /
+leading H1 the same way as the guide loader. Returns `null` on `IOException`
+(missing file for this version — expected, not an error).
+
+### 3. New: `WhatsNewViewModel` (`ui/whatsnew/WhatsNewViewModel.kt`)
+
+```kotlin
+@HiltViewModel
+class WhatsNewViewModel @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val loader: WhatsNewAssetLoader,
+    private val settingsDataStore: SettingsDataStore,
+) : ViewModel() {
+    var uiState by mutableStateOf(WhatsNewUiState())
+        private set
+    private var evaluated = false
+
+    fun evaluateIfNeeded() {
+        if (evaluated) return
+        evaluated = true
+        viewModelScope.launch {
+            val current = AppVersion.versionName(context)
+            val lastSeen = settingsDataStore.getLastSeenWhatsNewVersion()
+            if (lastSeen == null) {
+                settingsDataStore.saveLastSeenWhatsNewVersion(current)
+                if (!settingsDataStore.isWelcomeGuidePromptShown()) {
+                    uiState = uiState.copy(showGuideNudge = true)
+                }
+                return@launch
+            }
+            if (current != lastSeen) {
+                val notes = loader.loadNotesForVersion(current)
+                settingsDataStore.saveLastSeenWhatsNewVersion(current)
+                if (notes != null) {
+                    uiState = uiState.copy(whatsNewContent = notes, whatsNewVersion = current)
+                }
+            }
+        }
+    }
+
+    fun onWhatsNewDismissed() { uiState = uiState.copy(whatsNewContent = null) }
+    fun onGuideNudgeDismissed() {
+        uiState = uiState.copy(showGuideNudge = false)
+        viewModelScope.launch { settingsDataStore.saveWelcomeGuidePromptShown(true) }
+    }
+    fun onGuideNudgeOpenGuide() = onGuideNudgeDismissed() // marking-seen is identical either way
+}
+
+data class WhatsNewUiState(
+    val whatsNewContent: String? = null,
+    val whatsNewVersion: String = "",
+    val showGuideNudge: Boolean = false,
+)
+```
+
+`evaluateIfNeeded()` is idempotent per ViewModel instance — a fresh evaluation
+only happens if the process/ViewModelStore is actually recreated (correct
+"once per cold start" granularity).
+
+### 4. Wire into `AppShell` (`ui/shell/AppShell.kt`)
+
+At the top of `AppShell()`, alongside the existing `layoutTier` computation:
+
+```kotlin
+val whatsNewViewModel: WhatsNewViewModel = hiltViewModel()
+val whatsNewState = whatsNewViewModel.uiState
+val token = settingsDataStore?.tokenFlow?.collectAsState()?.value
+LaunchedEffect(token) {
+    if (!token.isNullOrBlank()) whatsNewViewModel.evaluateIfNeeded()
+}
+```
+
+After the existing `when (layoutTier) { ... }` block:
+
+```kotlin
+whatsNewState.whatsNewContent?.let { content ->
+    WhatsNewSheet(
+        version = whatsNewState.whatsNewVersion,
+        content = content,
+        onDismiss = whatsNewViewModel::onWhatsNewDismissed,
+    )
+}
+if (whatsNewState.showGuideNudge) {
+    WelcomeGuideNudgeDialog(
+        onOpenGuide = {
+            whatsNewViewModel.onGuideNudgeOpenGuide()
+            navController.navigate(UserGuideRoute) { launchSingleTop = true }
+        },
+        onDismiss = whatsNewViewModel::onGuideNudgeDismissed,
+    )
+}
+```
+
+This is the **only** change to `AppShell.kt` — no nav-graph edits, applies
+uniformly across all three tiers.
+
+### 5. New: `WhatsNewSheet` (`ui/whatsnew/WhatsNewSheet.kt`)
+
+`ModalBottomSheet` + `rememberModalBottomSheetState()`. Header: "What's New" +
+version subtitle. Body: `rememberMarkwon(onSectionNavigate = {})` +
+the same `AndroidView(TextView)` pattern as
+`UserGuideSectionScreen.kt:150-174` (selectable text, `LinkMovementMethod`,
+`applyMarkwonColors`). Footer: single **Got it** button routed through
+`ui/components/BottomSheetDismiss.kt`'s `dismissSheet(sheetState) { onDismiss()
+}` (the #25 consistency helper), and `onDismissRequest` wired the same way, so
+button/swipe/scrim all animate identically. No history link in v1.
+
+### 6. New: `WelcomeGuideNudgeDialog` (`ui/whatsnew/WelcomeGuideNudgeDialog.kt`)
+
+Simple `AlertDialog`: title + one-line body, confirm **Open the User Guide**
+(`onOpenGuide`), dismiss **Not now** (`onDismiss`).
+
+### 7. About row (manual re-open)
+
+- `AboutViewModel.kt`: inject `WhatsNewAssetLoader`, add `whatsNewContent:
+  String?` + `showWhatsNewSheet: Boolean` to `UiState`, add `onClickWhatsNew()`
+  (loads via `viewModelScope.launch`, mirroring `loadAndRefreshServerInfo`'s
+  style) and `onDismissWhatsNewSheet()`.
+- `AboutScreen.kt`: add a "What's New" `Row` after the existing Font Licenses
+  row (`AboutScreen.kt:445-468` is the template), wired to `onClickWhatsNew`.
+  Render `WhatsNewSheet` conditionally at the bottom of `AboutScreenContent`.
+- No `Routes.kt` / `NavHost` changes for v1.
+
+### 8. `SettingsDataStore` additions
+
+```kotlin
+suspend fun getLastSeenWhatsNewVersion(): String?
+suspend fun saveLastSeenWhatsNewVersion(version: String)
+suspend fun isWelcomeGuidePromptShown(): Boolean
+suspend fun saveWelcomeGuidePromptShown(shown: Boolean)
+```
+
+New keys in `SettingsDataStoreImpl`, stored in `userPreferences` (non-sensitive
+tier, matching `KEY_LAYOUT_MODE`/`KEY_SHOW_COMPACT_FAVICONS`):
+`stringPreferencesKey("last_seen_whatsnew_version")`,
+`booleanPreferencesKey("welcome_guide_prompt_shown")`. No migration entries
+(brand-new keys, no legacy counterpart). Update any test fake implementing
+`SettingsDataStore` with the two new methods.
+
+### 9. Strings & docs
+
+New strings (sheet title, "Got it", nudge title/body, "Open the User Guide",
+"Not now", About row label+subtitle) in `values/strings.xml` and every
+`values-*/strings.xml`. Update `CHANGELOG.md` `[Unreleased]`, a User Guide page
+(English only), and add the release-prep step (author `whatsnew/en/<version>.md`)
+to `docs/WORKFLOW.md`/`CLAUDE.md`.
+
+### Files touched
+
+**New:** `assets/whatsnew/<locale>/<version>.md`,
+`ui/whatsnew/WhatsNewAssetLoader.kt`, `ui/whatsnew/WhatsNewViewModel.kt`,
+`ui/whatsnew/WhatsNewSheet.kt`, `ui/whatsnew/WelcomeGuideNudgeDialog.kt`.
+**Edited:** `ui/shell/AppShell.kt`, `io/prefs/SettingsDataStore.kt` +
+`SettingsDataStoreImpl.kt`, `ui/about/AboutViewModel.kt` + `AboutScreen.kt`,
+all `strings.xml`, `CHANGELOG.md`, a guide page, `docs/WORKFLOW.md`/`CLAUDE.md`.
+**Not touched:** `ui/navigation/Routes.kt`, both `NavHost` blocks (no new
+route needed in v1).
+
+### Verification
+
+1. `./gradlew :app:assembleDebugAll`, `:app:testDebugUnitTestAll`,
+   `:app:lintDebugAll` — compiles, existing unit tests (incl. any
+   `SettingsDataStore` fake) still pass, all-locales string lint passes.
+2. Manual, on-device:
+   - Fresh install (clear app data) → sign in → guide nudge appears once;
+     "Open the User Guide" navigates; "Not now" dismisses; never reappears.
+   - Simulate an update (rewrite the stored marker to an older value, or bump
+     `versionName` locally to one with a matching `whatsnew/en/<version>.md`)
+     → sheet shows only that version's notes; button/swipe/tap-outside all
+     dismiss identically; doesn't reappear next launch.
+   - About → "What's New" reopens current version's notes on demand.
+   - A version with no matching file → no sheet, no crash, marker still
+     advances.
+3. Dark/light theme rendering of the sheet's markdown matches the User Guide's
+   existing look (shared `MarkdownRenderer` styling).

--- a/docs/specs/whats-new-page-spec.md
+++ b/docs/specs/whats-new-page-spec.md
@@ -156,33 +156,50 @@ authenticated shell is reached with `welcome_guide_prompt_shown == false`).
   interactive coached overlay. An overlay-style tutorial is noted as a possible
   future enhancement in Open decisions.
 
-### 6. Manual entry (v1); history (fast-follow)
+### 6. Manual entry + history (both shipped)
 
-- **About screen (v1):** add a "What's New" row (`ui/about/AboutScreen.kt`) that
-  opens the *current* version's notes sheet directly. Makes the content
-  re-findable after dismissal, matching iOS, without needing history.
-- **History screen (fast-follow, not v1):** `WhatsNewHistoryRoute` lists every
-  `whatsnew/<locale>/*.md` via `AssetManager.list(...)`, sorted newest-first,
-  each opening its notes. Register the route in **both** nav graphs when built.
-  At that point, the About row switches to opening history (or gains a second
-  entry point), and the sheet regains its "See previous releases" link.
+- **History screen:** `WhatsNewHistoryRoute` (`ui/whatsnew/WhatsNewHistoryScreen.kt`
+  + `WhatsNewHistoryViewModel.kt`) lists every version with notes for the
+  resolved locale via `WhatsNewAssetLoader.listAvailableVersions()`
+  (`context.assets.list(...)`, `.md` suffix stripped), sorted newest-first with
+  a small numeric-aware `compareVersions` comparator (a plain string sort would
+  put `"1.0.10"` before `"1.0.9"`, and would rank a release below its own `-rc`
+  builds). Tapping a row loads that version's notes and shows them in the same
+  `WhatsNewSheet` used elsewhere. Registered in **both** `NavHost` blocks in
+  `AppShell.kt` (the inline one in `CompactAppShell` and the shared
+  `AppShellNavHost` used by `MediumAppShell`/`ExpandedAppShell`).
+- **About screen:** the "What's New" row now navigates to `WhatsNewHistoryRoute`
+  (via the existing `NavigationEvent` channel pattern) instead of opening the
+  current version's sheet directly — the top entry in history *is* the current
+  version, so this subsumes the original v1 behavior without a second affordance.
+  The row is gated on `AboutViewModel.UiState.hasWhatsNewHistory`
+  (`listAvailableVersions().isNotEmpty()`), not on the current version having
+  notes specifically.
+- **Auto-triggered sheet:** the on-update `WhatsNewSheet` shown from `AppShell`
+  gained the `onSeePreviousReleases` link (dismisses the sheet, then navigates to
+  `WhatsNewHistoryRoute`).
 
-## Files touched (v1)
+## Files touched
 
 - **New:** `app/src/main/assets/whatsnew/<locale>/<version>.md` (all locales).
-- **New:** `ui/whatsnew/WhatsNewSheet.kt`, `WhatsNewViewModel.kt`, a loader (either
-  generalize `MarkdownAssetLoader` to take a base path, or a thin sibling).
-- **Edit:** `io/prefs/SettingsDataStoreImpl.kt` (+ interface) — two new keys.
-- **Edit:** `ui/shell/AppShell.kt` — trigger `LaunchedEffect` + sheet state (both
-  compact and expanded shells).
-- **Edit:** `ui/about/AboutScreen.kt` — "What's New" row (opens current notes).
+- **New:** `ui/whatsnew/WhatsNewAssetLoader.kt`, `WhatsNewViewModel.kt`,
+  `WhatsNewSheet.kt`, `WelcomeGuideNudgeDialog.kt`, `WhatsNewHistoryViewModel.kt`,
+  `WhatsNewHistoryScreen.kt`.
+- **Edit:** `io/prefs/SettingsDataStore.kt` + `SettingsDataStoreImpl.kt` — two
+  new keys.
+- **Edit:** `ui/navigation/Routes.kt` — `WhatsNewHistoryRoute`.
+- **Edit:** `ui/shell/AppShell.kt` — trigger `LaunchedEffect` + sheet/dialog
+  overlays (once, top-level); `WhatsNewHistoryRoute` registered in both
+  `NavHost` blocks.
+- **Edit:** `ui/about/AboutViewModel.kt` + `AboutScreen.kt` — "What's New" row
+  navigating to history.
 - **New strings** in `values/strings.xml` **and every** `values-*/strings.xml`
-  (English placeholders) per the localization rule: sheet title, "Got it",
-  welcome-nudge title/body, "Open the User Guide", "Not now", About row label.
-
-**Deferred to fast-follow:** `ui/whatsnew/WhatsNewHistoryScreen.kt`,
-`WhatsNewHistoryRoute` + registration in both `NavHost` blocks, "See previous
-releases" string.
+  (English placeholders): sheet title, "Got it", "See previous releases",
+  welcome-nudge title/body, "Open the User Guide", "Not now", About row
+  label/subtitle, history screen title/empty-state.
+- **New test:** `WhatsNewAssetLoaderTest.kt` — covers `normalizeVersion` and the
+  `compareVersions` numeric/pre-release ordering (pure functions, no Robolectric
+  needed).
 
 ## Workflow / process changes
 
@@ -210,12 +227,12 @@ releases" string.
    only when shown" are functionally equivalent here; always-advance is simpler.
    Note this means a user who updates straight through several versions (e.g.
    1.0.0 → 1.0.3) only ever auto-sees 1.0.3's notes, never the skipped-over ones
-   — those remain reachable manually once the History screen (below) ships.
-2. **History deferred to a fast-follow.** v1 ships the trigger, single-version
-   sheet, and an About row that opens the *current* version's notes only. The
-   `WhatsNewHistoryRoute` (asset-listing, newest-first, both nav graphs) is a
-   follow-up PR. The sheet's "See previous releases" link is omitted from v1
-   copy rather than shipped disabled.
+   — those remain reachable manually via the History screen (below).
+2. **History shipped as a fast-follow (§6).** `WhatsNewHistoryRoute` lists every
+   version with notes, newest-first via a numeric-aware comparator, and is
+   registered in both nav graphs. The About row now opens history (its top entry
+   is the current version, subsuming the original v1 direct-open behavior), and
+   the auto-triggered sheet's "See previous releases" link navigates there too.
 3. **Sheet dismissal:** any dismissal — "Got it", swipe-away, or tap-outside —
    is equivalent, since the marker is already advanced at show-time (§3). No
    extra state needed; standard `ModalBottomSheet` dismiss behavior applies.

--- a/docs/specs/whats-new-page-spec.md
+++ b/docs/specs/whats-new-page-spec.md
@@ -62,8 +62,9 @@ before diving in.
 | Content source | **Curated, decoupled** from `CHANGELOG.md`; hand-synced at release-prep time. |
 | Scope shown on update | **Only the new release**, with an optional "See previous releases" link. |
 | Localization | **Full locale set** (en + placeholder files for all supported locales), following the guide pattern. |
-| Fresh install | **Suppress** What's New; show an optional dismissible **User Guide nudge** instead. |
+| Fresh install | **Suppress** What's New; show an optional dismissible **User Guide nudge** instead. A null marker is disambiguated from "upgrade from a pre-feature build" via `isInitialSyncPerformed()` — see Resolved decisions §6. |
 | Doc status | This spec stays **untracked** for now (active unrelated branch in flight). |
+| Release dates | Each `whatsnew/*.md` carries a `date:` YAML frontmatter field, shown in the history list (not the popup sheet — see Resolved decisions §7). |
 
 ## Design
 
@@ -108,10 +109,16 @@ current = AppVersion.versionName(context)
 lastSeen = prefs.last_seen_whatsnew_version   // may be null
 
 if lastSeen == null:
-    // Fresh install (or upgrade from a build predating this feature).
-    // Do NOT show What's New. Record current so it never fires retroactively.
     prefs.last_seen_whatsnew_version = current
-    maybeShowWelcomeGuidePrompt()             // see §5
+    if settingsDataStore.isInitialSyncPerformed():
+        // No marker, but this account already has synced data: an upgrade
+        // from a build that predates this feature, not a fresh install.
+        // Treat like any other version change — see Resolved decisions §6.
+        if assetExists("whatsnew/<locale-or-en>/$current.md"):
+            show What's New sheet for `current`
+    else:
+        // Genuinely fresh install. Do NOT show What's New.
+        maybeShowWelcomeGuidePrompt()          // see §5
 else if current != lastSeen AND assetExists("whatsnew/<locale-or-en>/$current.md"):
     show What's New sheet for `current`
     prefs.last_seen_whatsnew_version = current
@@ -230,9 +237,12 @@ authenticated shell is reached with `welcome_guide_prompt_shown == false`).
    — those remain reachable manually via the History screen (below).
 2. **History shipped as a fast-follow (§6).** `WhatsNewHistoryRoute` lists every
    version with notes, newest-first via a numeric-aware comparator, and is
-   registered in both nav graphs. The About row now opens history (its top entry
-   is the current version, subsuming the original v1 direct-open behavior), and
-   the auto-triggered sheet's "See previous releases" link navigates there too.
+   registered in both nav graphs. **Refined after initial ship:** the About row
+   opens the *current* version's note directly if one exists (falling back
+   straight to history if not) — closer to the original v1 behavior than pure
+   history-first, since that's the more common case. The sheet itself (both the
+   auto-triggered one and About's) carries a "See previous releases" link into
+   history; tapping any past entry there reopens it in the same sheet.
 3. **Sheet dismissal:** any dismissal — "Got it", swipe-away, or tap-outside —
    is equivalent, since the marker is already advanced at show-time (§3). No
    extra state needed; standard `ModalBottomSheet` dismiss behavior applies.
@@ -240,6 +250,32 @@ authenticated shell is reached with `welcome_guide_prompt_shown == false`).
    version silently and show only the guide nudge — never both surfaces at once.
 5. **Future (out of scope):** an optional interactive coached-overlay tutorial
    (spotlight tips on real UI) as a richer alternative to the guide-link nudge.
+6. **Null-marker disambiguation via `isInitialSyncPerformed()` (2026-07-09).**
+   The original design collapsed "fresh install" and "upgrade from a
+   pre-feature build" into one null-marker branch that always suppressed the
+   sheet, since a bare `null` can't tell them apart on its own — but it doesn't
+   have to be guessed blindly. `isInitialSyncPerformed()` (existing sync-state
+   flag) is already a reliable proxy: a genuinely new user hasn't completed
+   their first sync yet at this point, while an existing account upgrading
+   from a pre-feature build has been syncing for a while. So on `lastSeen ==
+   null`: if `isInitialSyncPerformed()` is true, treat it as a normal version
+   change (show the sheet if a note exists for the current version); if false,
+   treat it as fresh (silent record + guide nudge). No new state — reuses an
+   existing flag. Edge case: a user who signed in but hadn't completed their
+   first sync yet (e.g., offline) on the old build, then upgrades, incorrectly
+   gets the nudge once instead of the sheet — rare and harmless.
+7. **Release dates via frontmatter (2026-07-09).** Convention check: iOS's
+   `RELEASE_NOTES.md` and typical App/Play Store "what's new" text don't date
+   their entries — the OS/store already timestamps "updated on," making an
+   in-app date redundant for the *current*-version popup sheet. The **history**
+   list is different: it's changelog-style browsing spanning months (including
+   the MyDeck → Readeck rebrand), where "how long ago" is genuinely useful
+   context, and `CHANGELOG.md` already records a date per version anyway. So:
+   no date in `WhatsNewSheet` itself; each `whatsnew/*.md` carries a `date:
+   YYYY-MM-DD` YAML frontmatter field, parsed by `WhatsNewAssetLoader
+   .parseFrontmatterDate` (a pure, unit-tested companion function; malformed or
+   missing dates degrade to "no date shown," never a crash) and displayed
+   under the version in each `WhatsNewHistoryScreen` row.
 
 ## Implementation checklist
 
@@ -472,3 +508,69 @@ route needed in v1).
      advances.
 3. Dark/light theme rendering of the sheet's markdown matches the User Guide's
    existing look (shared `MarkdownRenderer` styling).
+
+---
+
+## Addendum (2026-07-09): null-marker refinement, release dates, rc1–rc5 content
+
+Covers the two logic refinements in Resolved decisions §6–§7, plus authoring
+real content for the backlog of already-shipped versions.
+
+### Code changes
+
+- `ui/whatsnew/WhatsNewViewModel.kt` — `evaluateIfNeeded()`'s null-marker branch
+  now checks `settingsDataStore.isInitialSyncPerformed()` before deciding
+  between "show the sheet" and "show the guide nudge" (§6). Extracted a
+  `showNotesIfAvailable(version)` helper shared by both the null-marker and
+  normal version-change paths.
+- `ui/whatsnew/WhatsNewAssetLoader.kt` — new `WhatsNewHistoryEntry(version,
+  date: LocalDate?)` data class; `listAvailableVersions()` now returns
+  `List<WhatsNewHistoryEntry>` instead of `List<String>` (still newest-first);
+  new pure companion function `parseFrontmatterDate(raw): LocalDate?`; shared
+  `readRawFile(version)` private helper so `loadNotesForVersion` and the new
+  date parsing don't duplicate the asset-open/try-catch.
+- `ui/whatsnew/WhatsNewHistoryViewModel.kt` / `WhatsNewHistoryScreen.kt` —
+  updated for the `WhatsNewHistoryEntry` type; each history row now shows the
+  parsed date (ISO `YYYY-MM-DD`, locale-neutral) under the version, when present.
+- `WhatsNewAssetLoaderTest.kt` — added `parseFrontmatterDate` cases: reads a
+  valid date, returns null with no frontmatter, returns null with frontmatter
+  but no `date:` field, returns null (not a crash) for a malformed date.
+- `docs/WORKFLOW.md` — release-prep step 4 now shows the `date:` frontmatter
+  block in its `whatsnew/en/X.Y.Z.md` template.
+
+### Content authored
+
+Real (not placeholder-only) English content for every version since the
+MyDeck → Readeck rebrand, each with `date:` frontmatter matching its
+`CHANGELOG.md` heading, curated (not copy-pasted) per the workflow rule —
+internal-only entries (F-Droid build changes, dead-code removal) dropped:
+
+- `whatsnew/en/1.0.0-rc1.md` (2026-06-08) — the rebrand itself: new name, new
+  home on Codeberg.
+- `whatsnew/en/1.0.0-rc2.md` (2026-06-21) — offline pinning, storage-pool split,
+  foreground-service downloads.
+- `whatsnew/en/1.0.0-rc3.md` (2026-06-27) — quick label-edit, UI-customization
+  toggles, label search ranking, error/no-content badges, assorted fixes.
+- `whatsnew/en/1.0.0-rc4.md` (2026-06-29) — nightly-server sign-in fix.
+- `whatsnew/en/1.0.0-rc5.md` (2026-07-03) — added `date:` frontmatter to the
+  file authored during initial development (content unchanged).
+
+English-placeholder copies (verbatim, per the localization rule) created for
+all five versions across all nine other locales (`de, es, fr, gl, pl, pt, ru,
+uk, zh`) — 45 additional files.
+
+**v1.0.0 (production release) is deliberately not authored yet** — see the
+"What to do with v1.0.0" discussion (2026-07-09, not written into this doc
+verbatim): plan is a short milestone-style note ("official 1.0.0 release, now
+on Google Play," with a one-line nod to the MyDeck rebrand) rather than a
+bare "no changes" note, authored at actual release-prep time once versioning
+is finalized.
+
+### Note on auto-popup semantics for already-installed testers
+
+Because this feature didn't exist before rc5, any tester already on rc5 will
+hit the null-marker branch the first time they update to whichever version
+ships this feature. With the §6 refinement, since they'll have
+`isInitialSyncPerformed() == true`, they *will* see that version's sheet (if a
+note exists) rather than just the nudge — the original gap this refinement
+was built to close.


### PR DESCRIPTION
## What's New sheet + release history

Adds a curated, per-version **What's New** experience, ported from Readeck for Android and adapted for MyDeck. After an update, a short bottom sheet highlights what changed; **About → What's New** browses the full release history.

### Added

- **What's New sheet on update** — the first time the app is opened after updating to a version that has notes, a bottom sheet highlights that release's changes. Content lives in `app/src/main/assets/whatsnew/<locale>/<version>.md`, curated and decoupled from `CHANGELOG.md`, so the copy is user-facing and skips internal-only entries. A version with no matching file simply never fires the sheet.
- **First-launch guide nudge** — genuinely fresh installs don't see What's New; instead they get a one-time, dismissible nudge toward the User Guide.
- **Release history** — **About → What's New** opens the current version's notes if they exist (falling back to history if not). From there, "See previous releases" lists every version with notes, newest-first via a numeric-aware comparator, each showing its release date; tapping one reopens it in the same sheet.
- **Release notes back to the MyDeck rebrand** — authored real, curated notes for every release from 0.9.0 through 0.14.5, each dated from its `CHANGELOG.md` heading, so the history list ships populated. English-placeholder copies added for all supported locales pending translation.

### Changed

- **Fresh-install vs. pre-feature-upgrade disambiguation** — an existing user upgrading from a build that predates this feature now correctly sees the What's New sheet (not just the guide nudge). A null "last seen" marker is disambiguated via the existing `isInitialSyncPerformed()` flag: already-synced ⇒ show the sheet; never-synced ⇒ treat as a fresh install.

### Docs

- `docs/specs/whats-new-page-spec.md` — feature spec (ported, MyDeck-adapted).
- `docs/porting/whats-new-page-port.md` — cross-repo port checklist.
- `docs/WORKFLOW.md` — release-prep step now covers authoring the `whatsnew/en/X.Y.Z.md` file, including the `date:` frontmatter and the consistent `**Bold lead-in:** description` entry format.

### Notes

- No schema changes; the two new preference keys are Preferences DataStore, not Room.
- Ported from Readeck for Android commits `9ebe5bf`, `b241612`, `1b43fa1`, `b6eeb55` (the sample `whatsnew/*.md` content files were intentionally not ported — MyDeck authors its own). See `docs/porting/whats-new-page-port.md`.

### Test plan

- [x] `./gradlew :app:assembleDebugAll :app:testDebugUnitTestAll :app:lintDebugAll` green
- [x] On-device: simulated a version bump to fire the on-update sheet; verified the guide nudge on fresh install; browsed the history list (all 17 entries, correct dates/order, each note renders and stays no-scroll)