### PR TITLE
docs: porting tag guardrails + pending F-Droid docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,32 @@ The English text serves as a placeholder until professional translators provide 
 
 ---
 
+## Cross-Repo Fetches — Never Import Tags
+
+When adding the sibling repo (MyDeck ⇄ Readeck) as a scratch remote for a port,
+ALWAYS configure it to never fetch tags, in the same command that creates it:
+
+    git remote add --no-tags <name> <path>
+    git fetch <name>
+
+Never run a bare `git fetch` against a remote that lacks `tagOpt = --no-tags`
+(check with `git config remote.<name>.tagOpt`). Git's default fetch auto-follows
+tags into the local shared tag namespace, polluting this repo with the sibling's
+tags — and `git remote remove` does NOT clean fetched tags up afterward. This
+applies to the durable `codeberg` remote too (its `tagOpt` is set locally —
+verify before fetching it).
+
+---
+
+## Never Bulk-Delete Refs
+
+Never delete tags or branches by pattern/filter (`grep | xargs git tag -d`,
+wildcard `git push --delete`, etc.). If stray refs are found, present the
+explicit, complete list of names and get the maintainer's approval before
+deleting anything — one literal command, no patterns.
+
+---
+
 ## GitHub Interactions
 
 The `gh` CLI is installed and authenticated locally. Use it freely for **read-only** inspection — `gh pr view`, `gh pr list`, `gh pr diff`, `gh run view`, `gh api` GETs, etc. This is the preferred way to verify PR/CI state instead of guessing from local git.

