### PR TITLE
chore(release): bump version to 0.14.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.6] - 2026-07-10
+
 ### Added
 
 - **Reading fonts** — the reading view now offers a curated app font set (System Default, Literata, Cantarell, Cormorant Garamond, Recursive, Bitter, Gentium, Old Standard, JetBrains Mono). A new **Include native Readeck fonts** setting (off by default) adds the fonts from Readeck's native reading view (Lora, Public Sans, Merriweather, Inter, IBM Plex Serif, Luciole, Atkinson Hyperlegible).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,8 +30,8 @@ android {
         applicationId = "com.mydeck.app"
         minSdk = 24
         targetSdk = 35
-        versionCode = 14005
-        versionName = "0.14.5"
+        versionCode = 14006
+        versionName = "0.14.6"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/assets/whatsnew/de/0.14.6.md
+++ b/app/src/main/assets/whatsnew/de/0.14.6.md
@@ -1,0 +1,16 @@
+---
+date: 2026-07-10
+---
+# What's New in 0.14.6
+
+**Reading fonts:** The reading view now offers a curated set of app fonts with a dedicated picker that previews each font in its own typeface and applies it live. An optional setting adds the fonts from Readeck's own reader.
+
+**Better font coverage:** Bundled fonts now render real bold and support Latin Extended (for example Polish) and, where available, Cyrillic (Russian, Ukrainian). A new Font licenses page under About credits every bundled font.
+
+**Browser sign-in:** Tapping Sign In now opens the Readeck authorization page in your browser and completes sign-in without entering a code. If you can't use a browser, "Sign in with a code instead" still works.
+
+**What's New and release history:** After updating, a short sheet like this one highlights what changed, and About now lists every past release's notes.
+
+**Clearer delete confirmations:** Deleting a label shows how many bookmarks it affects, and deleting 25 or more bookmarks at once asks for an extra confirmation.
+
+**Fixes:** Bottom sheets now slide closed consistently when you dismiss them with a button, and browser sign-in shows your correct username on the Account screen.

--- a/app/src/main/assets/whatsnew/en/0.14.6.md
+++ b/app/src/main/assets/whatsnew/en/0.14.6.md
@@ -1,0 +1,16 @@
+---
+date: 2026-07-10
+---
+# What's New in 0.14.6
+
+**Reading fonts:** The reading view now offers a curated set of app fonts with a dedicated picker that previews each font in its own typeface and applies it live. An optional setting adds the fonts from Readeck's own reader.
+
+**Better font coverage:** Bundled fonts now render real bold and support Latin Extended (for example Polish) and, where available, Cyrillic (Russian, Ukrainian). A new Font licenses page under About credits every bundled font.
+
+**Browser sign-in:** Tapping Sign In now opens the Readeck authorization page in your browser and completes sign-in without entering a code. If you can't use a browser, "Sign in with a code instead" still works.
+
+**What's New and release history:** After updating, a short sheet like this one highlights what changed, and About now lists every past release's notes.
+
+**Clearer delete confirmations:** Deleting a label shows how many bookmarks it affects, and deleting 25 or more bookmarks at once asks for an extra confirmation.
+
+**Fixes:** Bottom sheets now slide closed consistently when you dismiss them with a button, and browser sign-in shows your correct username on the Account screen.

--- a/app/src/main/assets/whatsnew/es/0.14.6.md
+++ b/app/src/main/assets/whatsnew/es/0.14.6.md
@@ -1,0 +1,16 @@
+---
+date: 2026-07-10
+---
+# What's New in 0.14.6
+
+**Reading fonts:** The reading view now offers a curated set of app fonts with a dedicated picker that previews each font in its own typeface and applies it live. An optional setting adds the fonts from Readeck's own reader.
+
+**Better font coverage:** Bundled fonts now render real bold and support Latin Extended (for example Polish) and, where available, Cyrillic (Russian, Ukrainian). A new Font licenses page under About credits every bundled font.
+
+**Browser sign-in:** Tapping Sign In now opens the Readeck authorization page in your browser and completes sign-in without entering a code. If you can't use a browser, "Sign in with a code instead" still works.
+
+**What's New and release history:** After updating, a short sheet like this one highlights what changed, and About now lists every past release's notes.
+
+**Clearer delete confirmations:** Deleting a label shows how many bookmarks it affects, and deleting 25 or more bookmarks at once asks for an extra confirmation.
+
+**Fixes:** Bottom sheets now slide closed consistently when you dismiss them with a button, and browser sign-in shows your correct username on the Account screen.

