### PR TITLE
chore(release): bump version to 0.14.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.7] - 2026-07-11
+
 ### Fixed
 
 - **F-Droid build compatibility** — signing config lookups in the Gradle build now use a null-safe `findByName` instead of `getByName`, so the build no longer crashes when a build tool (like F-Droid's) strips the `release` signing config block. No change to normal build behavior.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,8 +30,8 @@ android {
         applicationId = "com.mydeck.app"
         minSdk = 24
         targetSdk = 35
-        versionCode = 14006
-        versionName = "0.14.6"
+        versionCode = 14007
+        versionName = "0.14.7"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/assets/whatsnew/de/0.14.7.md
+++ b/app/src/main/assets/whatsnew/de/0.14.7.md
@@ -1,0 +1,8 @@
+---
+date: 2026-07-11
+---
+# What's New in 0.14.7
+
+**Label sorting fixed in more places:** Sorting labels by name or count now works in the label picker opened from Add Bookmark (including saving via the share sheet) and from Edit Labels on the Bookmark Details page, and each label shows its bookmark count.
+
+**F-Droid readiness:** A build fix that paves the way for MyDeck to be distributed on F-Droid. Nothing changes in the app itself.

--- a/app/src/main/assets/whatsnew/en/0.14.7.md
+++ b/app/src/main/assets/whatsnew/en/0.14.7.md
@@ -1,0 +1,8 @@
+---
+date: 2026-07-11
+---
+# What's New in 0.14.7
+
+**Label sorting fixed in more places:** Sorting labels by name or count now works in the label picker opened from Add Bookmark (including saving via the share sheet) and from Edit Labels on the Bookmark Details page, and each label shows its bookmark count.
+
+**F-Droid readiness:** A build fix that paves the way for MyDeck to be distributed on F-Droid. Nothing changes in the app itself.

--- a/app/src/main/assets/whatsnew/es/0.14.7.md
+++ b/app/src/main/assets/whatsnew/es/0.14.7.md
@@ -1,0 +1,8 @@
+---
+date: 2026-07-11
+---
+# What's New in 0.14.7
+
+**Label sorting fixed in more places:** Sorting labels by name or count now works in the label picker opened from Add Bookmark (including saving via the share sheet) and from Edit Labels on the Bookmark Details page, and each label shows its bookmark count.
+
+**F-Droid readiness:** A build fix that paves the way for MyDeck to be distributed on F-Droid. Nothing changes in the app itself.

--- a/app/src/main/assets/whatsnew/fr/0.14.7.md
+++ b/app/src/main/assets/whatsnew/fr/0.14.7.md
@@ -1,0 +1,8 @@
+---
+date: 2026-07-11
+---
+# What's New in 0.14.7
+
+**Label sorting fixed in more places:** Sorting labels by name or count now works in the label picker opened from Add Bookmark (including saving via the share sheet) and from Edit Labels on the Bookmark Details page, and each label shows its bookmark count.
+
+**F-Droid readiness:** A build fix that paves the way for MyDeck to be distributed on F-Droid. Nothing changes in the app itself.

--- a/app/src/main/assets/whatsnew/gl/0.14.7.md
+++ b/app/src/main/assets/whatsnew/gl/0.14.7.md
@@ -1,0 +1,8 @@
+---
+date: 2026-07-11
+---
+# What's New in 0.14.7
+
+**Label sorting fixed in more places:** Sorting labels by name or count now works in the label picker opened from Add Bookmark (including saving via the share sheet) and from Edit Labels on the Bookmark Details page, and each label shows its bookmark count.
+
+**F-Droid readiness:** A build fix that paves the way for MyDeck to be distributed on F-Droid. Nothing changes in the app itself.

--- a/app/src/main/assets/whatsnew/pl/0.14.7.md
+++ b/app/src/main/assets/whatsnew/pl/0.14.7.md
@@ -1,0 +1,8 @@
+---
+date: 2026-07-11
+---
+# What's New in 0.14.7
+
+**Label sorting fixed in more places:** Sorting labels by name or count now works in the label picker opened from Add Bookmark (including saving via the share sheet) and from Edit Labels on the Bookmark Details page, and each label shows its bookmark count.
+
+**F-Droid readiness:** A build fix that paves the way for MyDeck to be distributed on F-Droid. Nothing changes in the app itself.

--- a/app/src/main/assets/whatsnew/pt/0.14.7.md
+++ b/app/src/main/assets/whatsnew/pt/0.14.7.md
@@ -1,0 +1,8 @@
+---
+date: 2026-07-11
+---
+# What's New in 0.14.7
+
+**Label sorting fixed in more places:** Sorting labels by name or count now works in the label picker opened from Add Bookmark (including saving via the share sheet) and from Edit Labels on the Bookmark Details page, and each label shows its bookmark count.
+
+**F-Droid readiness:** A build fix that paves the way for MyDeck to be distributed on F-Droid. Nothing changes in the app itself.

--- a/app/src/main/assets/whatsnew/ru/0.14.7.md
+++ b/app/src/main/assets/whatsnew/ru/0.14.7.md
@@ -1,0 +1,8 @@
+---
+date: 2026-07-11
+---
+# What's New in 0.14.7
+
+**Label sorting fixed in more places:** Sorting labels by name or count now works in the label picker opened from Add Bookmark (including saving via the share sheet) and from Edit Labels on the Bookmark Details page, and each label shows its bookmark count.
+
+**F-Droid readiness:** A build fix that paves the way for MyDeck to be distributed on F-Droid. Nothing changes in the app itself.

--- a/app/src/main/assets/whatsnew/uk/0.14.7.md
+++ b/app/src/main/assets/whatsnew/uk/0.14.7.md
@@ -1,0 +1,8 @@
+---
+date: 2026-07-11
+---
+# What's New in 0.14.7
+
+**Label sorting fixed in more places:** Sorting labels by name or count now works in the label picker opened from Add Bookmark (including saving via the share sheet) and from Edit Labels on the Bookmark Details page, and each label shows its bookmark count.
+
+**F-Droid readiness:** A build fix that paves the way for MyDeck to be distributed on F-Droid. Nothing changes in the app itself.

--- a/app/src/main/assets/whatsnew/zh/0.14.7.md
+++ b/app/src/main/assets/whatsnew/zh/0.14.7.md
@@ -1,0 +1,8 @@
+---
+date: 2026-07-11
+---
+# What's New in 0.14.7
+
+**Label sorting fixed in more places:** Sorting labels by name or count now works in the label picker opened from Add Bookmark (including saving via the share sheet) and from Edit Labels on the Bookmark Details page, and each label shows its bookmark count.
+
+**F-Droid readiness:** A build fix that paves the way for MyDeck to be distributed on F-Droid. Nothing changes in the app itself.

--- a/metadata/en-US/changelogs/14007.txt
+++ b/metadata/en-US/changelogs/14007.txt
@@ -1,0 +1,3 @@
+<b>Fixed</b>
+- F-Droid build compatibility: the Gradle build no longer fails when the release signing config is stripped by a build tool like F-Droid's
+- Label sort by name/count now works in the label picker from Add Bookmark (including the share sheet) and from Bookmark Details' Edit Labels, with count chips shown


### PR DESCRIPTION
## Summary

Release prep for v0.14.7 — a small fix release carrying the two fixes merged since 0.14.6.

- versionCode `14007`, versionName `0.14.7`
- CHANGELOG: move `[Unreleased]` into `[0.14.7] - 2026-07-11`
- `metadata/en-US/changelogs/14007.txt` (Fastlane store changelog)
- What's New sheet `whatsnew/en/0.14.7.md` + English placeholders for all 9 other locales

## What ships in 0.14.7

- **F-Droid build compatibility** (#231) — null-safe signing config lookups so F-Droid's build server can build the app; this unblocks the pending F-Droid inclusion request
- **Label sort by name/count** (#232) — now works in the label pickers from Add Bookmark (incl. share sheet) and Bookmark Details' Edit Labels, with count chips shown

## Test plan

- [x] `./gradlew :app:assembleDebugAll :app:testDebugUnitTestAll :app:lintDebugAll` — all green