### PR TITLE
fix: make the What's New sheet scrollable

### DIFF
--- a/app/src/main/assets/whatsnew/de/0.14.6.md
+++ b/app/src/main/assets/whatsnew/de/0.14.6.md
@@ -3,9 +3,7 @@ date: 2026-07-10
 ---
 # What's New in 0.14.6
 
-**Reading fonts:** The reading view now offers a curated set of app fonts with a dedicated picker that previews each font in its own typeface and applies it live. An optional setting adds the fonts from Readeck's own reader.
-
-**Better font coverage:** Bundled fonts now render real bold and support Latin Extended (for example Polish) and, where available, Cyrillic (Russian, Ukrainian). A new Font licenses page under About credits every bundled font.
+**Reading fonts:** The reading view now offers a curated set of app fonts with a dedicated picker that previews and applies each one live, plus an optional set of Readeck's own reader fonts. Bundled fonts now render real bold and cover Latin Extended (for example Polish) and, where available, Cyrillic; a new Font licenses page under About credits them all.
 
 **Browser sign-in:** Tapping Sign In now opens the Readeck authorization page in your browser and completes sign-in without entering a code. If you can't use a browser, "Sign in with a code instead" still works.
 

--- a/app/src/main/assets/whatsnew/en/0.14.6.md
+++ b/app/src/main/assets/whatsnew/en/0.14.6.md
@@ -3,9 +3,7 @@ date: 2026-07-10
 ---
 # What's New in 0.14.6
 
-**Reading fonts:** The reading view now offers a curated set of app fonts with a dedicated picker that previews each font in its own typeface and applies it live. An optional setting adds the fonts from Readeck's own reader.
-
-**Better font coverage:** Bundled fonts now render real bold and support Latin Extended (for example Polish) and, where available, Cyrillic (Russian, Ukrainian). A new Font licenses page under About credits every bundled font.
+**Reading fonts:** The reading view now offers a curated set of app fonts with a dedicated picker that previews and applies each one live, plus an optional set of Readeck's own reader fonts. Bundled fonts now render real bold and cover Latin Extended (for example Polish) and, where available, Cyrillic; a new Font licenses page under About credits them all.
 
 **Browser sign-in:** Tapping Sign In now opens the Readeck authorization page in your browser and completes sign-in without entering a code. If you can't use a browser, "Sign in with a code instead" still works.
 

--- a/app/src/main/assets/whatsnew/es/0.14.6.md
+++ b/app/src/main/assets/whatsnew/es/0.14.6.md
@@ -3,9 +3,7 @@ date: 2026-07-10
 ---
 # What's New in 0.14.6
 
-**Reading fonts:** The reading view now offers a curated set of app fonts with a dedicated picker that previews each font in its own typeface and applies it live. An optional setting adds the fonts from Readeck's own reader.
-
-**Better font coverage:** Bundled fonts now render real bold and support Latin Extended (for example Polish) and, where available, Cyrillic (Russian, Ukrainian). A new Font licenses page under About credits every bundled font.
+**Reading fonts:** The reading view now offers a curated set of app fonts with a dedicated picker that previews and applies each one live, plus an optional set of Readeck's own reader fonts. Bundled fonts now render real bold and cover Latin Extended (for example Polish) and, where available, Cyrillic; a new Font licenses page under About credits them all.
 
 **Browser sign-in:** Tapping Sign In now opens the Readeck authorization page in your browser and completes sign-in without entering a code. If you can't use a browser, "Sign in with a code instead" still works.
 

--- a/app/src/main/assets/whatsnew/fr/0.14.6.md
+++ b/app/src/main/assets/whatsnew/fr/0.14.6.md
@@ -3,9 +3,7 @@ date: 2026-07-10
 ---
 # What's New in 0.14.6
 
-**Reading fonts:** The reading view now offers a curated set of app fonts with a dedicated picker that previews each font in its own typeface and applies it live. An optional setting adds the fonts from Readeck's own reader.
-
-**Better font coverage:** Bundled fonts now render real bold and support Latin Extended (for example Polish) and, where available, Cyrillic (Russian, Ukrainian). A new Font licenses page under About credits every bundled font.
+**Reading fonts:** The reading view now offers a curated set of app fonts with a dedicated picker that previews and applies each one live, plus an optional set of Readeck's own reader fonts. Bundled fonts now render real bold and cover Latin Extended (for example Polish) and, where available, Cyrillic; a new Font licenses page under About credits them all.
 
 **Browser sign-in:** Tapping Sign In now opens the Readeck authorization page in your browser and completes sign-in without entering a code. If you can't use a browser, "Sign in with a code instead" still works.
 

