### PR TITLE
fix: use a distinct OAuth callback scheme per non-production flavor

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,7 +38,10 @@ android {
         // Single source of truth for the OAuth authorization-code redirect URI.
         // The manifest intent-filter, MainActivity's callback matcher, and the use case's
         // registered redirect_uri all derive from these — change them here only.
-        // (For the Readeck port, swap these values or move them per-flavor.)
+        // Every non-production flavor overrides the scheme (see below) so its build can
+        // coexist with the production install without an app-chooser on the browser redirect.
+        // NOTE: changing the scheme requires a CLEAN build — REDIRECT_URI is a constant-folded
+        // BuildConfig expression that incremental compilation may not recompile.
         val oauthCallbackScheme = "mydeck"
         val oauthCallbackHost = "oauth-callback"
         manifestPlaceholders["oauthCallbackScheme"] = oauthCallbackScheme
@@ -102,6 +105,10 @@ android {
             buildConfigField("boolean", "ALLOW_INSECURE_HTTP", "false")
             buildConfigField("boolean", "ALLOW_USER_CA_CERTIFICATES", "false")
             buildConfigField("boolean", "IS_HTTP_ENABLED_BUILD", "false")
+            // Distinct OAuth callback scheme so this build can coexist with production
+            // (and other variants) without the browser redirect popping an app-chooser.
+            manifestPlaceholders["oauthCallbackScheme"] = "mydeck-snapshot"
+            buildConfigField("String", "OAUTH_CALLBACK_SCHEME", "\"mydeck-snapshot\"")
             if (signingConfigs.getByName("release").storeFile != null) {
                 signingConfig = signingConfigs.getByName("release")
             }
@@ -119,6 +126,10 @@ android {
             buildConfigField("boolean", "ALLOW_INSECURE_HTTP", "true")
             buildConfigField("boolean", "ALLOW_USER_CA_CERTIFICATES", "true")
             buildConfigField("boolean", "IS_HTTP_ENABLED_BUILD", "true")
+            // Distinct OAuth callback scheme so this build can coexist with production
+            // (and other variants) without the browser redirect popping an app-chooser.
+            manifestPlaceholders["oauthCallbackScheme"] = "mydeck-snapshot-permissive"
+            buildConfigField("String", "OAUTH_CALLBACK_SCHEME", "\"mydeck-snapshot-permissive\"")
             if (signingConfigs.getByName("release").storeFile != null) {
                 signingConfig = signingConfigs.getByName("release")
             }
@@ -152,6 +163,10 @@ android {
             buildConfigField("boolean", "ALLOW_INSECURE_HTTP", "true")
             buildConfigField("boolean", "ALLOW_USER_CA_CERTIFICATES", "true")
             buildConfigField("boolean", "IS_HTTP_ENABLED_BUILD", "true")
+            // Distinct OAuth callback scheme so this build can coexist with production
+            // (and other variants) without the browser redirect popping an app-chooser.
+            manifestPlaceholders["oauthCallbackScheme"] = "mydeck-permissive"
+            buildConfigField("String", "OAUTH_CALLBACK_SCHEME", "\"mydeck-permissive\"")
             if (signingConfigs.getByName("release").storeFile != null) {
                 signingConfig = signingConfigs.getByName("release")
             }

--- a/app/src/test/java/com/mydeck/app/domain/usecase/OAuthAuthorizationCodeUseCaseTest.kt
+++ b/app/src/test/java/com/mydeck/app/domain/usecase/OAuthAuthorizationCodeUseCaseTest.kt
@@ -3,6 +3,7 @@ package com.mydeck.app.domain.usecase
 import android.content.Context
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
+import com.mydeck.app.BuildConfig
 import com.mydeck.app.io.rest.ReadeckApi
 import com.mydeck.app.io.rest.model.OAuthAuthCodeTokenRequestDto
 import com.mydeck.app.io.rest.model.OAuthClientRegistrationRequestDto
@@ -82,7 +83,10 @@ class OAuthAuthorizationCodeUseCaseTest {
         val captured = registrationSlot.captured
         assertTrue(captured.grantTypes.contains("authorization_code"))
         assertNotNull(captured.redirectUris)
-        assertTrue(captured.redirectUris!!.contains("mydeck://oauth-callback"))
+        // Derived from BuildConfig so it's correct for every flavor (each non-production
+        // flavor overrides the scheme, e.g. mydeck-snapshot://oauth-callback).
+        val expectedRedirect = "${BuildConfig.OAUTH_CALLBACK_SCHEME}://${BuildConfig.OAUTH_CALLBACK_HOST}"
+        assertTrue(captured.redirectUris!!.contains(expectedRedirect))
     }
 
     @Test

--- a/docs/specs/oauth-snapshot-callback-scheme-spec.md
+++ b/docs/specs/oauth-snapshot-callback-scheme-spec.md
@@ -1,0 +1,78 @@
+# OAuth callback scheme — distinct per non-production flavor (mini-spec)
+
+**Status:** Implemented (branch `fix/oauth-snapshot-callback-scheme`). Ported from Readeck
+for Android (`docs/specs/oauth-snapshot-callback-scheme-spec.md`).
+
+---
+
+## Problem
+
+With more than one build installed side by side (e.g. a **snapshot** plus the **production**
+install), completing browser-based OAuth sign-in (Authorization Code + PKCE) pops an Android
+**"Open with" app-chooser** on the redirect back from the browser tab, and can route to the
+wrong app — instead of returning straight to the app that started the flow.
+
+Only visible once two builds coexist, so it wasn't caught until snapshot + release were both
+installed with the new OAuth flow.
+
+## Root cause
+
+MyDeck's flavors have distinct `applicationId`s so they coexist as separate apps, but they all
+inherited the **same** OAuth callback scheme+host from `defaultConfig` (`mydeck://oauth-callback`).
+Each therefore registered an identical `VIEW`/`BROWSABLE` intent-filter for that URI, so the
+browser redirect had multiple claimants. Custom schemes carry no verification (unlike verified
+App Links), so Android cannot auto-pick.
+
+The scheme+host are single-sourced in `app/build.gradle.kts` `defaultConfig` and flow, drift-free,
+to all three consumers: the manifest intent-filter (`${oauthCallbackScheme}` placeholder),
+`MainActivity`'s matcher (`BuildConfig.OAUTH_CALLBACK_SCHEME/HOST`), and the registered
+`redirect_uri` (`OAuthAuthorizationCodeUseCase`, built from the same `BuildConfig` values).
+
+## Change
+
+Give every **non-production** flavor a distinct scheme by overriding the placeholder +
+`buildConfigField` in its flavor block. `githubRelease` (the production install) keeps the bare
+`mydeck` scheme so existing users are unaffected. Host stays `oauth-callback` throughout.
+
+| Flavor | applicationId | scheme |
+|---|---|---|
+| `githubRelease` | `com.mydeck.app` | `mydeck` (unchanged) |
+| `githubReleaseHttp` | `com.mydeck.app.permissive` | `mydeck-permissive` |
+| `githubSnapshot` | `com.mydeck.app.snapshot` | `mydeck-snapshot` |
+| `githubSnapshotHttp` | `com.mydeck.app.snapshot.permissive` | `mydeck-snapshot-permissive` |
+
+No two coexisting `applicationId`s share a scheme, so each redirect resolves to exactly one app.
+
+## Why it's safe (no server change)
+
+The `redirect_uri` is registered **dynamically per sign-in** — the app registers an ephemeral
+OAuth client with `redirect_uris = [that URI]`, and Readeck honors whatever it is given (the
+server creates a fresh client per registration and only ever redirects to the request's own
+validated `redirect_uri`; confirmed against the server source). A per-flavor redirect URI is
+simply registered as-is. Pure client build-config change.
+
+## Verification
+
+- Build + install a non-production build alongside the production install; run browser OAuth
+  sign-in on it and confirm it returns directly to that app with **no** app-chooser and **no**
+  wrong-app.
+- `githubRelease` sign-in is unchanged.
+- `:app:testDebugUnitTestAll` + `:app:lintDebugAll` + `:app:assembleDebugAll` green.
+
+### GOTCHA — this change requires a CLEAN build (`./gradlew clean`)
+
+`OAuthAuthorizationCodeUseCase.REDIRECT_URI` is `"${BuildConfig.OAUTH_CALLBACK_SCHEME}://…"`,
+which the Kotlin compiler **constant-folds**. When the scheme changes, an *incremental* build
+regenerates the manifest and the `BuildConfig` field but may **not** recompile the use case,
+leaving the OLD scheme folded into `REDIRECT_URI`. The result is a build that **listens** on the
+new scheme but **sends** the old `redirect_uri` — the redirect then routes to the production app,
+and a clean *reinstall* does not help because the wrong scheme is baked into the APK. This is
+exactly how the first Readeck snapshot of this fix behaved (diagnosed by dex inspection).
+
+- Always build these variants for this change with `./gradlew clean` first (or wipe `app/build`).
+  A CI/fresh-checkout build is inherently clean and unaffected.
+- Verifying the merged manifest + `BuildConfig` field is **not sufficient** — check the *compiled*
+  `REDIRECT_URI`:
+  `unzip -p <apk> 'classes*.dex' | strings | grep -E 'mydeck[a-z-]*://oauth-callback'`
+  must show only the flavor's own scheme, never the bare `mydeck://`.
+- `githubRelease` is immune (its scheme never changes).


### PR DESCRIPTION
Snapshot/HTTP builds coexist with production (distinct applicationIds) but inherited the same mydeck://oauth-callback scheme, so multiple apps registered the same VIEW/BROWSABLE filter and the browser redirect popped an app-chooser (and could route to the wrong app). Give each non-production flavor a distinct scheme (githubSnapshot=mydeck-snapshot, githubSnapshotHttp=mydeck-snapshot-permissive, githubReleaseHttp=mydeck-permissive); githubRelease keeps mydeck. Scheme/host are single-sourced through manifestPlaceholders + BuildConfig, so the manifest filter, MainActivity matcher, and registered redirect_uri all follow.

Make OAuthAuthorizationCodeUseCaseTest derive the expected redirect_uri from BuildConfig so it holds for every flavor.

No server change: the redirect_uri is registered dynamically per sign-in.

NOTE: changing the scheme requires a CLEAN build — REDIRECT_URI is a constant-folded BuildConfig expression that incremental compilation may not recompile. See docs/specs/oauth-snapshot-callback-scheme-spec.md.

Ported from Readeck for Android (sibling repo).