--- a/docs/porting/fdroid-signing-and-label-counts-port.md
+++ b/docs/porting/fdroid-signing-and-label-counts-port.md
@@ -1,0 +1,127 @@
+# Port: F-Droid signingConfig fix + label-count pickers (from MyDeck v0.14.7)
+
+**Status:** Ready to implement. Not yet applied.
+**Direction:** SOURCE = MyDeck, TARGET = Readeck for Android (this repo).
+**Methodology:** see [`mydeck-readeck-port.md`](./mydeck-readeck-port.md). This is the per-feature checklist (§6 there).
+**SOURCE commits (on MyDeck `main`, shipped in v0.14.7):**
+- `f5b8a24b` — fix: null-safe `signingConfig` lookups for F-Droid build compatibility (#231)
+- `a143f1db` — fix: pass real label counts to Add Bookmark & Bookmark Details label pickers (#232)
+- `a20eb25b` — fix: distinct OAuth callback scheme per non-production flavor (#230) — **see §0, do NOT port**
+
+Target release: this port lands on Readeck `main`, then the user cuts **v1.0.0-rc7** separately (release process is out of scope for this port).
+
+---
+
+## 0. Scope: three v0.14.7 fixes make up the next RC — two port, one is already here
+
+These three fixes shipped together in MyDeck v0.14.7 and together make up the content of Readeck's next release candidate (**v1.0.0-rc7**, cut separately by the maintainer after this port). Of the three, **only two need porting**; the third is already in this repo:
+
+| Fix | MyDeck commit | Port? |
+|---|---|---|
+| signingConfig `findByName` (F-Droid) | `f5b8a24b` | **Yes** — apply to Readeck's 3 sites (§1) |
+| Label-count pickers | `a143f1db` | **Yes** — cherry-pick / apply to 5 files (§2) |
+| Per-flavor OAuth callback scheme | `a20eb25b` | **No — already in Readeck** (§0.1) |
+
+### 0.1 Why #230 is already here
+MyDeck's #230 was itself **ported *from* this repo** ("Ported from Readeck for Android" in its commit message). Readeck's `app/build.gradle.kts` already gives the `snapshot` flavor the distinct `readeck-snapshot` scheme, and `stable` keeps the default `readeck` scheme — the complete equivalent of MyDeck's change (Readeck has no `*Http` flavors, so there is nothing else to differentiate). **Verify-only:** confirm `manifestPlaceholders["oauthCallbackScheme"] = "readeck-snapshot"` and the matching `buildConfigField` are still present in the `snapshot` block; if so, #230 needs no work.
+
+---
+
+## 1. Fix #231 — null-safe signingConfig lookups (F-Droid build compatibility)
+
+**Why it matters for Readeck:** F-Droid's build tooling strips the `signingConfigs { create("release") … }` block before building. `getByName("release")` then throws `SigningConfig with name 'release' not found` at configuration time. `findByName` returns `null` instead, degrading gracefully to debug-signing — exactly what already happens locally when `KEYSTORE` is unset. This is prerequisite work for Readeck's own eventual F-Droid submission and is behavior-preserving for all normal builds.
+
+**Do NOT cherry-pick `f5b8a24b`** — it edits `app/build.gradle.kts`, whose flavor/signing block is a §2 branding-divergent file (MyDeck has 4 flavors, Readeck has 2). Apply the transform by hand to Readeck's **3 sites** (MyDeck had 5 because of its extra `*Http` flavors).
+
+### Site A — `buildTypes { release { … } }` (Readeck build.gradle.kts ~line 76)
+Replace:
+```kotlin
+            signingConfig = if (signingConfigs.getByName("release").storeFile != null) {
+                signingConfigs.getByName("release")
+            } else {
+                signingConfigs.getByName("debug")
+            }
+```
+with:
+```kotlin
+            signingConfig = signingConfigs.findByName("release")?.takeIf { it.storeFile != null }
+                ?: signingConfigs.findByName("debug")
+```
+
+### Sites B & C — the `snapshot` and `stable` flavor blocks (~lines 110 and 125)
+In **each** flavor block, replace:
+```kotlin
+            if (signingConfigs.getByName("release").storeFile != null) {
+                signingConfig = signingConfigs.getByName("release")
+            }
+```
+with:
+```kotlin
+            signingConfigs.findByName("release")?.takeIf { it.storeFile != null }?.let {
+                signingConfig = it
+            }
+```
+
+**Done check:** `grep -n 'getByName("release")' app/build.gradle.kts` returns nothing; `findByName("release")` appears 3 times.
+
+---
+
+## 2. Fix #232 — real label counts to Add Bookmark & Bookmark Details pickers
+
+**What it fixes:** the label picker's sort-by-name/count and count chips only work when the caller passes a real `Map<String, Int>` (label → bookmark count). The Add Bookmark sheet (incl. the share-sheet "Save to Readeck" flow) and Bookmark Details' Edit Labels instead flattened counts to a `List<String>` and rebuilt the map with every count hardcoded to `0` — hiding count chips and making the sort toggle a no-op. This threads the real counts through end-to-end.
+
+**Pure repo-agnostic UI logic — no branding.** All 5 files share Readeck's package `com.mydeck.app` and matching baselines, so **cherry-pick `a143f1db`** — it should apply clean:
+```
+git remote add mydeck /Users/nathan/development/MyDeck && git fetch mydeck
+git cherry-pick a143f1db        # or: git cherry-pick -n, to fold into your own commit
+git remote remove mydeck        # scratch remote, remove when done (methodology §3)
+```
+The commit also edits `CHANGELOG.md`; drop that hunk (§3 below re-adds it in Readeck's own `[Unreleased]`).
+
+**If the cherry-pick conflicts** (minor line drift is possible), apply the same transform manually. In each of the 5 files, the change is mechanical:
+
+- **`ui/list/AddBookmarkSheet.kt`** and **`ui/detail/BookmarkDetailsDialog.kt`** — rename the composable param `existingLabels: List<String> = emptyList()` → `existingLabelCounts: Map<String, Int> = emptyMap()` (both the public composable and its private `*LabelsSection`/`CreateBookmarkLabelsSection`), pass it through at the call site, and change the `labelOptions` builder:
+  ```kotlin
+  // before
+  val labelOptions = remember(existingLabels, labels) {
+      (existingLabels + labels).distinct().associateWith { 0 }
+  }
+  // after
+  val labelOptions = remember(existingLabelCounts, labels) {
+      existingLabelCounts + labels.associateWith { existingLabelCounts[it] ?: 0 }
+  }
+  ```
+- **`ui/detail/BookmarkDetailScreen.kt`** — the `BookmarkDetailsDialog(...)` call: `existingLabels = labelsWithCounts.keys.toList()` → `existingLabelCounts = labelsWithCounts`.
+- **`ui/list/BookmarkListScreen.kt`** — the `AddBookmarkBottomSheet(...)` call: `existingLabels = labelsWithCounts.value.keys.toList()` → `existingLabelCounts = labelsWithCounts.value`; and the private `AddBookmarkBottomSheet` wrapper's param + pass-through.
+- **`ui/share/ShareActivity.kt`** — change the remembered state from `List<String>` to `Map<String, Int>`, assign `bookmarkRepository.observeAllLabelsWithCounts().first()` directly (drop the `.keys.toList()`), and thread `existingLabelCounts` through `ShareBookmarkContent`.
+
+**Done check:** `grep -rn existingLabels app/src/main/java/com/mydeck/app/ui/{list,detail,share}` returns nothing (the only remaining `existingLabels` in the tree is `ui/components/LabelAutocompleteTextField.kt`, which is a different, unrelated param — leave it).
+
+---
+
+## 3. CHANGELOG (Readeck wording)
+
+Add to the `[Unreleased]` `### Fixed` section of Readeck's `CHANGELOG.md` (adapt "MyDeck"→"Readeck" in prose; the label item names no brand):
+```markdown
+- **F-Droid build compatibility** — signing config lookups in the Gradle build now use a null-safe `findByName` instead of `getByName`, so the build no longer crashes when a build tool (like F-Droid's) strips the `release` signing config block. No change to normal build behavior.
+- **Label sort by name/count** now works in the label picker shown from Add Bookmark (including the share-sheet "Save to Readeck" flow) and from the Bookmark Details page's Edit Labels — these previously showed no count chips and ignored the sort toggle because bookmark counts weren't passed through to the picker.
+```
+
+No new string resources, no data-model/Room change → methodology §4 is a no-op.
+
+---
+
+## 4. Verify
+
+```
+./gradlew :app:assembleDebugAll :app:testDebugUnitTestAll :app:lintDebugAll
+```
+All green. Optional device check via `scripts/install-phone.sh`: open Add Bookmark and Bookmark Details → Edit Labels, confirm labels show counts and the sort toggle reorders them. (No signing behavior to observe locally — #231 only manifests when a build tool strips the signing block.)
+
+## 5. Branch / commit / release
+
+- **Both fixes go on a single branch** off `main` (one push/PR cycle — do not split them into two branches). One or two commits on that branch is fine.
+- **Commit this port doc** (`docs/porting/fdroid-signing-and-label-counts-port.md`) on the same branch — it is currently untracked in this repo and must not be left dangling. The MyDeck mirror already exists (placed untracked there by the maintainer, awaiting their next docs branch), so there is **no need to copy it back to MyDeck**.
+- **Related specs:** scan MyDeck's `docs/` for any spec tied to these two fixes and mirror + commit it here if found. Expected result: none — both are reactive fixes with no dedicated feature spec (the earlier F-Droid *build-prep* spec is already mirrored as `docs/archive/fdroid-build-prep-spec.md`). Surface anything you do find rather than assuming.
+- **Do not** run the release process — the maintainer cuts **v1.0.0-rc7** afterward (version bump, changelog move, any whatsnew/store metadata).
+- Propose state-changing git/PR commands for the maintainer rather than running them.

--- a/docs/porting/mydeck-readeck-port.md
+++ b/docs/porting/mydeck-readeck-port.md
@@ -58,10 +58,11 @@ Everything else — logic, DTOs, ViewModels, Compose UI, tests, DAOs, workers, s
 ## 3. Roles + cross-repo git
 
 - **SOURCE** = repo the change landed in (read-only; never edit). **TARGET** = repo you're porting into (the one you're working in). Neither is permanently MyDeck or Readeck.
-- To cherry-pick or read source commits from the TARGET, add the sibling as a local remote and fetch:
-  `git remote add <source> <path-or-url> && git fetch <source>` (a local path like `/Users/nathan/development/MyDeck` works). Then `git cherry-pick <sha>` or `git show <sha>:<path>`.
+- To cherry-pick or read source commits from the TARGET, add the sibling as a local remote **with tag-following disabled** and fetch:
+  `git remote add --no-tags <source> <path-or-url> && git fetch <source>` (a local path like `/Users/nathan/development/MyDeck` works). Then `git cherry-pick <sha>` or `git show <sha>:<path>`.
+  **The `--no-tags` flag is mandatory.** A default fetch auto-follows the source repo's tags into the target's shared tag namespace (release tags, archive/* tags, backups — dozens of refs that don't belong there), and `git remote remove` does not remove fetched tags. If a fetch ever does import stray tags, do not bulk-delete by pattern: list them explicitly and have the maintainer approve the exact deletion command.
 - Because the source package is identical (§0), cherry-picks apply with no path/package fixups — only the §2 branding edits and any §4 model regeneration remain.
-- **Remove the remote once done.** A remote added solely to cherry-pick for a port is scratch, not durable repo config — once the port is complete (committed/PR proposed), `git remote remove <source>`. Exception: if another port from the same source is already queued in the same session, leave it until the last queued port from that source completes, then remove it.
+- **Remove the remote once done.** A remote added solely to cherry-pick for a port is scratch, not durable repo config — once the port is complete (committed/PR proposed), `git remote remove <source>`. Exception: if another port from the same source is already queued in the same session, leave it until the last queued port from that source completes, then remove it. After removing the remote, verify no tags came over: `git tag -l` should show no refs originating from the source repo.
 
 ## 4. Data-model / migration reconciliation (the only real gotcha)
 

--- a/docs/specs/fdroid-submission-plan.md
+++ b/docs/specs/fdroid-submission-plan.md
@@ -1,0 +1,179 @@
+# F-Droid Submission Plan — MyDeck
+
+**Status:** Draft — not started
+**Date:** 2026-07-11
+**Related:** `docs/archive/fdroid-build-prep-port-spec.md` (build-prep work, already merged to `main`)
+
+## 1. Where things stand
+
+The build-prep work (removing the JitPack-sourced Treessence dependency and the
+unused `BUILD_TIME` field) already landed on `main`. That was gating item #1.
+A survey of the current repo state shows most of the rest of the checklist is
+already satisfied incidentally:
+
+| Requirement | Status |
+|---|---|
+| FOSS license | ✅ GPL-3.0 (`LICENSE`, full text) |
+| Public source repo | ✅ `github.com/NateEaton/mydeck-android`, public |
+| No proprietary deps (Firebase, Play Services, JitPack, ads, analytics) | ✅ confirmed via grep, none present |
+| `dependenciesInfo` (Play "Play Install Referrer" block) disabled | ✅ already `includeInApk/Bundle = false` |
+| No NDK / native code / prebuilt `.jar`/`.aar` blobs | ✅ none found — pure Gradle/Kotlin |
+| Reproducible version fields without CI secrets | ✅ `githubRelease` flavor falls back to `defaultConfig` versionCode/Name when `RELEASE_VERSION_*` env vars are unset |
+| Minimal permissions (no location/camera/tracking) | ✅ INTERNET, POST_NOTIFICATIONS, FOREGROUND_SERVICE(_DATA_SYNC) only |
+| Fastlane-style store metadata already in-repo | ✅ `metadata/en-US/` (title, descriptions, changelogs per versionCode, phone+tablet screenshots) — F-Droid can consume this directly, no duplicate write-up needed |
+| Tagged releases | ✅ `v0.14.6` exists and is pushed to GitHub (commit `fe895b8`) |
+
+This means the app itself needs **no further code changes** to be F-Droid-ready.
+What's left is entirely on the submission side: local tooling, drafting the
+`fdroiddata` metadata recipe, and opening the inclusion request.
+
+One pre-existing item worth a quick look separately (not an F-Droid blocker):
+`metadata/en-US/full_description.txt` still says "OAuth Device Code Grant
+authentication" and doesn't mention the browser PKCE flow or reading fonts
+added in 0.14.6. Since F-Droid's listing pulls this same text, it'd be worth
+refreshing before or shortly after submission — but it doesn't block anything.
+
+## 2. Decisions made in this plan (flag if you'd prefer otherwise)
+
+- **Flavor to submit:** `githubRelease` (the secure/default flavor — HTTPS-only,
+  no cleartext, no user CA trust). The `githubReleaseHttp` variant is a
+  self-hosting convenience for GitHub-direct users and isn't something we need
+  to also carry through F-Droid; it stays GitHub-only.
+- **Build task:** `assembleGithubReleaseRelease`, `subdir: app`.
+- **First version to submit:** tag `v0.14.6` (versionCode `14006`), since it's
+  the latest tagged, pushed release and matches the in-repo changelog/metadata.
+
+## 3. Phase A — Local tooling (one-time setup on the MBP)
+
+```
+brew install fdroidserver
+```
+
+This pulls in the `fdroid` CLI and its Python dependencies (androguard, etc.).
+It uses your existing Android SDK — confirm `ANDROID_HOME` (or
+`ANDROID_SDK_ROOT`) is set in your shell profile, since `fdroidserver` reads it
+for `fdroid build`/`fdroid readmeta`.
+
+You'll also need a **GitLab.com account** — F-Droid's metadata repo
+(`fdroiddata`) and its inclusion-request workflow live on GitLab, not GitHub.
+If you don't have one, create it now; the rest of the plan assumes you do.
+
+## 4. Phase B — Fork and clone `fdroiddata`
+
+1. On gitlab.com, fork `https://gitlab.com/fdroid/fdroiddata` into your account.
+2. Clone your fork locally (pick a working directory outside `MyDeck`, e.g.
+   next to your other repos):
+
+```
+git clone git@gitlab.com:<your-gitlab-username>/fdroiddata.git
+cd fdroiddata
+git remote add upstream https://gitlab.com/fdroid/fdroiddata.git
+git checkout -b add-com.mydeck.app
+```
+
+## 5. Phase C — Draft the metadata recipe
+
+Create `metadata/com.mydeck.app.yml` in the `fdroiddata` fork. Draft content:
+
+```yaml
+Categories:
+  - Reading
+  - Internet
+License: GPL-3.0-only
+AuthorName: Nate Eaton
+SourceCode: https://github.com/NateEaton/mydeck-android
+IssueTracker: https://github.com/NateEaton/mydeck-android/issues
+Changelog: https://github.com/NateEaton/mydeck-android/blob/main/CHANGELOG.md
+
+RepoType: git
+Repo: https://github.com/NateEaton/mydeck-android.git
+
+Builds:
+  - versionName: 0.14.6
+    versionCode: 14006
+    commit: v0.14.6
+    subdir: app
+    gradle:
+      - githubRelease
+
+AutoUpdateMode: Version
+UpdateCheckMode: Tags
+CurrentVersion: 0.14.6
+CurrentVersionCode: 14006
+```
+
+Notes to verify against the current `fdroiddata` docs/examples at submission
+time (the schema evolves and reviewers are picky about it):
+- Confirm `Reading` and `Internet` are still valid F-Droid category names
+  (check `categories.yml` in the `fdroiddata` repo you just cloned).
+- Confirm whether `UpdateCheckMode: Tags` needs a pattern
+  (e.g. `Tags ^v[0-9.]+$`) given the repo also has non-release tags like
+  `v1.0.0-rc*` and `wip/*` branches that shouldn't be picked up.
+- Bundled fonts under SIL OFL / CC BY 4.0 (documented in-app under
+  About → Font licenses) don't need special YAML handling — F-Droid only
+  wants the top-level `License:` to reflect the app's own code license — but
+  it's worth calling out in the MR description for the reviewer's benefit.
+
+## 6. Phase D — Local validation before opening the MR
+
+Run these from inside the `fdroiddata` checkout:
+
+```
+fdroid readmeta
+fdroid rewritemeta com.mydeck.app
+fdroid lint com.mydeck.app
+fdroid checkupdates com.mydeck.app
+fdroid build -v -l com.mydeck.app:14006
+```
+
+- `readmeta`/`rewritemeta` normalize formatting (run `rewritemeta` and let it
+  reformat the file — this is expected and avoids a reviewer nitpick).
+- `lint` catches metadata schema issues.
+- `checkupdates` confirms the tag/version detection works.
+- `fdroid build -l` (local, non-buildserver mode) does a real Gradle build of
+  `assembleGithubReleaseRelease` from the tagged commit in an isolated
+  checkout — this is the closest local approximation of what F-Droid's build
+  server will do, and it's the step most likely to surface a problem (missing
+  env var assumption, a repository not being mirrorable, etc.).
+
+Fix anything that surfaces here before moving on.
+
+## 7. Phase E — Open the inclusion request (GitLab web UI, not CLI)
+
+Same principle as your GitHub/Codeberg workflow: I'll give you the exact
+branch-push command and the MR title/description to paste into GitLab's web
+UI; you open the MR yourself.
+
+```
+git add metadata/com.mydeck.app.yml
+git commit -m "New app: MyDeck"
+git push -u origin add-com.mydeck.app
+```
+
+Then open a Merge Request on GitLab from your fork's `add-com.mydeck.app`
+branch into `fdroid/fdroiddata`'s default branch. `fdroiddata`'s MR template
+auto-populates a checklist — fill it in based on the table in §1 of this doc.
+
+## 8. Phase F — Review cycle
+
+F-Droid's bots (`fdroid checkupdates`/CI) and human reviewers will comment on
+the MR — commonly requesting metadata tweaks, not code changes, given the
+build-prep work is already done. Iterate on the same branch until merged.
+
+## 9. Phase G — After merge (ongoing, low-effort)
+
+Once merged, F-Droid's build server builds new versions automatically based on
+`UpdateCheckMode: Tags` — each future `vX.Y.Z` tag you push to GitHub (as
+you already do at release time) gets picked up without a new MR, as long as
+versionCode/versionName continue to resolve correctly from `defaultConfig`
+without secrets. No change to the existing release workflow in
+`docs/WORKFLOW.md` is needed.
+
+## 10. Open items to revisit
+
+- Refresh `metadata/en-US/full_description.txt` to mention browser OAuth
+  (PKCE) sign-in and reading fonts — cosmetic, not a submission blocker.
+- Confirm current F-Droid category list and tag-matching pattern at
+  submission time (schema/policy details drift; re-check against the live
+  `fdroiddata` repo rather than trusting this doc verbatim if much time has
+  passed).


### PR DESCRIPTION
Mirror of the guardrails landing in the Readeck repo, plus previously-untracked docs.

### Guardrails
While porting the v0.14.7 fixes to Readeck, a default `git fetch` of a scratch port remote imported the sibling repo's tags into the local tag namespace (local-only in both repos; neither remote was affected). To prevent recurrence:
- **CLAUDE.md**: new *Cross-Repo Fetches — Never Import Tags* and *Never Bulk-Delete Refs* sections.
- **docs/porting/mydeck-readeck-port.md §3**: `git remote add --no-tags` is now mandatory for port remotes, with a post-removal tag check. (Mirrored doc — same edit landed in the Readeck repo.)
- The durable `codeberg` remote's `tagOpt` is now set to `--no-tags` locally (git config, not tracked).

### Pending docs (previously untracked)
- **docs/porting/fdroid-signing-and-label-counts-port.md** — finalized checklist for the v0.14.7 → Readeck rc7 port (mirror of the Readeck copy).
- **docs/specs/fdroid-submission-plan.md** — F-Droid submission plan.

Docs only — no code, strings, or build changes.