--- a/app/src/main/assets/whatsnew/fr/0.14.6.md
+++ b/app/src/main/assets/whatsnew/fr/0.14.6.md
@@ -1,0 +1,16 @@
+---
+date: 2026-07-10
+---
+# What's New in 0.14.6
+
+**Reading fonts:** The reading view now offers a curated set of app fonts with a dedicated picker that previews each font in its own typeface and applies it live. An optional setting adds the fonts from Readeck's own reader.
+
+**Better font coverage:** Bundled fonts now render real bold and support Latin Extended (for example Polish) and, where available, Cyrillic (Russian, Ukrainian). A new Font licenses page under About credits every bundled font.
+
+**Browser sign-in:** Tapping Sign In now opens the Readeck authorization page in your browser and completes sign-in without entering a code. If you can't use a browser, "Sign in with a code instead" still works.
+
+**What's New and release history:** After updating, a short sheet like this one highlights what changed, and About now lists every past release's notes.
+
+**Clearer delete confirmations:** Deleting a label shows how many bookmarks it affects, and deleting 25 or more bookmarks at once asks for an extra confirmation.
+
+**Fixes:** Bottom sheets now slide closed consistently when you dismiss them with a button, and browser sign-in shows your correct username on the Account screen.

--- a/app/src/main/assets/whatsnew/gl/0.14.6.md
+++ b/app/src/main/assets/whatsnew/gl/0.14.6.md
@@ -1,0 +1,16 @@
+---
+date: 2026-07-10
+---
+# What's New in 0.14.6
+
+**Reading fonts:** The reading view now offers a curated set of app fonts with a dedicated picker that previews each font in its own typeface and applies it live. An optional setting adds the fonts from Readeck's own reader.
+
+**Better font coverage:** Bundled fonts now render real bold and support Latin Extended (for example Polish) and, where available, Cyrillic (Russian, Ukrainian). A new Font licenses page under About credits every bundled font.
+
+**Browser sign-in:** Tapping Sign In now opens the Readeck authorization page in your browser and completes sign-in without entering a code. If you can't use a browser, "Sign in with a code instead" still works.
+
+**What's New and release history:** After updating, a short sheet like this one highlights what changed, and About now lists every past release's notes.
+
+**Clearer delete confirmations:** Deleting a label shows how many bookmarks it affects, and deleting 25 or more bookmarks at once asks for an extra confirmation.
+
+**Fixes:** Bottom sheets now slide closed consistently when you dismiss them with a button, and browser sign-in shows your correct username on the Account screen.

--- a/app/src/main/assets/whatsnew/pl/0.14.6.md
+++ b/app/src/main/assets/whatsnew/pl/0.14.6.md
@@ -1,0 +1,16 @@
+---
+date: 2026-07-10
+---
+# What's New in 0.14.6
+
+**Reading fonts:** The reading view now offers a curated set of app fonts with a dedicated picker that previews each font in its own typeface and applies it live. An optional setting adds the fonts from Readeck's own reader.
+
+**Better font coverage:** Bundled fonts now render real bold and support Latin Extended (for example Polish) and, where available, Cyrillic (Russian, Ukrainian). A new Font licenses page under About credits every bundled font.
+
+**Browser sign-in:** Tapping Sign In now opens the Readeck authorization page in your browser and completes sign-in without entering a code. If you can't use a browser, "Sign in with a code instead" still works.
+
+**What's New and release history:** After updating, a short sheet like this one highlights what changed, and About now lists every past release's notes.
+
+**Clearer delete confirmations:** Deleting a label shows how many bookmarks it affects, and deleting 25 or more bookmarks at once asks for an extra confirmation.
+
+**Fixes:** Bottom sheets now slide closed consistently when you dismiss them with a button, and browser sign-in shows your correct username on the Account screen.

--- a/app/src/main/assets/whatsnew/pt/0.14.6.md
+++ b/app/src/main/assets/whatsnew/pt/0.14.6.md
@@ -1,0 +1,16 @@
+---
+date: 2026-07-10
+---
+# What's New in 0.14.6
+
+**Reading fonts:** The reading view now offers a curated set of app fonts with a dedicated picker that previews each font in its own typeface and applies it live. An optional setting adds the fonts from Readeck's own reader.
+
+**Better font coverage:** Bundled fonts now render real bold and support Latin Extended (for example Polish) and, where available, Cyrillic (Russian, Ukrainian). A new Font licenses page under About credits every bundled font.
+
+**Browser sign-in:** Tapping Sign In now opens the Readeck authorization page in your browser and completes sign-in without entering a code. If you can't use a browser, "Sign in with a code instead" still works.
+
+**What's New and release history:** After updating, a short sheet like this one highlights what changed, and About now lists every past release's notes.
+
+**Clearer delete confirmations:** Deleting a label shows how many bookmarks it affects, and deleting 25 or more bookmarks at once asks for an extra confirmation.
+
+**Fixes:** Bottom sheets now slide closed consistently when you dismiss them with a button, and browser sign-in shows your correct username on the Account screen.