--- a/app/src/main/assets/whatsnew/gl/0.14.6.md
+++ b/app/src/main/assets/whatsnew/gl/0.14.6.md
@@ -3,9 +3,7 @@ date: 2026-07-10
 ---
 # What's New in 0.14.6
 
-**Reading fonts:** The reading view now offers a curated set of app fonts with a dedicated picker that previews each font in its own typeface and applies it live. An optional setting adds the fonts from Readeck's own reader.
-
-**Better font coverage:** Bundled fonts now render real bold and support Latin Extended (for example Polish) and, where available, Cyrillic (Russian, Ukrainian). A new Font licenses page under About credits every bundled font.
+**Reading fonts:** The reading view now offers a curated set of app fonts with a dedicated picker that previews and applies each one live, plus an optional set of Readeck's own reader fonts. Bundled fonts now render real bold and cover Latin Extended (for example Polish) and, where available, Cyrillic; a new Font licenses page under About credits them all.
 
 **Browser sign-in:** Tapping Sign In now opens the Readeck authorization page in your browser and completes sign-in without entering a code. If you can't use a browser, "Sign in with a code instead" still works.
 

--- a/app/src/main/assets/whatsnew/pl/0.14.6.md
+++ b/app/src/main/assets/whatsnew/pl/0.14.6.md
@@ -3,9 +3,7 @@ date: 2026-07-10
 ---
 # What's New in 0.14.6
 
-**Reading fonts:** The reading view now offers a curated set of app fonts with a dedicated picker that previews each font in its own typeface and applies it live. An optional setting adds the fonts from Readeck's own reader.
-
-**Better font coverage:** Bundled fonts now render real bold and support Latin Extended (for example Polish) and, where available, Cyrillic (Russian, Ukrainian). A new Font licenses page under About credits every bundled font.
+**Reading fonts:** The reading view now offers a curated set of app fonts with a dedicated picker that previews and applies each one live, plus an optional set of Readeck's own reader fonts. Bundled fonts now render real bold and cover Latin Extended (for example Polish) and, where available, Cyrillic; a new Font licenses page under About credits them all.
 
 **Browser sign-in:** Tapping Sign In now opens the Readeck authorization page in your browser and completes sign-in without entering a code. If you can't use a browser, "Sign in with a code instead" still works.
 

--- a/app/src/main/assets/whatsnew/pt/0.14.6.md
+++ b/app/src/main/assets/whatsnew/pt/0.14.6.md
@@ -3,9 +3,7 @@ date: 2026-07-10
 ---
 # What's New in 0.14.6
 
-**Reading fonts:** The reading view now offers a curated set of app fonts with a dedicated picker that previews each font in its own typeface and applies it live. An optional setting adds the fonts from Readeck's own reader.
-
-**Better font coverage:** Bundled fonts now render real bold and support Latin Extended (for example Polish) and, where available, Cyrillic (Russian, Ukrainian). A new Font licenses page under About credits every bundled font.
+**Reading fonts:** The reading view now offers a curated set of app fonts with a dedicated picker that previews and applies each one live, plus an optional set of Readeck's own reader fonts. Bundled fonts now render real bold and cover Latin Extended (for example Polish) and, where available, Cyrillic; a new Font licenses page under About credits them all.
 
 **Browser sign-in:** Tapping Sign In now opens the Readeck authorization page in your browser and completes sign-in without entering a code. If you can't use a browser, "Sign in with a code instead" still works.
 

--- a/app/src/main/assets/whatsnew/ru/0.14.6.md
+++ b/app/src/main/assets/whatsnew/ru/0.14.6.md
@@ -3,9 +3,7 @@ date: 2026-07-10
 ---
 # What's New in 0.14.6
 
-**Reading fonts:** The reading view now offers a curated set of app fonts with a dedicated picker that previews each font in its own typeface and applies it live. An optional setting adds the fonts from Readeck's own reader.
-
-**Better font coverage:** Bundled fonts now render real bold and support Latin Extended (for example Polish) and, where available, Cyrillic (Russian, Ukrainian). A new Font licenses page under About credits every bundled font.
+**Reading fonts:** The reading view now offers a curated set of app fonts with a dedicated picker that previews and applies each one live, plus an optional set of Readeck's own reader fonts. Bundled fonts now render real bold and cover Latin Extended (for example Polish) and, where available, Cyrillic; a new Font licenses page under About credits them all.
 
 **Browser sign-in:** Tapping Sign In now opens the Readeck authorization page in your browser and completes sign-in without entering a code. If you can't use a browser, "Sign in with a code instead" still works.
 

