### PR TITLE
chore(release): correct 0.14.7 change records before tagging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **F-Droid build compatibility** — signing config lookups in the Gradle build now use a null-safe `findByName` instead of `getByName`, so the build no longer crashes when a build tool (like F-Droid's) strips the `release` signing config block. No change to normal build behavior.
+- **Browser sign-in with multiple builds installed** — snapshot and HTTP builds now use a distinct OAuth callback scheme per flavor, so signing in through the browser no longer pops an app chooser or risks routing the redirect to the wrong installed build. Production builds are unaffected.
 - **Label sort by name/count** now works in the label picker shown from Add Bookmark (including the share-sheet "Save to MyDeck" flow) and from the Bookmark Details page's Edit Labels — these previously showed no count chips and ignored the sort toggle because bookmark counts weren't passed through to the picker.
+- **F-Droid build compatibility** — signing config lookups in the Gradle build now use a null-safe `findByName` instead of `getByName`, so the build no longer crashes when a build tool (like F-Droid's) strips the `release` signing config block. No change to normal build behavior.
 
 ## [0.14.6] - 2026-07-10
 

--- a/app/src/main/assets/whatsnew/de/0.14.7.md
+++ b/app/src/main/assets/whatsnew/de/0.14.7.md
@@ -3,6 +3,4 @@ date: 2026-07-11
 ---
 # What's New in 0.14.7
 
-**Label sorting fixed in more places:** Sorting labels by name or count now works in the label picker opened from Add Bookmark (including saving via the share sheet) and from Edit Labels on the Bookmark Details page, and each label shows its bookmark count.
-
-**F-Droid readiness:** A build fix that paves the way for MyDeck to be distributed on F-Droid. Nothing changes in the app itself.
+**Label sorting now works everywhere:** When you add labels while saving a bookmark or editing one, the label list now sorts by name or by how often you use each label, and shows a count next to each one — matching the main label screen.

--- a/app/src/main/assets/whatsnew/en/0.14.7.md
+++ b/app/src/main/assets/whatsnew/en/0.14.7.md
@@ -3,6 +3,4 @@ date: 2026-07-11
 ---
 # What's New in 0.14.7
 
-**Label sorting fixed in more places:** Sorting labels by name or count now works in the label picker opened from Add Bookmark (including saving via the share sheet) and from Edit Labels on the Bookmark Details page, and each label shows its bookmark count.
-
-**F-Droid readiness:** A build fix that paves the way for MyDeck to be distributed on F-Droid. Nothing changes in the app itself.
+**Label sorting now works everywhere:** When you add labels while saving a bookmark or editing one, the label list now sorts by name or by how often you use each label, and shows a count next to each one — matching the main label screen.

--- a/app/src/main/assets/whatsnew/es/0.14.7.md
+++ b/app/src/main/assets/whatsnew/es/0.14.7.md
@@ -3,6 +3,4 @@ date: 2026-07-11
 ---
 # What's New in 0.14.7
 
-**Label sorting fixed in more places:** Sorting labels by name or count now works in the label picker opened from Add Bookmark (including saving via the share sheet) and from Edit Labels on the Bookmark Details page, and each label shows its bookmark count.
-
-**F-Droid readiness:** A build fix that paves the way for MyDeck to be distributed on F-Droid. Nothing changes in the app itself.
+**Label sorting now works everywhere:** When you add labels while saving a bookmark or editing one, the label list now sorts by name or by how often you use each label, and shows a count next to each one — matching the main label screen.

--- a/app/src/main/assets/whatsnew/fr/0.14.7.md
+++ b/app/src/main/assets/whatsnew/fr/0.14.7.md
@@ -3,6 +3,4 @@ date: 2026-07-11
 ---
 # What's New in 0.14.7
 
-**Label sorting fixed in more places:** Sorting labels by name or count now works in the label picker opened from Add Bookmark (including saving via the share sheet) and from Edit Labels on the Bookmark Details page, and each label shows its bookmark count.
-
-**F-Droid readiness:** A build fix that paves the way for MyDeck to be distributed on F-Droid. Nothing changes in the app itself.
+**Label sorting now works everywhere:** When you add labels while saving a bookmark or editing one, the label list now sorts by name or by how often you use each label, and shows a count next to each one — matching the main label screen.

--- a/app/src/main/assets/whatsnew/gl/0.14.7.md
+++ b/app/src/main/assets/whatsnew/gl/0.14.7.md
@@ -3,6 +3,4 @@ date: 2026-07-11
 ---
 # What's New in 0.14.7
 
-**Label sorting fixed in more places:** Sorting labels by name or count now works in the label picker opened from Add Bookmark (including saving via the share sheet) and from Edit Labels on the Bookmark Details page, and each label shows its bookmark count.
-
-**F-Droid readiness:** A build fix that paves the way for MyDeck to be distributed on F-Droid. Nothing changes in the app itself.
+**Label sorting now works everywhere:** When you add labels while saving a bookmark or editing one, the label list now sorts by name or by how often you use each label, and shows a count next to each one — matching the main label screen.

--- a/app/src/main/assets/whatsnew/pl/0.14.7.md
+++ b/app/src/main/assets/whatsnew/pl/0.14.7.md
@@ -3,6 +3,4 @@ date: 2026-07-11
 ---
 # What's New in 0.14.7
 
-**Label sorting fixed in more places:** Sorting labels by name or count now works in the label picker opened from Add Bookmark (including saving via the share sheet) and from Edit Labels on the Bookmark Details page, and each label shows its bookmark count.
-
-**F-Droid readiness:** A build fix that paves the way for MyDeck to be distributed on F-Droid. Nothing changes in the app itself.
+**Label sorting now works everywhere:** When you add labels while saving a bookmark or editing one, the label list now sorts by name or by how often you use each label, and shows a count next to each one — matching the main label screen.

--- a/app/src/main/assets/whatsnew/pt/0.14.7.md
+++ b/app/src/main/assets/whatsnew/pt/0.14.7.md
@@ -3,6 +3,4 @@ date: 2026-07-11
 ---
 # What's New in 0.14.7
 
-**Label sorting fixed in more places:** Sorting labels by name or count now works in the label picker opened from Add Bookmark (including saving via the share sheet) and from Edit Labels on the Bookmark Details page, and each label shows its bookmark count.
-
-**F-Droid readiness:** A build fix that paves the way for MyDeck to be distributed on F-Droid. Nothing changes in the app itself.
+**Label sorting now works everywhere:** When you add labels while saving a bookmark or editing one, the label list now sorts by name or by how often you use each label, and shows a count next to each one — matching the main label screen.

--- a/app/src/main/assets/whatsnew/ru/0.14.7.md
+++ b/app/src/main/assets/whatsnew/ru/0.14.7.md
@@ -3,6 +3,4 @@ date: 2026-07-11
 ---
 # What's New in 0.14.7
 
-**Label sorting fixed in more places:** Sorting labels by name or count now works in the label picker opened from Add Bookmark (including saving via the share sheet) and from Edit Labels on the Bookmark Details page, and each label shows its bookmark count.
-
-**F-Droid readiness:** A build fix that paves the way for MyDeck to be distributed on F-Droid. Nothing changes in the app itself.
+**Label sorting now works everywhere:** When you add labels while saving a bookmark or editing one, the label list now sorts by name or by how often you use each label, and shows a count next to each one — matching the main label screen.

--- a/app/src/main/assets/whatsnew/uk/0.14.7.md
+++ b/app/src/main/assets/whatsnew/uk/0.14.7.md
@@ -3,6 +3,4 @@ date: 2026-07-11
 ---
 # What's New in 0.14.7
 
-**Label sorting fixed in more places:** Sorting labels by name or count now works in the label picker opened from Add Bookmark (including saving via the share sheet) and from Edit Labels on the Bookmark Details page, and each label shows its bookmark count.
-
-**F-Droid readiness:** A build fix that paves the way for MyDeck to be distributed on F-Droid. Nothing changes in the app itself.
+**Label sorting now works everywhere:** When you add labels while saving a bookmark or editing one, the label list now sorts by name or by how often you use each label, and shows a count next to each one — matching the main label screen.

--- a/app/src/main/assets/whatsnew/zh/0.14.7.md
+++ b/app/src/main/assets/whatsnew/zh/0.14.7.md
@@ -3,6 +3,4 @@ date: 2026-07-11
 ---
 # What's New in 0.14.7
 
-**Label sorting fixed in more places:** Sorting labels by name or count now works in the label picker opened from Add Bookmark (including saving via the share sheet) and from Edit Labels on the Bookmark Details page, and each label shows its bookmark count.
-
-**F-Droid readiness:** A build fix that paves the way for MyDeck to be distributed on F-Droid. Nothing changes in the app itself.
+**Label sorting now works everywhere:** When you add labels while saving a bookmark or editing one, the label list now sorts by name or by how often you use each label, and shows a count next to each one — matching the main label screen.

--- a/metadata/en-US/changelogs/14007.txt
+++ b/metadata/en-US/changelogs/14007.txt
@@ -1,3 +1,2 @@
 <b>Fixed</b>
-- F-Droid build compatibility: the Gradle build no longer fails when the release signing config is stripped by a build tool like F-Droid's
-- Label sort by name/count now works in the label picker from Add Bookmark (including the share sheet) and from Bookmark Details' Edit Labels, with count chips shown
+- Label sort by name/count now works in the label picker from Add Bookmark (including the share sheet) and from Bookmark Details' Edit Labels, with a count shown next to each label


### PR DESCRIPTION
## Summary

Cleanup of the 0.14.7 change records before the release is tagged. No code or behavior changes — only CHANGELOG, the Fastlane store changelog, and the in-app What's New sheets.

Three corrections:

- **CHANGELOG** — add the OAuth callback-scheme fix (#230). It merged right after 0.14.6 was tagged but was never recorded in the changelog, so it would have shipped in 0.14.7 undocumented.
- **Fastlane store changelog** (`metadata/en-US/changelogs/14007.txt`) — drop the F-Droid build-compatibility item. It's a build-infra fix with no user-observable effect, so it doesn't belong in the store "What's New in this version" listing. Kept the label sort fix.
- **What's New sheets** (all 10 locales) — rewrite down to just the label sort fix, in plain user-facing terms, and remove the F-Droid build item (its own text admitted "nothing changes in the app itself").

The guiding principle applied: **CHANGELOG is the complete record (technical changes included); the store changelog and in-app What's New are user-facing only.**

## What each record now says for 0.14.7

| Change | CHANGELOG | Store changelog | What's New |
|---|---|---|---|
| Label sort by name/count | ✓ | ✓ | ✓ |
| OAuth callback scheme (#230) | ✓ | — | — |
| F-Droid build fix (#231) | ✓ | — | — |

## Test plan

- [x] Content-only change; What's New frontmatter matches the existing 0.14.6 sheet format