--- a/app/src/main/assets/whatsnew/ru/0.14.6.md
+++ b/app/src/main/assets/whatsnew/ru/0.14.6.md
@@ -1,0 +1,16 @@
+---
+date: 2026-07-10
+---
+# What's New in 0.14.6
+
+**Reading fonts:** The reading view now offers a curated set of app fonts with a dedicated picker that previews each font in its own typeface and applies it live. An optional setting adds the fonts from Readeck's own reader.
+
+**Better font coverage:** Bundled fonts now render real bold and support Latin Extended (for example Polish) and, where available, Cyrillic (Russian, Ukrainian). A new Font licenses page under About credits every bundled font.
+
+**Browser sign-in:** Tapping Sign In now opens the Readeck authorization page in your browser and completes sign-in without entering a code. If you can't use a browser, "Sign in with a code instead" still works.
+
+**What's New and release history:** After updating, a short sheet like this one highlights what changed, and About now lists every past release's notes.
+
+**Clearer delete confirmations:** Deleting a label shows how many bookmarks it affects, and deleting 25 or more bookmarks at once asks for an extra confirmation.
+
+**Fixes:** Bottom sheets now slide closed consistently when you dismiss them with a button, and browser sign-in shows your correct username on the Account screen.

--- a/app/src/main/assets/whatsnew/uk/0.14.6.md
+++ b/app/src/main/assets/whatsnew/uk/0.14.6.md
@@ -1,0 +1,16 @@
+---
+date: 2026-07-10
+---
+# What's New in 0.14.6
+
+**Reading fonts:** The reading view now offers a curated set of app fonts with a dedicated picker that previews each font in its own typeface and applies it live. An optional setting adds the fonts from Readeck's own reader.
+
+**Better font coverage:** Bundled fonts now render real bold and support Latin Extended (for example Polish) and, where available, Cyrillic (Russian, Ukrainian). A new Font licenses page under About credits every bundled font.
+
+**Browser sign-in:** Tapping Sign In now opens the Readeck authorization page in your browser and completes sign-in without entering a code. If you can't use a browser, "Sign in with a code instead" still works.
+
+**What's New and release history:** After updating, a short sheet like this one highlights what changed, and About now lists every past release's notes.
+
+**Clearer delete confirmations:** Deleting a label shows how many bookmarks it affects, and deleting 25 or more bookmarks at once asks for an extra confirmation.
+
+**Fixes:** Bottom sheets now slide closed consistently when you dismiss them with a button, and browser sign-in shows your correct username on the Account screen.

--- a/app/src/main/assets/whatsnew/zh/0.14.6.md
+++ b/app/src/main/assets/whatsnew/zh/0.14.6.md
@@ -1,0 +1,16 @@
+---
+date: 2026-07-10
+---
+# What's New in 0.14.6
+
+**Reading fonts:** The reading view now offers a curated set of app fonts with a dedicated picker that previews each font in its own typeface and applies it live. An optional setting adds the fonts from Readeck's own reader.
+
+**Better font coverage:** Bundled fonts now render real bold and support Latin Extended (for example Polish) and, where available, Cyrillic (Russian, Ukrainian). A new Font licenses page under About credits every bundled font.
+
+**Browser sign-in:** Tapping Sign In now opens the Readeck authorization page in your browser and completes sign-in without entering a code. If you can't use a browser, "Sign in with a code instead" still works.
+
+**What's New and release history:** After updating, a short sheet like this one highlights what changed, and About now lists every past release's notes.
+
+**Clearer delete confirmations:** Deleting a label shows how many bookmarks it affects, and deleting 25 or more bookmarks at once asks for an extra confirmation.
+
+**Fixes:** Bottom sheets now slide closed consistently when you dismiss them with a button, and browser sign-in shows your correct username on the Account screen.

--- a/metadata/en-US/changelogs/14006.txt
+++ b/metadata/en-US/changelogs/14006.txt
@@ -1,0 +1,13 @@
+<b>Added</b>
+- Reading fonts: a curated set of app fonts with a live font picker, plus an optional set of Readeck's own reader fonts
+- Wider font coverage: real bold, Latin Extended, and Cyrillic where the font supports it; new Font licenses page under About
+- Browser-based OAuth sign-in (Authorization Code + PKCE): tap Sign In to authorize in your browser, no code entry; a "Sign in with a code instead" fallback remains
+- What's New sheet on update, plus a release-history list under About
+
+<b>Changed</b>
+- Label delete confirmation now shows how many bookmarks are affected
+- Deleting 25 or more bookmarks at once asks for an extra confirmation
+- Bottom sheets slide closed consistently when dismissed with a button
+
+<b>Fixed</b>
+- Browser sign-in now shows your actual username on the Account screen


### PR DESCRIPTION
Release prep for v0.14.6: version bump (14006), CHANGELOG rollover, Fastlane store changelog, and the in-app What's New sheet (+ 9 locale placeholders). Tagging + release build follow after merge.