### PR TITLE
fix: use null-safe signingConfig lookups for F-Droid build compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **F-Droid build compatibility** — signing config lookups in the Gradle build now use a null-safe `findByName` instead of `getByName`, so the build no longer crashes when a build tool (like F-Droid's) strips the `release` signing config block. No change to normal build behavior.
+
 ## [0.14.6] - 2026-07-10
 
 ### Added

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -76,11 +76,8 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
-            signingConfig = if (signingConfigs.getByName("release").storeFile != null) {
-                signingConfigs.getByName("release")
-            } else {
-                signingConfigs.getByName("debug")
-            }
+            signingConfig = signingConfigs.findByName("release")?.takeIf { it.storeFile != null }
+                ?: signingConfigs.findByName("debug")
         }
         debug {
             isMinifyEnabled = false
@@ -109,8 +106,8 @@ android {
             // (and other variants) without the browser redirect popping an app-chooser.
             manifestPlaceholders["oauthCallbackScheme"] = "mydeck-snapshot"
             buildConfigField("String", "OAUTH_CALLBACK_SCHEME", "\"mydeck-snapshot\"")
-            if (signingConfigs.getByName("release").storeFile != null) {
-                signingConfig = signingConfigs.getByName("release")
+            signingConfigs.findByName("release")?.takeIf { it.storeFile != null }?.let {
+                signingConfig = it
             }
         }
         create("githubSnapshotHttp") {
@@ -130,8 +127,8 @@ android {
             // (and other variants) without the browser redirect popping an app-chooser.
             manifestPlaceholders["oauthCallbackScheme"] = "mydeck-snapshot-permissive"
             buildConfigField("String", "OAUTH_CALLBACK_SCHEME", "\"mydeck-snapshot-permissive\"")
-            if (signingConfigs.getByName("release").storeFile != null) {
-                signingConfig = signingConfigs.getByName("release")
+            signingConfigs.findByName("release")?.takeIf { it.storeFile != null }?.let {
+                signingConfig = it
             }
         }
         create("githubRelease") {
@@ -146,8 +143,8 @@ android {
             buildConfigField("boolean", "ALLOW_INSECURE_HTTP", "false")
             buildConfigField("boolean", "ALLOW_USER_CA_CERTIFICATES", "false")
             buildConfigField("boolean", "IS_HTTP_ENABLED_BUILD", "false")
-            if (signingConfigs.getByName("release").storeFile != null) {
-                signingConfig = signingConfigs.getByName("release")
+            signingConfigs.findByName("release")?.takeIf { it.storeFile != null }?.let {
+                signingConfig = it
             }
         }
         create("githubReleaseHttp") {
@@ -167,8 +164,8 @@ android {
             // (and other variants) without the browser redirect popping an app-chooser.
             manifestPlaceholders["oauthCallbackScheme"] = "mydeck-permissive"
             buildConfigField("String", "OAUTH_CALLBACK_SCHEME", "\"mydeck-permissive\"")
-            if (signingConfigs.getByName("release").storeFile != null) {
-                signingConfig = signingConfigs.getByName("release")
+            signingConfigs.findByName("release")?.takeIf { it.storeFile != null }?.let {
+                signingConfig = it
             }
         }
     }


### PR DESCRIPTION
## Summary

F-Droid's build tooling automatically strips the `signingConfigs { create("release") {...} }` block from `build.gradle.kts` before building any app, so it never has to trust a repo's own keystore/secrets. Our build referenced `signingConfigs.getByName("release")` in 5 places (the `release` buildType and all four product flavors) — `getByName` throws when the config is missing, so F-Droid's build crashed with `SigningConfig with name 'release' not found`.

Swapped all 5 sites to `findByName`, which returns `null` instead of throwing, falling back to debug signing exactly like the existing local-build-without-`KEYSTORE` path already does. No behavior change for normal dev/CI builds — confirmed by building `assembleGithubReleaseRelease` locally with `KEYSTORE`/`KEY_ALIAS`/etc. unset, reproducing and then fixing the exact failure seen on F-Droid's actual build server.

## Test plan

- [x] `./gradlew :app:assembleGithubReleaseRelease` with no `KEYSTORE` env vars set — reproduced the F-Droid failure before the fix, succeeds after
- [x] `./gradlew :app:assembleDebugAll :app:testDebugUnitTestAll :app:lintDebugAll` — all green
- [ ] Tag a new release (e.g. `v0.14.7`) once merged, so the F-Droid `fdroiddata` metadata can point at a build that actually works (`v0.14.6` is unaffected by this fix, since it predates it)