--- a/app/src/main/assets/whatsnew/uk/0.14.6.md
+++ b/app/src/main/assets/whatsnew/uk/0.14.6.md
@@ -3,9 +3,7 @@ date: 2026-07-10
 ---
 # What's New in 0.14.6
 
-**Reading fonts:** The reading view now offers a curated set of app fonts with a dedicated picker that previews each font in its own typeface and applies it live. An optional setting adds the fonts from Readeck's own reader.
-
-**Better font coverage:** Bundled fonts now render real bold and support Latin Extended (for example Polish) and, where available, Cyrillic (Russian, Ukrainian). A new Font licenses page under About credits every bundled font.
+**Reading fonts:** The reading view now offers a curated set of app fonts with a dedicated picker that previews and applies each one live, plus an optional set of Readeck's own reader fonts. Bundled fonts now render real bold and cover Latin Extended (for example Polish) and, where available, Cyrillic; a new Font licenses page under About credits them all.
 
 **Browser sign-in:** Tapping Sign In now opens the Readeck authorization page in your browser and completes sign-in without entering a code. If you can't use a browser, "Sign in with a code instead" still works.
 

--- a/app/src/main/assets/whatsnew/zh/0.14.6.md
+++ b/app/src/main/assets/whatsnew/zh/0.14.6.md
@@ -3,9 +3,7 @@ date: 2026-07-10
 ---
 # What's New in 0.14.6
 
-**Reading fonts:** The reading view now offers a curated set of app fonts with a dedicated picker that previews each font in its own typeface and applies it live. An optional setting adds the fonts from Readeck's own reader.
-
-**Better font coverage:** Bundled fonts now render real bold and support Latin Extended (for example Polish) and, where available, Cyrillic (Russian, Ukrainian). A new Font licenses page under About credits every bundled font.
+**Reading fonts:** The reading view now offers a curated set of app fonts with a dedicated picker that previews and applies each one live, plus an optional set of Readeck's own reader fonts. Bundled fonts now render real bold and cover Latin Extended (for example Polish) and, where available, Cyrillic; a new Font licenses page under About credits them all.
 
 **Browser sign-in:** Tapping Sign In now opens the Readeck authorization page in your browser and completes sign-in without entering a code. If you can't use a browser, "Sign in with a code instead" still works.
 

--- a/app/src/main/java/com/mydeck/app/ui/whatsnew/WhatsNewSheet.kt
+++ b/app/src/main/java/com/mydeck/app/ui/whatsnew/WhatsNewSheet.kt
@@ -3,6 +3,8 @@ package com.mydeck.app.ui.whatsnew
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
@@ -39,7 +41,11 @@ fun WhatsNewSheet(
         onDismissRequest = { scope.dismissSheet(sheetState) { onDismiss() } },
         sheetState = sheetState,
     ) {
-        Column(modifier = Modifier.padding(horizontal = 24.dp)) {
+        Column(
+            modifier = Modifier
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 24.dp)
+        ) {
             Text(
                 text = stringResource(R.string.whats_new_title),
                 style = MaterialTheme.typography.headlineSmall


### PR DESCRIPTION
Fixes a real bug in the What's New sheet (new in v0.14.6, from #226): the content column had no `verticalScroll`, so with `skipPartiallyExpanded` a tall release note — and the "Got it" / "See previous releases" buttons — ran off the bottom of the screen with no way to reach it. This sheet backs every entry path (auto-launch on update, About → current version, and tapping a history entry), so the fix covers all of them.

- **`WhatsNewSheet.kt`:** add `verticalScroll` to the content column.
- **`whatsnew/*/0.14.6.md`:** condense the 0.14.6 notes (merge the two font entries, 6 → 5) toward the intended single no-scroll sheet.

Verified: `:app:testDebugUnitTestAll` + `:app:lintDebugAll` + `:app:assembleDebugAll` green across all flavors.

**Note — separate, not fixed here (not a release bug):** on snapshot/nightly builds, About → What's New shows the history list instead of the current sheet, because CI stamps the versionName as `<timestamp>-<sha>-snapshot` which `normalizeVersion` can't map back to `0.14.6`. Release builds resolve correctly. Recorded as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)